### PR TITLE
Tweak the "Single Arrow" hint

### DIFF
--- a/resources/lang/en/hint.php
+++ b/resources/lang/en/hint.php
@@ -73,7 +73,7 @@ return [
 		"OneHundredRupees" => "Some cash",
 		"FiftyRupees" => "Some cash",
 		"Heart" => "A Small Heart",
-		"Arrow" => ["The Single Arrow", "A Unique Item"],
+		"Arrow" => "The Single Arrow",
 		"TenArrows" => "some Arrows",
 		"SmallMagic" => "Small Magic",
 		"ThreeHundredRupees" => "Some cash",


### PR DESCRIPTION
Yes, there only ever going to be one chest that contains a single arrow, but the fact it can receive the hint label "A Unique Item" is terribly misleading.