### PR TITLE
Some pitfall clarifications

### DIFF
--- a/resources/views/resources.blade.php
+++ b/resources/views/resources.blade.php
@@ -67,7 +67,7 @@
 		<li>Agahnim's barrier can be bypassed with the Magic Cape or destroyed with an upgraded sword.
 		<li>Desert Palace can be reached from Misery Mire even without the Book of Mudora.
 		<li>Bombos burns things as well as the Fire Rod which is useful in Ice Palace.
-		<li>You can cross small gaps by rebounding off of walls or objects.
+		<li>You can cross small gaps by rebounding off of walls or objects using the Pegasus Boots.
 		<li>Sahasrahla gives you his item when you speak to him with the Pendant of Courage.
 		<li>The Super Bomb spawns when you have acquired crystals 5 and 6.
 		<li>You're guaranteed to get the digging game item by the 30th dig.

--- a/resources/views/resources.blade.php
+++ b/resources/views/resources.blade.php
@@ -70,9 +70,6 @@
 		<li>You can cross small gaps by rebounding off of walls or objects using the Pegasus Boots.
 		<li>Sahasrahla gives you his item when you speak to him with the Pendant of Courage.
 		<li>The Super Bomb spawns when you have acquired crystals 5 and 6.
-		<li>You're guaranteed to get the digging game item by the 30th dig.
-		<li>You're guaranteed to get the Village of Outcasts chest game item on the 1st attempt (can
-			be 1st or 2nd chest).
 		<li>The Smith and the Purple chest will stay following you through Save and Quit.
 		<li>You are never required to navigate a dark room; the lamp will be available to light your way, so go out and find it!
 		<li>Keys might not be accessible if they are not required to finish the game. For instance, the Skull Woods big key might be in the big chest.

--- a/resources/views/resources.blade.php
+++ b/resources/views/resources.blade.php
@@ -65,7 +65,7 @@
 		<li>If you find yourself at bumper cave with the Cape but without the Hookshot, try walking
 			over the top left of the gap. No hookshot needed!
 		<li>Agahnim's barrier can be bypassed with the Magic Cape or destroyed with an upgraded sword.
-		<li>Desert Palace can be reached from Misery Mire even without the Book of Mudora.
+		<li>If you have the Magic Mirror, Desert Palace can be reached from Misery Mire without the Book of Mudora.
 		<li>Bombos burns things as well as the Fire Rod which is useful in Ice Palace.
 		<li>You can cross small gaps by rebounding off of walls or objects using the Pegasus Boots.
 		<li>Sahasrahla gives you his item when you speak to him with the Pendant of Courage.

--- a/resources/views/resources.blade.php
+++ b/resources/views/resources.blade.php
@@ -75,6 +75,7 @@
 			be 1st or 2nd chest).
 		<li>The Smith and the Purple chest will stay following you through Save and Quit.
 		<li>You are never required to navigate a dark room; the lamp will be available to light your way, so go out and find it!
+		<li>Keys might not be accessible if they are not required to finish the game. For instance, the Skull Woods big key might be in the big chest.
 		</ul>
 	</div>
 </div>


### PR DESCRIPTION
* Mirror required for DP via MM
* Boots required for rebounding
* Keys can be locked away

I've also removed the digging/chest game entries because I don't think they qualify as pitfalls. They are still mentioned in the hints section.