### PR TITLE
Add options for how many locations/items are reachable

### DIFF
--- a/app/Filler.php
+++ b/app/Filler.php
@@ -37,7 +37,7 @@ abstract class Filler {
 		$this->world = $world;
 	}
 
-	abstract public function fill(array $dungeon, array $required, array $nice, array $extra);
+	abstract public function fill(array $dungeon, array $required, array $win, array $nice, array $extra);
 
 	protected function shuffleLocations(Locations $locations) {
 		return $locations->randomCollection($locations->count());

--- a/app/Filler/RandomAssumed.php
+++ b/app/Filler/RandomAssumed.php
@@ -17,10 +17,10 @@ class RandomAssumed extends Filler {
 	 *
 	 * @return null
 	 */
-	public function fill(array $dungeon, array $required, array $nice, array $extra) {
+	public function fill(array $dungeon, array $required, array $win, array $nice, array $extra) {
 		$randomized_order_locations = $this->shuffleLocations($this->world->getEmptyLocations());
 
-		$this->fillItemsInLocations($dungeon, $randomized_order_locations, array_merge($required, $nice));
+		$this->fillItemsInLocations($dungeon, [], $randomized_order_locations, array_merge($required, $win, $nice));
 
 		// random junk fill
 		$gt_locations = $this->world->getRegion('Ganons Tower')->getEmptyLocations()->randomCollection(mt_rand(0, 15));
@@ -30,7 +30,7 @@ class RandomAssumed extends Filler {
 
 		$randomized_order_locations = $randomized_order_locations->getEmptyLocations()->reverse();
 
-		$this->fillItemsInLocations($this->shuffleItems($required), $randomized_order_locations);
+		$this->fillItemsInLocations($this->shuffleItems($required), $this->shuffleItems($win), $randomized_order_locations);
 
 		$randomized_order_locations = $this->shuffleLocations($randomized_order_locations->getEmptyLocations());
 
@@ -39,7 +39,7 @@ class RandomAssumed extends Filler {
 		$this->fastFillItemsInLocations($this->shuffleItems($extra), $randomized_order_locations->getEmptyLocations());
 	}
 
-	protected function fillItemsInLocations($fill_items, $locations, $base_assumed_items = []) {
+	protected function fillItemsInLocations($fill_items, $win_items, $locations, $base_assumed_items = []) {
 		$remaining_fill_items = new Items($fill_items);
 		Log::debug(sprintf("Filling %s items in %s locations", $remaining_fill_items->count(),
 			$locations->getEmptyLocations()->count()));
@@ -48,11 +48,34 @@ class RandomAssumed extends Filler {
 			throw new \Exception("Trying to fill more items than available locations.");
 		}
 
+		if ($this->world->config('region.reachability', 'random') == 'random') {
+			$min_reachable_locations = count($win_items);
+			Log::debug(sprintf("Will try for at least %s reachable locations", $min_reachable_locations));
+		}
+
 		foreach ($fill_items as $key => $item) {
 			$assumed_items = $this->world->collectItems($remaining_fill_items->removeItem($item->getName())->merge($base_assumed_items));
 
-			$fillable_locations = $locations->filter(function($location) use ($item, $assumed_items) {
-				return !$location->hasItem() && $location->canFill($item, $assumed_items);
+			$perform_access_check = true;
+
+			// Check if the world is winnable with all the $win_items
+			if ($this->world->config('region.reachability', 'random') == 'random') {
+				$merged_items = $assumed_items->merge($win_items);
+				if ($this->world->getWinCondition()($merged_items))
+				{
+					$reachable_locations = $locations->filter(function($location) use ($assumed_items) {
+						return !$location->hasItem() && $location->canAccess($assumed_items);
+					});
+					if (count($reachable_locations) >= $min_reachable_locations)
+					{
+						// Allow placing this item pretty much anywhere
+						$perform_access_check = false;
+					}
+				}
+			}
+
+			$fillable_locations = $locations->filter(function($location) use ($item, $assumed_items, $perform_access_check) {
+				return !$location->hasItem() && $location->canFill($item, $assumed_items, $perform_access_check);
 			});
 
 			if ($fillable_locations->count() == 0) {
@@ -65,5 +88,12 @@ class RandomAssumed extends Filler {
 
 			$fill_location->setItem($item);
 		}
+
+		// Put items needed to win in reachable locations
+		$assumed_items = $this->world->collectItems(new Items($base_assumed_items));
+		$reachable_locations = $locations->filter(function($location) use ($assumed_items) {
+			return !$location->hasItem() && $location->canAccess($assumed_items);
+		});
+		$this->fastFillItemsInLocations($win_items, $reachable_locations);
 	}
 }

--- a/app/Randomizer.php
+++ b/app/Randomizer.php
@@ -181,13 +181,21 @@ class Randomizer {
 		// at this point we have filled all the base locations that will affect the rest of the actual item placements
 		$advancement_items = $this->getAdvancementItems();
 
+		// items potentially required by goal that do not unlock new locations
+		$win_items = [];
+
 		// take out all the swords and silver arrows
 		$nice_items = $this->getNiceItems();
 		$nice_items_swords = [];
 		$nice_items_bottles = [];
 		foreach ($advancement_items as $key => $item) {
 			if ($item == Item::get('SilverArrowUpgrade')) {
-				$nice_items[] = $item;
+				if ($this->goal == 'dungeons' || $this->goal == 'ganon') {
+					$win_items[] = $item;
+				}
+				else {
+					$nice_items[] = $item;
+				}
 				unset($advancement_items[$key]);
 				continue;
 			}
@@ -198,6 +206,11 @@ class Randomizer {
 			}
 			if ($item instanceof Item\Bottle) {
 				$nice_items_bottles[] = $item;
+				unset($advancement_items[$key]);
+				continue;
+			}
+			if ($item == Item::get('TriforcePiece') && $this->goal == 'triforce-hunt') {
+				$win_items[] = $item;
 				unset($advancement_items[$key]);
 				continue;
 			}
@@ -212,6 +225,12 @@ class Randomizer {
 				array_push($advancement_items, array_pop($nice_items_swords));
 			} elseif ($this->config('region.forceUncleSword', true)) {
 				$this->world->getLocation("Link's Uncle")->setItem(array_pop($nice_items_swords));
+			}
+
+			if ($this->goal == 'dungeons' || $this->goal == 'ganon')
+			{
+				// need tempered to beat the game
+				array_push($win_items,  array_pop($nice_items_swords));
 			}
 
 			$nice_items = array_merge($nice_items, $nice_items_swords);
@@ -282,7 +301,7 @@ class Randomizer {
 
 		$advancement_items = mt_shuffle($advancement_items);
 
-		Filler::factory('RandomAssumed', $this->world)->fill($dungeon_items, $advancement_items, $nice_items, $trash_items);
+		Filler::factory('RandomAssumed', $this->world)->fill($dungeon_items, $advancement_items, $win_items, $nice_items, $trash_items);
 
 		return $this;
 	}

--- a/app/Region/GanonsTower.php
+++ b/app/Region/GanonsTower.php
@@ -190,9 +190,13 @@ class GanonsTower extends Region {
 			return $items->has('Hammer') && ($items->has('PegasusBoots') || $items->has('Hookshot'))
 				&& (in_array($locations["Ganon's Tower - Map Chest"]->getItem(), [Item::get('BigKeyA2'), Item::get('KeyA2')])
 					? $items->has('KeyA2', 3) : $items->has('KeyA2', 4));
-		})->setAlwaysAllow(function($item, $items) {
-			return $item == Item::get('KeyA2') && $items->has('KeyA2', 3);
 		});
+
+		if ($this->world->config('region.reachability', 'random') != 'full-clear') {
+			$this->locations["Ganon's Tower - Map Chest"]->setAlwaysAllow(function($item, $items) {
+				return $item == Item::get('KeyA2') && $items->has('KeyA2', 3);
+			});
+		};
 
 		$this->locations["Ganon's Tower - Big Chest"]->setRequirements(function($locations, $items) {
 			return $items->has('BigKeyA2') && $items->has('KeyA2', 3)

--- a/app/Region/PalaceOfDarkness.php
+++ b/app/Region/PalaceOfDarkness.php
@@ -101,9 +101,13 @@ class PalaceOfDarkness extends Region {
 			}
 
 			return (($items->has('Hammer') && $items->canShootArrows() && $items->has('Lamp')) ? $items->has('KeyD1', 6) : $items->has('KeyD1', 5));
-		})->setAlwaysAllow(function($item, $items) {
-			return $item == Item::get('KeyD1') && $items->has('KeyD1', 5);
 		});
+
+		if ($this->world->config('region.reachability', 'random') != 'full-clear') {
+			$this->locations["Palace of Darkness - Big Key Chest"]->setAlwaysAllow(function($item, $items) {
+				return $item == Item::get('KeyD1') && $items->has('KeyD1', 5);
+			});
+		};
 
 		$this->locations["Palace of Darkness - The Arena - Bridge"]->setRequirements(function($locations, $items) {
 			return $items->has('KeyD1')
@@ -125,9 +129,13 @@ class PalaceOfDarkness extends Region {
 			}
 
 			return (($items->has('Hammer') && $items->canShootArrows() && $items->has('Lamp')) ? $items->has('KeyD1', 6) : $items->has('KeyD1', 5));
-		})->setAlwaysAllow(function($item, $items) {
-			return $item == Item::get('KeyD1') && $items->has('KeyD1', 5);
 		});
+
+		if ($this->world->config('region.reachability', 'random') != 'full-clear') {
+			$this->locations["Palace of Darkness - Harmless Hellway"]->setAlwaysAllow(function($item, $items) {
+				return $item == Item::get('KeyD1') && $items->has('KeyD1', 5);
+			});
+		};
 
 		$this->locations["Palace of Darkness - Stalfos Basement"]->setRequirements(function($locations, $items) {
 			return $items->has('KeyD1')

--- a/app/Region/SkullWoods.php
+++ b/app/Region/SkullWoods.php
@@ -97,9 +97,13 @@ class SkullWoods extends Region {
 
 		$this->locations["Skull Woods - Big Chest"]->setRequirements(function($locations, $items) {
 			return $items->has('BigKeyD3');
-		})->setAlwaysAllow(function($item, $items) {
-			return $item == Item::get('BigKeyD3');
 		});
+
+		if ($this->world->config('region.reachability', 'random') != 'full-clear') {
+			$this->locations["Skull Woods - Big Chest"]->setAlwaysAllow(function($item, $items) {
+				return $item == Item::get('BigKeyD3');
+			});
+		};
 
 		$this->locations["Skull Woods - Bridge Room"]->setRequirements(function($locations, $items) {
 			return $items->has('MoonPearl') && $items->has('FireRod');

--- a/app/Region/SwampPalace.php
+++ b/app/Region/SwampPalace.php
@@ -91,9 +91,13 @@ class SwampPalace extends Region {
 			return $items->has('KeyD2')
 				&& $items->has('Hammer')
 				&& $items->has('BigKeyD2');
-		})->setAlwaysAllow(function($item, $items) {
-			return $item == Item::get('BigKeyD2');
 		});
+
+		if ($this->world->config('region.reachability', 'random') != 'full-clear') {
+			$this->locations["Swamp Palace - Big Chest"]->setAlwaysAllow(function($item, $items) {
+				return $item == Item::get('BigKeyD2');
+			});
+		};
 
 		$this->locations["Swamp Palace - Big Key Chest"]->setRequirements(function($locations, $items) {
 			return $items->has('KeyD2')

--- a/app/Region/ThievesTown.php
+++ b/app/Region/ThievesTown.php
@@ -89,9 +89,13 @@ class ThievesTown extends Region {
 			}
 
 			return $items->has('Hammer') && $items->has('KeyD4') && $items->has('BigKeyD4');
-		})->setAlwaysAllow(function($item, $items) {
-			return $item == Item::get('KeyD4');
 		});
+
+		if ($this->world->config('region.reachability', 'random') != 'full-clear') {
+			$this->locations["Thieves' Town - Big Chest"]->setAlwaysAllow(function($item, $items) {
+			return $item == Item::get('KeyD4');
+			});
+		}
 
 		$this->locations["Thieves' Town - Blind's Cell"]->setRequirements(function($locations, $items) {
 			return $items->has('BigKeyD4');

--- a/app/Region/TowerOfHera.php
+++ b/app/Region/TowerOfHera.php
@@ -79,9 +79,13 @@ class TowerOfHera extends Region {
 	public function initNoMajorGlitches() {
 		$this->locations["Tower of Hera - Big Key Chest"]->setRequirements(function($locations, $items) {
 			return $items->canLightTorches() && $items->has('KeyP3');
-		})->setAlwaysAllow(function($item, $items) {
-			return $item == Item::get('KeyP3');
 		});
+
+		if ($this->world->config('region.reachability', 'random') != 'full-clear') {
+			$this->locations["Tower of Hera - Big Key Chest"]->setAlwaysAllow(function($item, $items) {
+				return $item == Item::get('KeyP3');
+			});
+		}
 
 		$this->locations["Tower of Hera - Compass Chest"]->setRequirements(function($locations, $items) {
 			return $items->has('BigKeyP3');

--- a/app/Region/TurtleRock.php
+++ b/app/Region/TurtleRock.php
@@ -116,9 +116,13 @@ class TurtleRock extends Region {
 				return $locations["Turtle Rock - Big Key Chest"]->hasItem(Item::get('KeyD7')) ? $items->has('KeyD7', 3) : $items->has('KeyD7', 4);
 			}
 			return $items->has('KeyD7', 2);
-		})->setAlwaysAllow(function($item, $items) {
-			return $item == Item::get('KeyD7') && $items->has('KeyD7', 3);
 		});
+
+		if ($this->world->config('region.reachability', 'random') != 'full-clear') {
+			$this->locations["Turtle Rock - Big Key Chest"]->setAlwaysAllow(function($item, $items) {
+				return $item == Item::get('KeyD7') && $items->has('KeyD7', 3);
+			});
+		}
 
 		$this->locations["Turtle Rock - Crystaroller Room"]->setRequirements(function($locations, $items) {
 			return $items->has('BigKeyD7') && $items->has('KeyD7', 2);

--- a/resources/views/custom/_switches.blade.php
+++ b/resources/views/custom/_switches.blade.php
@@ -109,6 +109,7 @@
 				<select id="custom-reachability" class="form-control custom-value selectpicker" name="data[alttp.custom.region.reachability]">
 					<option value="random">Random</option>
 					<option value="full-clear">Full Clear</option>
+					<option value="minimal">Minimal</option>
 				</select>
 			</div>
 		</div>

--- a/resources/views/custom/_switches.blade.php
+++ b/resources/views/custom/_switches.blade.php
@@ -105,6 +105,15 @@
 		</div>
 		<div class="col-md-6 pb-5">
 			<div class="input-group" role="group">
+				<span class="input-group-addon">Reachability</span>
+				<select id="custom-reachability" class="form-control custom-value selectpicker" name="data[alttp.custom.region.reachability]">
+					<option value="random">Random</option>
+					<option value="full-clear">Full Clear</option>
+				</select>
+			</div>
+		</div>
+		<div class="col-md-6 pb-5">
+			<div class="input-group" role="group">
 				<span class="input-group-addon">Timer Start</span>
 				<input id="custom-timer-start" type="number" class="form-control custom-value" placeholder="seconds" name="data[alttp.custom.rom.timerStart]" />
 			</div>


### PR DESCRIPTION
This adds a Reachability option with the following values:

Random (the default): Any item or location may be unreachable, as long as it's not required to win.
Full Clear: Every location can be unlocked, including all dungeon keys.
Minimal: Every reachable advancement item is required to win. 

This needs a lot of testing. It's difficult to verify that all of these options do what they're supposed to, especially with my limited knowledge of the game.

With "Minimal" seeds in particular, I am unsure that enough unreachable locations will always be available to place the extra advancement items, and if not, some locations may be empty. Given the forgiving logic for dungeon keys, some of the extras might end up behind key doors in dungeons that you can access.

And of course, there's the question of what the community wants. I have little say as an outsider who's never even played through a seed.