### PR TITLE
Enable a Shooting Gallery item

### DIFF
--- a/app/Location/Archery.php
+++ b/app/Location/Archery.php
@@ -1,0 +1,10 @@
+<?php namespace ALttP\Location;
+
+use ALttP\Location;
+
+/**
+ * Archery type Location
+ */
+class Archery extends Location {
+
+}

--- a/app/Randomizer.php
+++ b/app/Randomizer.php
@@ -166,6 +166,11 @@ class Randomizer {
 			$locations["Turtle Rock - Trinexx"]->setItem($boss_item);
 			$locations["Tower of Hera - Moldorm"]->setItem($boss_item);
 		}
+		
+		// archery game is only available in custom mode (for now)
+		if( $this->difficulty !== 'custom' ) {
+		    $locations["Shooting Gallery"]->setItem(Item::get("Nothing"));
+		}
 
 		// Pedestal is the goal
 		if ($this->goal == 'pedestal') {
@@ -554,6 +559,8 @@ class Randomizer {
 	 */
 	public function writeToRom(Rom $rom) {
 		$this->setTexts($rom);
+		
+		$rom->enableArcheryGameItem();
 
 		foreach ($this->world->getRegions() as $name => $region) {
 			$region->getLocations()->getNonEmptyLocations()->each(function($location) use ($rom) {

--- a/app/Randomizer.php
+++ b/app/Randomizer.php
@@ -167,7 +167,7 @@ class Randomizer {
 			$locations["Tower of Hera - Moldorm"]->setItem($boss_item);
 		}
 		
-		// archery game is only available in custom mode (for now)
+		// shooting gallery item is only available in custom mode (for now)
 		if( $this->difficulty !== 'custom' ) {
 		    $locations["Shooting Gallery"]->setItem(Item::get("Nothing"));
 		}
@@ -560,7 +560,7 @@ class Randomizer {
 	public function writeToRom(Rom $rom) {
 		$this->setTexts($rom);
 		
-		$rom->enableArcheryGameItem();
+		$rom->enableShootingGalleryItem();
 
 		foreach ($this->world->getRegions() as $name => $region) {
 			$region->getLocations()->getNonEmptyLocations()->each(function($location) use ($rom) {

--- a/app/Randomizer.php
+++ b/app/Randomizer.php
@@ -1273,7 +1273,7 @@ class Randomizer {
 			array_push($items_to_find, Item::get('ArrowUpgrade70'));
 		}
 
-		for ($i = 0; $i < $this->config('item.count.Arrow', 1); $i++) {
+		for ($i = 0; $i < $this->config('item.count.Arrow', 1 + !$this->getWorld()->getLocation("Shooting Gallery")->hasItem()); $i++) {
 			array_push($items_to_find, Item::get('Arrow'));
 		}
 		for ($i = 0; $i < $this->config('item.count.TenArrows', 5); $i++) {

--- a/app/Region/DarkWorld/South.php
+++ b/app/Region/DarkWorld/South.php
@@ -30,6 +30,7 @@ class South extends Region {
 			new Location\Npc("Stumpy", 0x330C7, null, $this),
 			new Location\Npc("Hype Cave - NPC", 0x180011, null, $this),
 			new Location\Dig("Digging Game", 0x180148, null, $this),
+			new Location\Archery("Shooting Gallery", 0x3B51F, null, $this),
 		]);
 	}
 
@@ -46,6 +47,7 @@ class South extends Region {
 		$this->locations["Stumpy"]->setItem(Item::get('Shovel'));
 		$this->locations["Hype Cave - NPC"]->setItem(Item::get('ThreeHundredRupees'));
 		$this->locations["Digging Game"]->setItem(Item::get('PieceOfHeart'));
+		$this->locations["Shooting Gallery"]->setItem(Item::get('Nothing'));
 
 		return $this;
 	}

--- a/app/Rom.php
+++ b/app/Rom.php
@@ -10,7 +10,7 @@ use Log;
  */
 class Rom {
 	const BUILD = '2018-01-27';
-	const HASH = '704159aa2882c0fcc328598489daf6b2';
+	const HASH = '843cee371b4371fecfe035968747df95';
 	const SIZE = 2097152;
 	static private $digit_gfx = [
 		0 => 0x30,
@@ -2068,7 +2068,21 @@ class Rom {
 
 		return $this;
 	}
-
+	
+	/**
+	 * Enable item location at the archery minigame.
+	 *
+	 * @param bool $enable switch on or off
+	 *
+	 * @return $this
+	 */
+	public function enableArcheryGameItem() : self {
+	    $this->write(0x2843C, hex2bin("2211B507EAEAEAEAEAEAEAEAEA"));
+	    $this->write(0x3B511, hex2bin("5A48DAC940D020AF58F37ED01AA05AC05AF0149CE902229D9907A900EBA9018F58F37EFA688007FA68ACDA02D00CC2206F60F37E8F60F37EE2207A6B"));
+	
+	    return $this;
+	}
+	
 	/**
 	 * Enable/Disable Waterfall of Wishing Fairy's ability to upgrade items.
 	 *

--- a/app/Rom.php
+++ b/app/Rom.php
@@ -2070,13 +2070,11 @@ class Rom {
 	}
 	
 	/**
-	 * Enable item location at the archery minigame.
-	 *
-	 * @param bool $enable switch on or off
+	 * Enable item location at the shooting gallery minigame.
 	 *
 	 * @return $this
 	 */
-	public function enableArcheryGameItem() : self {
+	public function enableShootingGalleryItem() : self {
 	    $this->write(0x2843C, hex2bin("2211B507EAEAEAEAEAEAEAEAEA"));
 	    $this->write(0x3B511, hex2bin("5A48DAC940D020AF58F37ED01AA05AC05AF0149CE902229D9907A900EBA9018F58F37EFA688007FA68ACDA02D00CC2206F60F37E8F60F37EE2207A6B"));
 	

--- a/resources/views/customizer.blade.php
+++ b/resources/views/customizer.blade.php
@@ -334,6 +334,7 @@ $(function() {
 	$('.prizes').append($('#prizes').html());
 	$('.bottles').append($('#bottles').html());
 	$('.medallions').append($('#medallions').html());
+	$('.optional').append($('#optional').html());
 
 	$('form').on('submit', function() {
 		return false;
@@ -615,6 +616,15 @@ $(function() {
 <script id="items" type="text/template">
 	<option value="auto_fill">Random</option>
 	@foreach($items as $item)
+	<option class="placable placable-item{{ $item instanceof ALttP\Item\Bottle ? ' item-bottle' : '' }}"
+		value="{{ $item->getName() }}">{{ $item->getNiceName() }}</option>
+	@endforeach
+</script>
+<script id="optional" type="text/template">
+	<option value="Nothing">Nothing</option>
+	<option value="auto_fill">Random</option>
+	@foreach($items as $item)
+	<?php if ($item->getName() == "Nothing") continue; ?>
 	<option class="placable placable-item{{ $item instanceof ALttP\Item\Bottle ? ' item-bottle' : '' }}"
 		value="{{ $item->getName() }}">{{ $item->getNiceName() }}</option>
 	@endforeach

--- a/routes/web.php
+++ b/routes/web.php
@@ -51,6 +51,7 @@ Route::get('customize{r?}', function () {
 			Location\Prize\Crystal::class => 'prizes',
 			Location\Medallion::class => 'medallions',
 			Location\Fountain::class => 'bottles',
+			Location\Archery::class => 'optional',
 		],
 		'items' => $items->filter(function($item) {
 			return !$item instanceof Item\Pendant

--- a/tests/RandomizerTest.php
+++ b/tests/RandomizerTest.php
@@ -370,6 +370,7 @@ class RandomizerTest extends TestCase {
 			"Misery Mire Medallion" => "Bombos",
 			"Waterfall Bottle" => "BottleWithGreenPotion",
 			"Pyramid Bottle" => "BottleWithBee",
+			"Shooting Gallery" => "Nothing",
 		], $loc_item_array);
 	}
 
@@ -621,6 +622,7 @@ class RandomizerTest extends TestCase {
 			"Misery Mire Medallion" => "Bombos",
 			"Waterfall Bottle" => "BottleWithGreenPotion",
 			"Pyramid Bottle" => "BottleWithBee",
+			"Shooting Gallery" => "Nothing",
 		], $loc_item_array);
 	}
 
@@ -872,6 +874,7 @@ class RandomizerTest extends TestCase {
 			"Misery Mire Medallion" => "Bombos",
 			"Waterfall Bottle" => "BottleWithGreenPotion",
 			"Pyramid Bottle" => "BottleWithBee",
+			"Shooting Gallery" => "Nothing",
 		], $loc_item_array);
 	}
 }


### PR DESCRIPTION
I've been thinking the shooting gallery is so sad and neglected. There is no reason to go there, despite it being a decent place to make Rupees. And that folksy proprietor is just thrilled as fuck when you shoot his mutant crab varmints! So to make his life worth living, I enabled an item location there.

When the location is set to contain "Nothing", the minigame behaves exactly as in the vanilla game. Otherwise, if you hit 5 targets in a row, you receive an item along with the vanilla prize of 104 Rupees.

In an effort to avoid disruption, the location is made available only in the Customizer settings, and it is set to contain "Nothing" by default. This way, the normal randomizer behavior is not changed in any way unless a user sets the location to Random (or another item).

I hardcoded the altered minigame data in php, just to make things easy to merge and test. But if you think it's interesting and want to incorporate it into the base patch json, [here is the relevant .asm patch file](https://github.com/sporchia/alttp_vt_randomizer/files/1690758/archery_item.asm.zip).

Thanks and happy shooting.

Note: The new minigame stores a flag in SRAM $7EF358 indicating whether you have already received the item or not. As far as I can tell, this slot was unused, but I may be wrong.
