### PR TITLE
Upgrade to support ER v0.5.2 

### DIFF
--- a/app/EntranceRandomizer.php
+++ b/app/EntranceRandomizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Process\Process;
  */
 class EntranceRandomizer extends Randomizer {
 	const LOGIC = -1;
-	const VERSION = '0.5.1';
+	const VERSION = '0.5.2';
 	private $spoiler;
 	private $patch;
 	protected $shuffle;
@@ -135,7 +135,6 @@ class EntranceRandomizer extends Randomizer {
 				$rom->write($address, pack('C*', ...$bytes));
 			}
 		}
-		$this->setTexts($rom);
 
 		return $rom;
 	}
@@ -165,188 +164,5 @@ class EntranceRandomizer extends Randomizer {
 		$this->seed->save();
 
 		return $this->seed->hash;
-	}
-
-	/**
-	 * Set all texts for this randomization
-	 *
-	 * @param Rom $rom ROM to write to
-	 *
-	 * @return $this
-	 */
-	public function setTexts(Rom $rom) {
-		$rom->setUncleTextString(array_first(mt_shuffle([
-			"We're out of\nWeetabix. To\nthe store!",
-			"This seed is\nbootless\nuntil boots.",
-			"Why do we only\nhave one bed?",
-			"This is the\nonly textbox.",
-			"I'm going to\ngo watch the\nMoth tutorial.",
-			"This seed is\nthe worst.",
-			"Chasing tail.\nFly ladies.\nDo not follow.",
-			"I feel like\nI've done this\nbefore...",
-			"Magic cape can\npass through\nthe barrier!",
-			"If this is a\nKanzeon seed,\nI'm quitting.",
-			"I am not your\nreal uncle.",
-			"You're going\nto have a very\nbad time.",
-			"Today you\nwill have\nbad luck.",
-			"I am leaving\nforever.\nGoodbye.",
-			"Don't worry.\nI got this\ncovered.",
-			"Race you to\nthe castle!",
-			"\n      hi",
-			"I'M JUST GOING\nOUT FOR A\nPACK OF SMOKES",
-			"It's dangerous\nto go alone.\nSee ya!",
-			"ARE YOU A BAD\nENOUGH DUDE TO\nRESCUE ZELDA?",
-			"\n\n    I AM ERROR",
-			"This seed is\nsub 2 hours,\nguaranteed.",
-			"The chest is\na secret to\neverybody.",
-			"I'm off to\nfind the\nwind fish.",
-			"The shortcut\nto Ganon\nis this way!",
-			"THE MOON IS\nCRASHING! RUN\nFOR YOUR LIFE!",
-			"Time to fight\nhe who must\nnot be named.",
-			"RED MAIL\nIS FOR\nCOWARDS.",
-			"HEY!\n\nLISTEN!",
-			"Well\nexcuuuuuse me,\nprincess!",
-			"5,000 Rupee\nreward for >\nYou're boned",
-			"Welcome to\nStoops Lonk's\nHoose",
-			"Erreur de\ntraduction.\nsvp reessayer",
-			"I could beat\nit in an hour\nand one life",
-		])));
-
-		$rom->setBlindTextString(array_first(mt_shuffle([
-			"I hate insect\npuns, they\nreally bug me.",
-			"I haven't seen\nthe eye doctor\nin years",
-			"I don't see\nyou having a\nbright future",
-			"Are you doing\na blind run\nof this game?",
-			"pizza joke? no\nI think it's a\nbit too cheesy",
-			"A novice skier\noften jumps to\ncontusions.",
-			"the beach?\nI'm not shore\nI can make it.",
-			"Rental agents\noffer quarters\nfor dollars.",
-			"I got my tires\nfixed for a\nflat rate.",
-			"New lightbulb\ninvented?\nEnlighten me.",
-			"A baker's job\nis a piece of\ncake.",
-			"My optometrist\nsaid I have\nvision!",
-			"when you're a\nbaker, don't\nloaf around",
-			"mire requires\nether quake,\nor bombos",
-			"Broken pencils\nare pointless.",
-			"The food they\nserve guards\nlasts sentries",
-			"being crushed\nby big objects\nis depressing.",
-			"A tap dancer's\nroutine runs\nhot and cold.",
-			"A weeknight is\na tiny\nnobleman",
-			"The chimney\nsweep wore a\nsoot and tye.",
-			"Gardeners like\nto spring into\naction.",
-		])));
-
-		$rom->setTavernManTextString(array_first(mt_shuffle([
-			"What do you\ncall a blind\ndinosaur?\nadoyouthink-\nhesaurus\n",
-			"A blind man\nwalks into\na bar.\nAnd a table.\nAnd a chair.\n",
-			"What do ducks\nlike to eat?\n\nQuackers!\n",
-			"How do you\nset up a party\nin space?\n\nYou planet!\n",
-			"I'm glad I\nknow sign\nlanguage,\nit's pretty\nhandy.\n",
-			"What did Zelda\nsay to Link at\na secure door?\n\nTRIFORCE!\n",
-			"I am on a\nseafood diet.\n\nEvery time\nI see food,\nI eat it.",
-			"I've decided\nto sell my\nvacuum.\nIt was just\ngathering\ndust.",
-			"Whats the best\ntime to go to\nthe dentist?\n\nTooth-hurtie!\n",
-			"Why can't a\nbike stand on\nits own?\n\nIt's two-tired!\n",
-			"If you haven't\nfound Quake\nyet…\nit's not your\nfault.",
-			"Why is Peter\nPan always\nflying?\nBecause he\nNeverlands!",
-			"I once told a\njoke to Armos.\n\nBut he\nremained\nstone-faced!",
-			"Lanmola was\nlate to our\ndinner party.\nHe just came\nfor the desert",
-			"Moldorm is\nsuch a\nprankster.\nAnd I fall for\nit every time!",
-			"Helmasaur is\nthrowing a\nparty.\nI hope it's\na masquerade!",
-			"I'd like to\nknow Arrghus\nbetter.\nBut he won't\ncome out of\nhis shell!",
-			"Mothula didn't\nhave much fun\nat the party.\nHe's immune to\nspiked punch!",
-			"Don't set me\nup with that\nchick from\nSteve's Town.\n\n\nI'm not\ninterested in\na Blind date!",
-			"Kholdstare is\nafraid to go\nto the circus.\nHungry kids\nthought he was\ncotton candy!",
-			"I asked who\nVitreous' best\nfriends are.\nHe said,\n'Me, Myself,\nand Eye!'",
-			"Trinexx can be\na hothead or\nhe can be an\nice guy. In\nthe end, he's\na solid\nindividual!",
-			"Bari thought I\nhad moved out\nof town.\nHe was shocked\nto see me!",
-			"I can only get\nWeetabix\naround here.\nI have to go\nto Steve's\nTown for Count\nChocula!",
-			"Don't argue\nwith a frozen\nDeadrock.\nHe'll never\nchange his\nposition!",
-			"I offered to a\ndrink to a\nself-loathing\nGhini.\nHe said he\ndidn't like\nspirits!",
-			"I was supposed\nto meet Gibdo\nfor lunch.\nBut he got\nwrapped up in\nsomething!",
-			"Goriya sure\nhas changed\nin this game.\nI hope he\ncomes back\naround!",
-			"Hinox actually\nwants to be a\nlawyer.\nToo bad he\nbombed the\nbar exam!",
-			"I'm surprised\nMoblin's tusks\nare so gross.\nHe always has\nhis Trident\nwith him!",
-			"Don’t tell\nStalfos I’m\nhere.\nHe has a bone\nto pick with\nme!",
-			"I got\nWallmaster to\nhelp me move\nfurniture.\nHe was really\nhandy!",
-			"Wizzrobe was\njust here.\nHe always\nvanishes right\nbefore we get\nthe check!",
-			"I shouldn't\nhave picked up\nZora's tab.\nThat guy\ndrinks like\na fish!",
-			"I was sharing\na drink with\nPoe.\nFor no reason,\nhe left in a\nheartbeat!",
-			"Don’t trust\nhorsemen on\nDeath Mountain\nThey’re Lynel\nthe time!",
-			"Today's\nspecial is\nbattered bat.\nGot slapped\nfor offering a\nlady a Keese!",
-			"Don’t walk\nunder\npropellered\npineapples.\nYou may end up\nwearing\na pee hat!",
-			"My girlfriend\nburrowed under\nthe sand.\nSo I decided\nto Leever!",
-			"Geldman wants\nto be a\nBroadway star.\nHe’s always\npracticing\nJazz Hands!",
-			"Octoballoon\nmust be mad\nat me.\nHe blows up\nat the sight\nof me!",
-			"Toppo is a\ntotal pothead.\n\nHe hates it\nwhen you take\naway his grass",
-			"I lost my\nshield by a\nthat house.\nWhy did they\nput up a\nPikit fence?!",
-			"Know that fox\nin Steve’s\nTown?\nHe’ll Pikku\npockets if you\naren't careful",
-			"Dash through\nDark World\nbushes.\nYou’ll see\nGanon is tryin\nto Stal you!",
-			"Eyegore!\n\nYou gore!\nWe all gore\nthose jerks\nwith arrows!",
-			"I like my\nwhiskey neat.\n\nSome prefer it\nOctoroks!",
-			"I consoled\nFreezor over a\ncup of coffee.\nHis problems\njust seemed to\nmelt away!",
-			"Magic droplets\nof water don’t\nshut up.\nThey just\nKyameron!",
-			"I bought hot\nwings for\nSluggula.\nThey gave him\nexplosive\ndiarrhea!",
-			"Hardhat Beetle\nwon’t\nLet It Be?\nTell it to Get\nBack or give\nit a Ticket to\nRide down\na hole!",
-		])));
-
-		$rom->setGanon1TextString(array_first(mt_shuffle([
-			"Start your day\nsmiling with a\ndelicious\nwholegrain\nbreakfast\ncreated for\nyour\nincredible\ninsides.",
-			"You drove\naway my other\nself, Agahnim\ntwo times…\nBut, I won't\ngive you the\nTriforce.\nI'll defeat\nyou!",
-			"Impa says that\nthe mark on\nyour hand\nmeans that you\nare the hero\nchosen to\nawaken Zelda.\nyour blood can\nresurrect me.",
-			"Don't stand,\n\ndon't stand so\nDon't stand so\n\nclose to me\nDon't stand so\nclose to me\nback off buddy",
-			"So ya\nThought ya\nMight like to\ngo to the show\nTo feel the\nwarm thrill of\nconfusion\nThat space\ncadet glow.",
-			"Like other\npulmonate land\ngastropods,\nthe majority\nof land slugs\nhave two pairs\nof 'feelers'\nor tentacles\non their head.",
-			"If you were a\nburrito, what\nkind of a\nburrito would\nyou be?\nMe, I fancy I\nwould be a\nspicy barbacoa\nburrito.",
-			"I am your\nfather's\nbrother's\nnephew's\ncousin's\nformer\nroommate. What\ndoes that make\nus, you ask?",
-			"I'll be more\neager about\nencouraging\nthinking\noutside the\nbox when there\nis evidence of\nany thinking\ninside it.",
-			"If we're not\nmeant to have\nmidnight\nsnacks, then\nwhy is there\na light in the\nfridge?\n",
-			"I feel like we\nkeep ending up\nhere.\n\nDon't you?\n\nIt's like\nde'ja vu\nall over again",
-			"Did you know?\nThe biggest\nand heaviest\ncheese ever\nproduced\nweighed\n57,518 pounds,\nand was 32\nfeet long.",
-			"Now there was\na time, When\nyou loved me\nso. I couldn't\ndo wrong,\nAnd now you\nneed to know.\nSo How you\nlike me now?",
-			"Did you know?\nNutrition\nexperts\nrecommend that\nat least half\nof our daily\ngrains come\nfrom whole\ngrain products",
-		])));
-
-		switch ($this->goal) {
-			case 'pedestal':
-				$rom->setGanon1InvincibleTextString("You cannot\nkill me, you\nshould go for\nyour real goal\nit's in the\npedestal.\n\nYou dingus\n");
-				break;
-			case 'triforce-hunt':
-				$rom->setGanon1InvincibleTextString("So you thought\nyou could come\nhere and beat\nme? I have\nhidden the\ntriforce\npieces well.\nWithout them\nyou can't win!");
-				break;
-			default:
-				$rom->setGanon1InvincibleTextString("You think you\nare ready to\nface me?\n\nI will not die\n\nunless you\ncomplete your\ngoals. Dingus!");
-		}
-
-		$rom->setGanon2InvincibleTextString("Got wax in\nyour ears?\nI can not die!");
-
-		$rom->setTriforceTextString(array_first(mt_shuffle([
-			"\n     G G",
-			"All your base\nare belong\nto us.",
-			"You have ended\nthe domination\nof dr. wily",
-			"  thanks for\n  playing!!!",
-			"\n   You Win!",
-			"  Thank you!\n  your quest\n   is over.",
-			"   A winner\n      is\n     you!",
-			"\n   WINNER!!",
-			"\n  I'm  sorry\n\nbut your\nprincess is in\nanother castle",
-			"\n   success!",
-			"    Whelp…\n  that  just\n   happened",
-			"   Oh  hey…\n   it's you",
-			"\n  Wheeeeee!!",
-			"   Time for\n another one?",
-			"and\n\n         scene",
-			"\n   GOT EM!!",
-			"\nTHE VALUUUE!!!",
-			"Cool seed,\n\nright?",
-			"\n  We did it!",
-			"  Spam those\n  emotes in\n  wilds chat",
-			"\n   O  M  G",
-			" Hello.  Will\n  you be my\n   friend?",
-			"   Beetorp\n     was\n    here!",
-			"The Wind Fish\nwill wake\nsoon.    Hoot!",
-		])));
-
-		return $this;
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "laravel/tinker": "^1.0",
         "league/flysystem-rackspace": "^1.0",
         "z3/enemizer": "6.0.22",
-        "z3/entrancerandomizer": "0.5.1"
+        "z3/entrancerandomizer": "0.5.2"
     },
     "require-dev": {
         "sami/sami": "*",
@@ -47,11 +47,11 @@
             "type": "package",
             "package": {
                 "name": "z3/entrancerandomizer",
-                "version": "0.5.1",
+                "version": "0.5.2",
                 "source": {
                     "url": "https://github.com/AmazingAmpharos/ALttPEntranceRandomizer",
                     "type": "git",
-                    "reference": "tags/0.5.1-dev"
+                    "reference": "tags/0.5.2-dev"
                 }
             }
         }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "c8c9026315b43b2815143c2673e0b6bd",
