### PR TITLE
Rupee Bow sprite fix

### DIFF
--- a/app/Randomizer.php
+++ b/app/Randomizer.php
@@ -252,6 +252,7 @@ class Randomizer {
 				}
 			}
 			$trash_items = array_merge($trash_items, $trash_items_replace);
+			$this->write(0x6F661, pack("C*", 0xBA, 0x28, 0xBB, 0x28, 0xCA, 0x24, 0xCB, 0x28);
 		}
 
 		if ($this->world->config('region.wildBigKeys', false)) {


### PR DESCRIPTION
Fixed the Sprite corresponding to $7EF340 = 3, or Bow with Silvers (no more arrows), the state that you are put in when you grab a "Bow and Silver Arrows" item, for Rupee Bow mode. This only happens in Customizer, but a hotfix is nice, since it will not affect any other behavior.