### PR TITLE
Fixed checksums (for real this time)

### DIFF
--- a/app/Rom.php
+++ b/app/Rom.php
@@ -108,7 +108,7 @@ class Rom {
 	 */
 	public function updateChecksum() : self {
 		fseek($this->rom, 0x0);
-		$sum = 0;
+		$sum = 0x1FE;
 		for ($i = 0; $i < static::SIZE; $i += 1024) {
 			$bytes = array_values(unpack('C*', fread($this->rom, 1024)));
 			for ($j = 0; $j < 1024; ++$j) {

--- a/resources/assets/js/rom.js
+++ b/resources/assets/js/rom.js
@@ -94,7 +94,7 @@ var ROM = (function(blob, loaded_callback) {
 				}
 				return sum + mbyte;
 			});
-			var checksum = sum & 0xFFFF;
+			var checksum = (sum + 0x1FE) & 0xFFFF;
 			var inverse = checksum ^ 0xFFFF;
 			this.write(0x7FDC, [inverse & 0xFF, inverse >> 8, checksum & 0xFF, checksum >> 8]);
 			resolve(this);


### PR DESCRIPTION
Apparently I had some weird cache issues on my dev box when I was testing, which was causing my generated checksums to come out right even though the code was actually wrong.  @KevinCathcart had it right in the Entrance Rando, so I'm correcting the VT rando checksum code to match his.  The addition of the 0x1FE is due to the official documentation specifying that the header checksum field should be set to 0xFFFF and the complement to 0x0000 when calculating the checksum, which is the same as skipping both fields *and adding 0xFF + 0xFF* which is what I was missing.