### PR TITLE
Added hook to insert sprite metadata during import

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -206,6 +206,7 @@ Artisan::command('alttp:sprconf {sprites}', function($sprites) {
 		return "$sprites/$filename";
 	}, scandir($sprites));
 
+	$sprite_meta = array();    //placeholder for a later implementation that bulk loads the sprite metadata
 	$output = [];
 	$i = 0;
 	foreach ($sprites as $spr_file) {
@@ -214,10 +215,14 @@ Artisan::command('alttp:sprconf {sprites}', function($sprites) {
 		} catch (Exception $e) {
 			continue;
 		}
-		$output[basename($spr_file)] = [
+		$sprite_ID = strtok(basename($spr_file),'.'); //by convention, filename is id.version.zspr
+		if(!array_key_exists($sprite_ID, $sprite_meta)) { //if empty metadata
+			$sprite_meta[$sprite_ID] = array();
+		}
+		$output[basename($spr_file)] = array_merge([
 			'name' => $spr->getDisplayText(),
 			'author' => $spr->getAuthor(),
-		];
+		],$sprite_meta[$sprite_ID]);
 		$this->info(sprintf(".icon-custom-%s {background-position: percentage((%d - 149)/ 148) 0}", str_replace([' ', ')', '(', '.'], '', $spr->getDisplayText()), ++$i));
 	}
 	file_put_contents(config_path('sprites.php'), preg_replace('/  /', "\t",


### PR DESCRIPTION
During sprite import, variable $sprite_meta is referenced.  It can be set to contain metadata about the sprites (indexed by their unique ID). This data is then used in the auto-population of sprites.php.

Presently, this code does not prescribe where the metadata should come from, and a placeholder assignment
$sprite_meta = array();
has been inserted.

The functionality of bulk loading the metadata has been factored out to a separate branch.