### PR TITLE
Add more choices for heart color selection

### DIFF
--- a/app/Rom.php
+++ b/app/Rom.php
@@ -1078,22 +1078,39 @@ class Rom {
 	 */
 	public function setHeartColors(string $color) : self {
 		switch ($color_on) {
-			case 'blue':
-				$byte = 0x2C;
-				$file_byte = 0x0D;
-				break;
-			case 'green':
-				$byte = 0x3C;
-				$file_byte = 0x19;
-				break;
-			case 'yellow':
-				$byte = 0x28;
-				$file_byte = 0x09;
+			case 'orange':
+				$byte = 0x20;
+				$file_byte = 0x01;
 				break;
 			case 'red':
 			default:
 				$byte = 0x24;
 				$file_byte = 0x05;
+				break;
+			case 'yellow':
+				$byte = 0x28;
+				$file_byte = 0x09;
+				break;
+			case 'blue':
+				$byte = 0x2C;
+				$file_byte = 0x0D;
+				break;
+			case 'grey':
+				$byte = 0x30;
+				$file_byte = 0x11;
+				break;
+			case 'redgold':
+				$byte = 0x34;
+				$file_byte = 0x15;
+				break;
+			case 'navy':
+				$byte = 0x38;
+				$file_byte = 0x1D;
+				break;
+			case 'green':
+				$byte = 0x3C;
+				$file_byte = 0x19;
+				break;
 		}
 		$this->write(0x6FA1E, pack('C*', $byte));
 		$this->write(0x6FA20, pack('C*', $byte));

--- a/resources/assets/js/rom.js
+++ b/resources/assets/js/rom.js
@@ -228,22 +228,39 @@ var ROM = (function(blob, loaded_callback) {
 	this.setHeartColor = function(color_on) {
 		return new Promise(function(resolve, reject) {
 			switch (color_on) {
-				case 'blue':
-					byte = 0x2C;
-					file_byte = 0x0D;
-					break;
-				case 'green':
-					byte = 0x3C;
-					file_byte = 0x19;
-					break;
-				case 'yellow':
-					byte = 0x28;
-					file_byte = 0x09;
+				case 'orange':
+					byte = 0x20;
+					file_byte = 0x01;
 					break;
 				case 'red':
 				default:
 					byte = 0x24;
 					file_byte = 0x05;
+					break;
+				case 'yellow':
+					byte = 0x28;
+					file_byte = 0x09;
+					break;
+				case 'blue':
+					byte = 0x2C;
+					file_byte = 0x0D;
+					break;
+				case 'grey':
+					byte = 0x30;
+					file_byte = 0x11;
+					break;
+				case 'redgold':
+					byte = 0x34;
+					file_byte = 0x15;
+					break;
+				case 'navy':
+					byte = 0x38;
+					file_byte = 0x1D;
+					break;
+				case 'green':
+					byte = 0x3C;
+					file_byte = 0x19;
+					break;
 			}
 			this.write(0x6FA1E, byte);
 			this.write(0x6FA20, byte);

--- a/resources/views/_rom_settings.blade.php
+++ b/resources/views/_rom_settings.blade.php
@@ -47,9 +47,13 @@
 				<span class="input-group-addon">Heart Color</span>
 				<select id="heart-color" class="form-control selectpicker">
 					<option value="blue">Blue</option>
+					<option value="navy">Navy</option>
 					<option value="green">Green</option>
 					<option value="red" selected>Red</option>
+					<option value="redgold">Red w/Gold Outline</option>
+					<option value="orange">Orange</option>
 					<option value="yellow">Yellow</option>
+					<option value="grey">Grey</option>
 				</select>
 			</div>
 		</div>


### PR DESCRIPTION
Expands the heart color dropdown to encompass all of the usable options I could find in the palette these seem to use.

First PR for this repo, hoping to start contributing more once I get my bearings!

![](https://78.media.tumblr.com/tumblr_m57jskyTW01qhuanoo1_540.gif)