### PR TITLE
Fix heart speed not set

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,11 @@ You will need to build assets the first time (you will need [Yarn](https://yarnp
 $ yarn
 $ ./node_modules/gulp/bin/gulp.js --production
 ```
+Now setup a 32 character application key that will be used by the app (following only works on unix):
+
+```
+export APP_KEY=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+```
 
 Once you have the dependencies installed. Run the following command then navigate to http://localhost:8000/.
 

--- a/resources/views/entrance_randomizer.blade.php
+++ b/resources/views/entrance_randomizer.blade.php
@@ -377,6 +377,19 @@ var ROM = ROM || (function(blob, loaded_callback) {
 			resolve(this);
 		}.bind(this));
 	};
+	
+	this.setHeartSpeed = function(speed) {
+		return new Promise(function(resolve, reject) {
+			var sbyte = 0x20;
+			switch (speed) {
+				case 'off': sbyte = 0x00; break;
+				case 'half': sbyte = 0x40; break;
+				case 'quarter': sbyte = 0x80; break;
+			}
+			this.write(0x180033, sbyte);
+			resolve(this);
+		}.bind(this));
+	}.bind(this);
 });
 
 function resizeUint8(baseArrayBuffer, newByteSize) {
@@ -410,6 +423,7 @@ function applySeed(rom, seed, second_attempt) {
 			rom.parsePatch(patch.patch).then(getSprite($('#sprite-gfx').val())
 			.then(rom.parseSprGfx)
 			.then(rom.setMusicVolume($('#generate-music-on').prop('checked')))
+			.then(rom.setHeartSpeed($('#heart-speed').val()))
 			.then(function(rom) {
 				resolve({rom: rom, patch: patch});
 			}));
@@ -690,13 +704,7 @@ $(function() {
 
 	$('#heart-speed').on('change', function() {
 		if (rom) {
-			var sbyte = 0x20;
-			switch ($(this).val()) {
-				case 'off': sbyte = 0x00; break;
-				case 'half': sbyte = 0x40; break;
-				case 'quarter': sbyte = 0x80; break;
-			}
-			rom.write(0x180033, sbyte);
+			rom.setHeartSpeed($(this).val());
 		}
 		localforage.setItem('rom.heart-speed', $(this).val());
 		$('input[name=heart_speed]').val($(this).val());


### PR DESCRIPTION
On entrance randomiser, the heart speed isn't set correctly if you hit download. However if you generate then change the heart speed the downloaded rom does have the correct heart speed.

I changed it so that when you download the heart speed is applied. Not sure why this doesn't apply to the item randomiser but I'm guessing it is because the item randomiser is patched in browser whereas the entrance randomiser is patched on the server?