### PR TITLE
Always allow flying in inverted mode with the active flute.

### DIFF
--- a/app/Support/ItemCollection.php
+++ b/app/Support/ItemCollection.php
@@ -395,11 +395,14 @@ class ItemCollection extends Collection {
 	 * @return bool
 	 */
 	public function canFly() {
-		if ($this->world instanceof World\Inverted
-			&& !($this->has('MoonPearl') && $this->world->getRegion('North West Light World')->canEnter([], $this))) {
-			return $this->has('OcarinaActive');
+		return $this->has('OcarinaActive') || $this->has('OcarinaInactive') && $this->canActivateOcarina();
+	}
+	
+	private function canActivateOcarina() {
+		if ($this->world instanceof World\Inverted) {
+			return $this->has('MoonPearl') && $this->world->getRegion('North West Light World')->canEnter([], $this);
 		}
-		return $this->has('OcarinaActive') || $this->has('OcarinaInactive');
+		return true;
 	}
 
 	/**

--- a/app/Support/ItemCollection.php
+++ b/app/Support/ItemCollection.php
@@ -397,7 +397,7 @@ class ItemCollection extends Collection {
 	public function canFly() {
 		if ($this->world instanceof World\Inverted
 			&& !($this->has('MoonPearl') && $this->world->getRegion('North West Light World')->canEnter([], $this))) {
-			return false;
+			return $this->has('OcarinaActive');
 		}
 		return $this->has('OcarinaActive') || $this->has('OcarinaInactive');
 	}


### PR DESCRIPTION
Fix issue #615: the active flute should be available immediately without having to activate it in the light world.