### PR TITLE
Command Line Fixes

### DIFF
--- a/app/Console/Commands/Randomize.php
+++ b/app/Console/Commands/Randomize.php
@@ -124,8 +124,8 @@ class Randomize extends Command {
 				$this->info(sprintf('Rom Saved: %s', $output_file));
 			}
 			if ($this->option('spoiler')) {
-				$spoiler_file = sprintf($this->argument('output_directory') . '/' . 'alttp - VT_%s_%s_%s_%s_%s_%s.txt',
-					$rand->getLogic(), $this->option('difficulty'), config('game-mode'), $this->option('weapons'), $this->option('variation'), $rand->getSeed());
+				$spoiler_file = sprintf($this->argument('output_directory') . '/' . 'ALttP - VT_%s_%s-%s%s-%s%s_%s.txt',
+					$rand->getLogic(), $this->option('difficulty'), config('game-mode'), $this->option('weapons') ? '_' . $this->option('weapons') : '', $this->option('goal'), $this->option('variation')=='none' ? '' : '_' . $this->option('variation') , $rand->getSeed());
 				file_put_contents($spoiler_file, json_encode($rand->getSpoiler(), JSON_PRETTY_PRINT));
 				$this->info(sprintf('Spoiler Saved: %s', $spoiler_file));
 			}

--- a/app/Console/Commands/Randomize.php
+++ b/app/Console/Commands/Randomize.php
@@ -104,8 +104,8 @@ class Randomize extends Command {
 			$rom->muteMusic($this->option('no-music', false));
 			$rom->setMenuSpeed($this->option('menu-speed', 'normal'));
 
-			$output_file = sprintf($this->argument('output_directory') . '/' . 'alttp - VT_%s_%s_%s_%s_%s_%s.sfc',
-				$rand->getLogic(), $this->option('difficulty'), config('game-mode'), $this->option('weapons'), $this->option('variation'), $rand->getSeed());
+			$output_file = sprintf($this->argument('output_directory') . '/' . 'ALttP - VT_%s_%s-%s%s-%s%s_%s.sfc',
+				$rand->getLogic(), $this->option('difficulty'), config('game-mode'), $this->option('weapons') ? '_' . $this->option('weapons') : '', $this->option('goal'), $this->option('variation')=='none' ? '' : '_' . $this->option('variation') , $rand->getSeed());
 			if (!$this->option('no-rom', false)) {
 				if ($this->option('sprite') && is_readable($this->option('sprite'))) {
 					$this->info("sprite");

--- a/app/Console/Commands/UpdateBaseJson.php
+++ b/app/Console/Commands/UpdateBaseJson.php
@@ -1,6 +1,7 @@
 <?php namespace ALttP\Console\Commands;
 
 use Illuminate\Console\Command;
+use ALttP\Rom;
 
 class UpdateBaseJson extends Command {
 	/**
@@ -27,8 +28,13 @@ class UpdateBaseJson extends Command {
 			return $this->error('Source Files not readable');
 		}
 
-		$original_rom = fopen($this->argument('original_rom'), "r");
+		$tmp_file = tempnam(sys_get_temp_dir(), __CLASS__);
+		copy($this->argument('original_rom'), $tmp_file);
+
+		$original_rom = fopen($tmp_file, "r+");
+		ftruncate($original_rom, Rom::SIZE);
 		$updated_rom = fopen($this->argument('updated_rom'), "r");
+
 
 		$i = 0;
 		$cont = $i;
@@ -43,6 +49,7 @@ class UpdateBaseJson extends Command {
 		}
 		fclose($updated_rom);
 		fclose($original_rom);
+		unlink($tmp_file);
 
 		$backwards = array_reverse($out, true);
 		foreach ($backwards as $off => $value) {


### PR DESCRIPTION
This fixes the command line generation file names to match the website, since Karkat finds the difference in naming convention confusing.

I also updated the `updatebase` command to accept a 1MB vanilla rom instead of requiring a 2MB vanilla rom.