+    "content-hash": "3c924fcc5e37f91240337da347c3d9ac",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -2770,11 +2770,11 @@
         },
         {
             "name": "z3/entrancerandomizer",
-            "version": "0.5.1",
+            "version": "0.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/AmazingAmpharos/ALttPEntranceRandomizer",
-                "reference": "tags/0.5.1-dev"
+                "reference": "tags/0.5.2-dev"
             },
             "type": "library"
         }

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -179,3 +179,22 @@ input[readonly].custom-placed {
 	color: red;
 	font-weight: bold;
 }
+
+.tbody-striped {
+  > tbody {
+ 	> tr {
+    	background-color: $table-bg-accent;
+  	}
+    > tr:nth-of-type(odd) {
+    	background-color: inherit;
+  	}
+  }
+  > tbody:nth-of-type(odd){
+ 	> tr {
+    	background-color: inherit;
+  	}
+    > tr:nth-of-type(odd) {
+    	background-color: $table-bg-accent;
+  	}
+  }
+}

--- a/resources/views/_rom_spoiler.blade.php
+++ b/resources/views/_rom_spoiler.blade.php
@@ -86,6 +86,38 @@ function pasrseSpoilerToTabs(spoiler) {
 			content.append($('<div id="spoiler-' + section.replace(/ /g, '_') + '" class="tab-pane'
 				+ ((section == active_nav) ? ' active' : '') + '">'
 				+ '</div>').append(table));
+		} else if (['paths'].indexOf(section) !== -1) {
+			var table = $('<table class="table tbody-striped"><thead><tr><th>Location</th><th>Region</th><th>Entrance/Exit</th></tr></thead></table>');
+			var keys = Object.keys(spoiler[section]).sort()
+			for (key in keys) {
+				var loc = keys[key];
+				var path = spoiler[section][loc];
+				path.reverse();
+				var span = path.length;
+				var html = '<tbody><tr class="spoil-item-location"><td class="col-md-4" rowspan="' + span + '">' + loc + '</td>';
+				while (path.length)  {
+					var segment = path.pop();
+					var region = segment[0];
+					var entrance = segment[1];
+
+					html += '<td class="col-md-4">' + region + "</td>";
+
+					if(entrance){
+						html += '<td class="col-md-4">' + entrance + "</td>";
+					} else {
+						html += '<td class="col-md-4"></td>';
+					}
+					html += '</tr>';
+					if (path.length) {
+						html += '<tr class="spoil-item-location">';
+					}
+				}
+				html += '</tbody>'
+				table.append($(html));
+			}
+			content.append($('<div id="spoiler-' + section.replace(/ /g, '_') + '" class="tab-pane'
+				+ ((section == active_nav) ? ' active' : '') + '">'
+				+ '</div>').append(table));
 		} else if (['playthrough'].indexOf(section) === -1) {
 			var table = $('<table class="table table-striped"><thead><tr><th>Location</th><th>Item</th></tr></thead><tbody></tbody></table>');
 			var tbody = table.find('tbody');
@@ -101,13 +133,13 @@ function pasrseSpoilerToTabs(spoiler) {
 				+ ((section == active_nav) ? ' active' : '') + '"><pre>' + JSON.stringify(spoiler[section], null, 4)
 				+ '</pre></div>'));
 		}
