### PR TITLE
Rom options header h4 to h3

### DIFF
--- a/resources/views/_rom_settings.blade.php
+++ b/resources/views/_rom_settings.blade.php
@@ -5,7 +5,7 @@
 @section('rom-settings')
 <div class="panel panel-info panel-collapse collapse" id="rom-settings">
 	<div class="panel-heading">
-		<h4 class="panel-title">Additional ROM Options</h4>
+		<h3 class="panel-title">Additional ROM Options</h3>
 	</div>
 	<div class="panel-body">
 		<div class="col-md-6 pb-5">


### PR DESCRIPTION
With the update to css bolding h4 tags, this looks out of place, and I suspect it should've been h3 anyway.

Other panel-title headers throughout the site are all h3 and look great without the bolding.  This one looks great without the bold (v28/master), but the css bold for h4 (v29) ends up applied to it and doesn't look right compared to the rest of the site and the nearby h3 panel-title.