### PR TITLE
Remove Standard from Entrance Randomizer

### DIFF
--- a/resources/views/entrance_randomizer.blade.php
+++ b/resources/views/entrance_randomizer.blade.php
@@ -222,7 +222,6 @@
 	<input type="hidden" name="logic" value="NoMajorGlitches" />
 	<input type="hidden" name="difficulty" value="normal" />
 	<input type="hidden" name="variation" value="none" />
-	<input type="hidden" name="mode" value="standard" />
 	<input type="hidden" name="goal" value="ganon" />
 	<input type="hidden" name="shuffle" value="full" />
 	<input type="hidden" name="heart_speed" value="half" />

--- a/resources/views/entrance_randomizer.blade.php
+++ b/resources/views/entrance_randomizer.blade.php
@@ -43,7 +43,6 @@
 				<div class="input-group" role="group">
 					<span class="input-group-addon">Mode</span>
 					<select id="mode" class="form-control selectpicker">
-						<option value="standard">Standard</option>
 						<option value="open">Open</option>
 						<option value="swordless">Swordless</option>
 					</select>

--- a/resources/views/entrance_randomizer.blade.php
+++ b/resources/views/entrance_randomizer.blade.php
@@ -222,6 +222,7 @@
 	<input type="hidden" name="logic" value="NoMajorGlitches" />
 	<input type="hidden" name="difficulty" value="normal" />
 	<input type="hidden" name="variation" value="none" />
+	<input type="hidden" name="mode" value="open" />
 	<input type="hidden" name="goal" value="ganon" />
 	<input type="hidden" name="shuffle" value="full" />
 	<input type="hidden" name="heart_speed" value="half" />


### PR DESCRIPTION
Removes Standard as a Mode option from the Entrance Randomizer front-end
