### PR TITLE
Change Book Pedestal text

### DIFF
--- a/app/Location/Altar.php
+++ b/app/Location/Altar.php
@@ -284,7 +284,7 @@ class Altar extends Location {
 			case Item::get('TitansMitt'):
 				return "Now you can\nlift heavy\nstuff!";
 			case Item::get('BookOfMudora'):
-				return "This is a\nparadox?!";
+				return "Why are you\nreading this\nnow?!";
 			case Item::get('Flippers'):
 				return "fancy a swim?";
 			case Item::get('MoonPearl'):


### PR DESCRIPTION
I believe that initial book pedestal text was added with assumption that book couldn't be in there. Gamercal suggested a more-applicable message.