### PR TITLE
Typo in Ether tablet item description

### DIFF
--- a/app/Location/Drop/Ether.php
+++ b/app/Location/Drop/Ether.php
@@ -56,7 +56,7 @@ class Ether extends Location {
 			case Item::get('KeyD4'):
 				return "The small key\nof rogues";
 			case Item::get('KeyP3'):
-				return "The key\nto moldorms\nbasement";
+				return "The key\nto moldorm's\nbasement";
 			case Item::get('KeyD5'):
 				return "A frozen\nsmall key\nrests here";
 			case Item::get('KeyD3'):


### PR DESCRIPTION
On the topic of the descriptions:
The descriptions for Ether and Bombos are identical, Pedestal differs only in one description. Having triple instances of text that is supposed to stay the same seems like a good way to introduce errors. Wouldn't it be a good idea to collect the descriptions for tablets and pedestal in some common base?

One could have a standalone function with all default descriptions (say, based on Bombos/Ether) and then let Bombos/Ether just call that function while Pedestal special cases sword upgrades before calling the function.