### PR TITLE
Top Entrance Requirement Bug

### DIFF
--- a/app/Region/Inverted/TurtleRock.php
+++ b/app/Region/Inverted/TurtleRock.php
@@ -17,7 +17,7 @@ class TurtleRock extends Region\Standard\TurtleRock {
 					|| ($locations["Turtle Rock Medallion"]->hasItem(Item::get('Quake')) && $items->has('Quake')))
 				&& ($this->world->config('mode.weapons') == 'swordless' || $items->hasSword()))
 			&& $items->has('CaneOfSomaria')
-			&& $this->world->getRegion('East Death Mountain')->canEnter($locations, $items);
+			&& $this->world->getRegion('East Dark World Death Mountain')->canEnter($locations, $items);
 	}
 
 	protected function enterMiddle($locations, $items) {


### PR DESCRIPTION
The bug causes upper TRock entrance to think you need LW access to get to it.