### PR TITLE
allow desert keys in locked locations in customizer

### DIFF
--- a/app/Region/DesertPalace.php
+++ b/app/Region/DesertPalace.php
@@ -88,12 +88,23 @@ class DesertPalace extends Region {
 			return $items->has('BigKeyP2');
 		});
 
+		$this->might_complete = function($locations, $items) {
+			return $this->canEnter($locations, $items)
+				&& $items->canLiftRocks() && $items->canLightTorches()
+				&& $items->has('BigKeyP2')
+				&& $this->boss->canBeat($items, $locations);
+		};
+
 		$this->locations["Desert Palace - Big Key Chest"]->setRequirements(function($locations, $items) {
-			return $items->has('KeyP2');
+			return $items->has('KeyP2')
+				|| ($this->locations["Desert Palace - Lanmolas'"]->hasItem(Item::get('KeyP2'))
+					&& call_user_func($this->might_complete, $locations, $items));
 		});
 
 		$this->locations["Desert Palace - Compass Chest"]->setRequirements(function($locations, $items) {
-			return $items->has('KeyP2');
+			return $items->has('KeyP2')
+				|| ($this->locations["Desert Palace - Lanmolas'"]->hasItem(Item::get('KeyP2'))
+					&& call_user_func($this->might_complete, $locations, $items));
 		});
 
 		$this->locations["Desert Palace - Torch"]->setRequirements(function($locations, $items) {
@@ -107,10 +118,9 @@ class DesertPalace extends Region {
 		};
 
 		$this->locations["Desert Palace - Lanmolas'"]->setRequirements(function($locations, $items) {
-			return $this->canEnter($locations, $items)
-				&& $items->canLiftRocks() && $items->canLightTorches()
-				&& $items->has('BigKeyP2') && $items->has('KeyP2')
-				&& $this->boss->canBeat($items, $locations);
+			return call_user_func($this->might_complete, $locations, $items)
+				&& ($items->has('KeyP2') || $this->locations["Desert Palace - Big Key Chest"]->hasItem(Item::get('KeyP2'))
+					|| $this->locations["Desert Palace - Compass Chest"]->hasItem(Item::get('KeyP2')));
 		})->setFillRules(function($item, $locations, $items) {
 			if (!$this->world->config('region.bossNormalLocation', true)
 				&& ($item instanceof Item\Key || $item instanceof Item\BigKey
@@ -141,14 +151,14 @@ class DesertPalace extends Region {
 	public function initOverworldGlitches() {
 		$this->initNoMajorGlitches();
 
-		$this->locations["Desert Palace - Lanmolas'"]->setRequirements(function($locations, $items) {
+		$this->might_complete = function($locations, $items) {
 			return $this->canEnter($locations, $items) && $items->canLightTorches()
-				&& $items->has('BigKeyP2') && $items->has('KeyP2')
+				&& $items->has('BigKeyP2')
 				&& $this->boss->canBeat($items, $locations)
 				&& (($items->has('BookOfMudora') && $items->canLiftRocks())
 					|| $items->has('PegasusBoots')
 					|| ($items->has('MagicMirror') && $this->world->getRegion('Mire')->canEnter($locations, $items)));
-		});
+		};
 
 		$this->can_enter = function($locations, $items) {
 			return $items->has('RescueZelda')


### PR DESCRIPTION
This allows the desert palace small key to be on lanmolas or right-side,
which is logically locked behind a key, as long as the key's location
is not required.

If the key is in the right side of DP, we can assume that it is possible
to defeat Lanmolas, but we can't assume that the right side chests are
accessible. If the player decides to steal the key for right side, they
will get the key back and still be able to access the boss. Otherwise,
they will be locked out of the right side.

Similarly, if Lanmolas has the key, AND the player can defeat Lanmolas
(by using the intended key), we can assume the right side chests are
accessible but we can't assume Lanmolas is. If the player goes all the
way to the boss door with the intended key, then they have to defeat
the boss to get the key back, and so we need to make sure the other
requirements are satisfied to prevent a softlock.

Currently, this has no effect on the default RandomAssumed filler or
RandomBeatable, because they won't place an important item in an
inaccessible location. So for right now, it only matters for customizer.

We could change that with a fill rule, but we don't want this to be
possible for RandomAssumed, and locking out extra locations may create
an unwinnable situation. We might be able to address this for the
"beatable" filler by adding another possible result to the fill rule,
which indicates that placing the item here opens some locations while
locking others, and it's up to the filler to check whether it breaks
things (or just don't place the item there, if we want all locations
to be accessible).