### PR TITLE
Bulk load metadata from spritemeta.json

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -201,6 +201,11 @@ Artisan::command('alttp:sprconf {sprites}', function($sprites) {
 	if (!is_dir($sprites)) {
 		return $this->error('Must be a directory of zsprs');
 	}
+	if (!file_exists("$sprites/spritemeta.json")) {
+		return $this->error("Missing $sprites/spritemeta.json");
+	}
+
+	$sprite_meta = json_decode(file_get_contents("$sprites/spritemeta.json"), true);
 
 	$sprites = array_map(function($filename) use ($sprites) {
 		return "$sprites/$filename";


### PR DESCRIPTION
During sprite import, expects spritemeta.json which contains metadata about the sprites (indexed by their unique ID). This code imports the json file.

This branch alone does not do anything further with the data, and it is meant to interface with two other proposed changes which auto-populate sprites.php and push that data to the endpoint at alttpr.com/sprites.  The overall intention is to make sprite metadata available to the website in order to produce a more versatile menu that allows filtering/searching/etc. while selecting a sprite.

Requires a commitment by the sprite-dev community to maintain the JSON document, or its originating spreadsheet, and so this should be discussed before deciding to merge this pull request.