### PR TITLE
Entrance update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "laravel/framework": "5.4.*",
         "laravel/tinker": "^1.0",
         "league/flysystem-rackspace": "^1.0",
-        "z3/entrancerandomizer": "0.4.7"
+        "z3/entrancerandomizer": "0.5.0"
     },
     "require-dev": {
         "sami/sami": "*",
@@ -34,11 +34,11 @@
             "type": "package",
             "package": {
                 "name": "z3/entrancerandomizer",
-                "version": "0.4.7",
+                "version": "0.5.0",
                 "source": {
-                    "url": "https://github.com/LLCoolDave/ALttPEntranceRandomizer",
+                    "url": "https://github.com/AmazingAmpharos/ALttPEntranceRandomizer",
                     "type": "git",
-                    "reference": "tags/0.4.7-dev"
+                    "reference": "tags/0.5.0-dev"
                 }
             }
         }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "7caab87f7f07c44b8d144afef04df9d9",
+    "content-hash": "e80a8b6606ad1b65f1810d18e6a5ea33",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -2685,11 +2685,11 @@
         },
         {
             "name": "z3/entrancerandomizer",
-            "version": "0.4.7",
+            "version": "0.5.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/LLCoolDave/ALttPEntranceRandomizer",
-                "reference": "tags/0.4.7-dev"
+                "url": "https://github.com/AmazingAmpharos/ALttPEntranceRandomizer",
+                "reference": "tags/0.5.0-dev"
             },
             "type": "library"
         }

--- a/config/alttp.php
+++ b/config/alttp.php
@@ -691,7 +691,11 @@ return [
 	'randomizer' => [
 		'entrance' => [
 			'difficulties' => [
+				'easy' => 'Easy',
 				'normal' => 'Normal',
+				'hard' => 'Hard',
+				'expert' => 'Expert',
+				'insane' => 'Insane',
 			],
 			'goals' => [
 				'ganon' => 'Defeat Ganon',
@@ -718,6 +722,7 @@ return [
 				'timed-race' => 'Timed Race',
 				'timed-ohko' => 'Timed OHKO',
 				'triforce-hunt' => 'Triforce Piece Hunt',
+				'key-sanity' => 'Key-sanity',
 			],
 		],
 		'item' => [

--- a/resources/views/_rom_spoiler.blade.php
+++ b/resources/views/_rom_spoiler.blade.php
@@ -73,6 +73,19 @@ function pasrseSpoilerToTabs(spoiler) {
 			content.append($('<div id="spoiler-' + section.replace(/ /g, '_') + '" class="tab-pane'
 				+ ((section == active_nav) ? ' active' : '') + '">'
 				+ '</div>').append(table));
+		} else if (['playthrough'].indexOf(section) !== -1 && spoiler['entrances']) {
+			var table = $('<table class="table table-striped"><thead><tr><th>Sphere</th><th>Location</th><th>Item</th></tr></thead><tbody></tbody></table>');
+			var tbody = table.find('tbody');
+			for (sphere in spoiler[section]) {
+				for (loc in spoiler[section][sphere]) {
+					tbody.append($('<tr class="spoil-item-location"><td class="col-md-1">' + sphere + '</td>'
+						+ '<td class="col-md-5">' + loc + '</td>'
+						+ '<td class="item">' + spoiler[section][sphere][loc] + '</td></tr>'));
+				}
+			};
+			content.append($('<div id="spoiler-' + section.replace(/ /g, '_') + '" class="tab-pane'
+				+ ((section == active_nav) ? ' active' : '') + '">'
+				+ '</div>').append(table));
 		} else if (['playthrough'].indexOf(section) === -1) {
 			var table = $('<table class="table table-striped"><thead><tr><th>Location</th><th>Item</th></tr></thead><tbody></tbody></table>');
 			var tbody = table.find('tbody');


### PR DESCRIPTION
Update to use version 0.5.0 of the Entrance Randomizer.

I've also copied in the latest blind/uncle/triforce etc messages from the item randomizer. Eventually that code should be removed, since ER should incorporate a sufficiently large set of them for each area, but that has not happened yet.

I've kept the options mirroring what Item Randomizer offers. I do know that AmazingAmpharos would prefer to restructure the web version to offer additional options. For example ER the timer modes are independent of the Triforce Hunt goal, and both are independent of key-sanity.

Similarly, apparently many ER racers don't like the web version because it does not offer the shuffle-ganon option in simple and full shuffle modes. 

I could add additional options for these if you want them, but thought keeping things in line with what is currently present is better for the initial pull request.