### PR TITLE
Display sprite metadata at endpoint

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -159,11 +159,9 @@ class SettingsController extends Controller {
 	public function sprites(Request $request) {
 		$sprites =  [];
 		foreach (config('sprites') as $file => $info) {
-			$sprites[] = [
-				'name' => $info['name'],
-				'author' => $info['author'],
+			$sprites[] = array_merge($info,[
 				'file' => 'https://s3.us-east-2.amazonaws.com/alttpr/' . $file,
-			];
+			]);
 		}
 		return $sprites;
 	}


### PR DESCRIPTION
If sprites.php has info besides the sprite author and name, it also pushes this data to the endpoint at alttpr.com/sprites. The intention is to create a pipeline so that sprite metadata can be pushed to the endpoint.

This code on its own does not prescribe how the metadata should be inserted into sprites.php (this functionality has been separated into a different branch).