### PR TITLE
Add base update script and instructions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "sentry/sentry-laravel": "^0.8.0",
         "wnx/laravel-stats": "^1.7",
         "z3/enemizer": "6.0.29",
-        "z3/entrancerandomizer": "0.6.2+pre0"
+        "z3/entrancerandomizer": "0.6.2+pre0",
+        "z3/randomizer": "v30"
     },
     "require-dev": {
         "filp/whoops": "~2.0",
@@ -43,6 +44,18 @@
         "symfony/dom-crawler": "3.1.*"
     },
     "repositories": [
+        {
+            "type": "package",
+            "package": {
+                "name": "z3/randomizer",
+                "version": "v30",
+                "source": {
+                    "url": "https://github.com/mmxbass/z3randomizer",
+                    "type": "git",
+                    "reference": "master"
+                }
+            }
+        },
         {
             "type": "package",
             "package": {

--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,29 @@ You can run the current test suite with the following command (you may need to i
 $ phpunit
 ```
 
+## Updating base randomizer code
+The base randomizer code requires xkas v0.6 to be installed.  Once that is done, you will need a copy of the unmodified Zelda no Densetsu - Kamigami no Triforce (J) (V1.0) ROM named "alttp.sfc" and copied to the root of this repository.  You can then update the base randomizer ROM (source files located in vendor/z3/randomizer) by running
+
+```
+$ ./updatebase.sh
+```
+
+## Installing xkas
+xkas does not build or run properly on linux, so it must be run via WINE.  Also, it only supports 32-bit WINE, which may or may not require enabling multiarch support, depending on your environment.  Once wine32 is installed, copy xkas.exe anywhere on your system and then create a text file named xkas somewhere in your $PATH (e.g. /usr/local/bin) containing the following:
+
+```
+#!/bin/sh
+wine /path/to/xkas.exe "$@"
+```
+
+Now you can should be able to run xkas normally.
+
+```
+$ xkas
+xkas v0.06 ~byuu
+usage: xas file.asm <file.smc>
+```
+
 ## Bug Reports
 Bug reports for the current release version can be opened in this repository's [issue tracker](https://github.com/sporchia/alttp_vt_randomizer/issues).
 

--- a/updatebase.sh
+++ b/updatebase.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+if [ ! -f "alttp.sfc" ]; then
+    echo "alttp.sfc not found"
+    exit 1
+fi
+
+echo 03a63945398191337e896e5771f77173  alttp.sfc | md5sum -c >/dev/null 2>&1
+
+if [ $? != 0 ]; then
+    echo "checksum error"
+    exit 2
+fi
+
+rm -f base.sfc
+cp alttp.sfc base.sfc
+
+cd vendor/z3/randomizer
+
+# xkas does not properly build or run on Linux, so you'll need 'xkas' either
+# aliased or else as a script in $PATH pointing to wine /path/to/xkas.exe "$@"
+# NB: wine32 is required, xkas won't run on wine64
+xkas LTTP_RND_GeneralBugfixes.asm ../../../base.sfc
+
+if [ $? != 0 ]; then
+    echo "assembly error"
+    exit 2
+fi
+
+cd ../../..
+
+php artisan alttp:updatebase alttp.sfc base.sfc
+sed -i "s/\(const\s*BUILD\s*=\s*'\)\(.*\)\('\s*;\)/\1$(date +%Y-%m-%d)\3/g" app/Rom.php
+sed -i "s/\(const\s*HASH\s*=\s*'\)\(.*\)\('\s*;\)/\1$(md5sum base.sfc | awk '{print $1}')\3/g" app/Rom.php
+
+npm run production


### PR DESCRIPTION
Requires xkas.exe to be aliased or scripted somewhere in $PATH to launch in WINE, and the unmodified Jv1.0 ROM to be placed in the repo root.  Probably still needs some work, like the fact that the composer package is set to reference master instead of a specific commit (since the z3randomizer repo doesn't have any tagged releases to reference), but it's working, so I figured I'd submit it for feedback.