### PR TITLE
Fixed canExtendMagic

### DIFF
--- a/app/Support/ItemCollection.php
+++ b/app/Support/ItemCollection.php
@@ -454,8 +454,8 @@ class ItemCollection extends Collection {
 	 * @return bool
 	 */
 	public function canExtendMagic($bars = 2) {
-		return ($this->has('HalfMagic') ? 2 : 1)
-			* ($this->has('QuarterMagic') ? 4 : 1)
+		return ($this->has('QuarterMagic') ? 4 : 
+			($this->has('HalfMagic') ? 2 : 1))
 			* ($this->bottleCount() + 1) >= $bars;
 	}
 


### PR DESCRIPTION
Changed canExtendMagic to check for Half Magic and Quarter Magic in the same statement, as opposed to multiplying them together, to account for that both can be in the item pool.