### PR TITLE
Command-line interface feature parity

### DIFF
--- a/app/Console/Commands/Randomize.php
+++ b/app/Console/Commands/Randomize.php
@@ -37,6 +37,14 @@ class Randomize extends Command {
 
 		for ($i = 0; $i < $bulk; $i++) {
 			$rom = new Rom($this->argument('input_file'));
+
+			$basejson = file_get_contents(public_path('js/base2current.json'));
+
+			$rom->applyJSONPatches($basejson);
+			if (!$rom->checkMD5()) {
+				return $this->error('Error patching vanilla ROM');
+			}
+
 			$rand = new Randomizer($this->option('rules'), $this->option('mode'));
 			$rand->makeSeed($this->option('seed'));
 

--- a/app/Console/Commands/Randomize.php
+++ b/app/Console/Commands/Randomize.php
@@ -10,7 +10,7 @@ class Randomize extends Command {
 	 *
 	 * @var string
 	 */
-	protected $signature = 'alttp:randomize {input_file} {output_directory} {--debug} {--spoiler} {--rules=v8} {--mode=NoMajorGlitches} {--seed=} {--bulk=1}';
+	protected $signature = 'alttp:randomize {input_file} {output_directory} {--debug} {--spoiler} {--rules=v8} {--mode=NoMajorGlitches} {--heartbeep=half} {--trace}  {--seed=} {--bulk=1}';
 
 	/**
 	 * The console command description.
@@ -47,6 +47,11 @@ class Randomize extends Command {
 
 			$rand = new Randomizer($this->option('rules'), $this->option('mode'));
 			$rand->makeSeed($this->option('seed'));
+
+			$rom->setHeartBeepSpeed($this->option('heartbeep'));
+			if ($this->option('trace')) {
+				$rom->setSRAMTrace(true);
+			}
 
 			if ($this->option('debug')) {
 				$rom->setDebugMode(true);

--- a/app/Rom.php
+++ b/app/Rom.php
@@ -9,6 +9,7 @@ use Log;
 class Rom {
 	const BUILD = '2017-02-10';
 	const HASH = 'f14c5f1ee129a824f87a9d9c9022f31d';
+	const ROM_SIZE = 2097152;
 	private $tmp_file;
 	protected $rom;
 	protected $write_log = [];
@@ -49,6 +50,7 @@ class Rom {
 		}
 
 		$this->rom = fopen($this->tmp_file, "r+");
+		$this->extend(static::ROM_SIZE);
 	}
 
 	/**
@@ -719,6 +721,17 @@ class Rom {
 		fseek($this->rom, $offset);
 		$unpacked = unpack('C*', fread($this->rom, $length));
 		return count($unpacked) == 1 ? $unpacked[1] : array_values($unpacked);
+	}
+
+	/**
+	 * Extend ROM to a given size
+	 *
+	 * @param int $size minimum number of bytes the ROM should be
+	 *
+	 */
+	public function extend(int $size) {
+		ftruncate($this->rom, $size);
+		rewind($this->rom);
 	}
 
 	/**

--- a/app/Rom.php
+++ b/app/Rom.php
@@ -59,7 +59,7 @@ class Rom {
 	 * @return bool
 	 */
 	public function checkMD5() {
-		return hash_file('md5', $this->tmp_file) === static::BUILD;
+		return hash_file('md5', $this->tmp_file) === static::HASH;
 	}
 
 	/**
@@ -697,6 +697,26 @@ class Rom {
 		fseek($this->rom, $offset);
 		fwrite($this->rom, $data);
 
+		return $this;
+	}
+
+	/**
+	 * Apply a JSON string containing patches to the ROM
+	 *
+	 * The string should consist of an array of patches, where each patch is an object
+	 * with keys of integer addresses and values of data to write at that address in
+	 * the form of arrays of integers between 0 and 255.
+	 *
+	 * @param string $patches JSON string of patches to apply
+	 *
+	 **/
+	public function applyJSONPatches(string $json) {
+		$patches = json_decode($json, true);
+		foreach ($patches as $patch) {
+		foreach ($patch as $address => $data) {
+			$this->write(intval($address), pack('C*', ...array_values($data)));
+		}
+		}
 		return $this;
 	}
 

--- a/app/Rom.php
+++ b/app/Rom.php
@@ -709,13 +709,15 @@ class Rom {
 	 *
 	 * @param string $patches JSON string of patches to apply
 	 *
+	 * @return $this
+	 *
 	 **/
 	public function applyJSONPatches(string $json) {
 		$patches = json_decode($json, true);
 		foreach ($patches as $patch) {
-		foreach ($patch as $address => $data) {
-			$this->write(intval($address), pack('C*', ...array_values($data)));
-		}
+			foreach ($patch as $address => $data) {
+				$this->write($address, pack('C*', ...array_values($data)));
+			}
 		}
 		return $this;
 	}
@@ -748,10 +750,13 @@ class Rom {
 	 *
 	 * @param int $size minimum number of bytes the ROM should be
 	 *
+	 * @return $this
+	 *
 	 */
 	public function extend(int $size) {
 		ftruncate($this->rom, $size);
 		rewind($this->rom);
+		return $this;
 	}
 
 	/**


### PR DESCRIPTION
Greetings!

I made some enhancements to the command-line interface for my own use so that it behaved more like the web interface.  Specifically, these commits add:

- Patching from the vanilla ROM to the customized Randomizer base ROM using the same base2current.json that's used by the client-side code.
- A command-line option to set the heartbeat speed, defaulting to half
- A command-line option to enable SRAM trace, defaulting to off

The code isn't very long or complex, and I tried to make it as unobtrusive as possible for easy merging.  As far as I've been able to test, the ROMs produced are byte-for-byte identical to those produced using the currently-deployed web interface with the same base ROM and settings.

This is the first PHP I've written in at least 10 years, so if there's anything that could be done better, please let me know.