-		if (['meta', 'playthrough', 'Fountains', 'Medallions'].indexOf(section) === -1) {
+		if (['meta', 'playthrough', 'Fountains', 'Medallions', 'paths'].indexOf(section) === -1) {
 			tabsContent.set('spoiler-' + section.replace(/ /g, '_'), Object.keys(spoiler[section]).map(function (key) {
 				return spoiler[section][key];
 			}));
 		}
 		for (loc in spoiler[section]) {
-			if (['meta', 'playthrough', 'Fountains', 'Medallions'].indexOf(section) > -1) continue;
+			if (['meta', 'playthrough', 'Fountains', 'Medallions', 'paths'].indexOf(section) > -1) continue;
 			items[spoiler[section][loc]] = true;
 		}
 		var sopts = '';


### PR DESCRIPTION
This pull request is for integrating the soon to be released Entrance Randomizer version 0.5.2.

As for what is new that is applicable to the site:
It adds the applicable logic updates from v28.

It has bunny logic now (in theory you can be required to do things like get the hype cave item as a bunny, although this very rarely happens).

It now has updated messages (largely borrowed from this site), so the code to overwrite the messages in php has been removed. 

It also adds a new paths section to the spoiler log, which lists how to get to each area mentioned in the playthrough. The `_rom_spoiler.blade.php` file has been updated to accommodate this, and display it cleanly.

Fixes #338 
  