### PR TITLE
Allow "always" requirement by passing null

### DIFF
--- a/app/Location.php
+++ b/app/Location.php
@@ -103,11 +103,11 @@ class Location {
 	 * Set the requirements callback for this Lcation, closure should take 2 arguments, $locations and $items and
 	 * return boolean.
 	 *
-	 * @param Callable $callback function to be called when checking if Location can have Item
+	 * @param Callable|null $callback function to be called when checking if Location can have Item
 	 *
 	 * @return $this
 	 */
-	public function setRequirements(Callable $callback) {
+	public function setRequirements(Callable $callback = null) {
 		$this->requirement_callback = $callback;
 
 		return $this;

--- a/app/Region/Inverted/LightWorld/NorthWest.php
+++ b/app/Region/Inverted/LightWorld/NorthWest.php
@@ -132,18 +132,10 @@ class NorthWest extends Region\Standard\LightWorld\NorthWest {
 			return !$this->world->config('region.cantTakeDamage', false) || $items->has('MoonPearl') || $items->has('MagicMirror');
 		});
 
-		$this->locations["Kakariko Well - Left"]->setRequirements(function($locations, $items) {
-			return true;
-		});
-		$this->locations["Kakariko Well - Middle"]->setRequirements(function($locations, $items) {
-			return true;
-		});
-		$this->locations["Kakariko Well - Right"]->setRequirements(function($locations, $items) {
-			return true;
-		});
-		$this->locations["Kakariko Well - Bottom"]->setRequirements(function($locations, $items) {
-			return true;
-		});
+		$this->locations["Kakariko Well - Left"]->setRequirements(null);
+		$this->locations["Kakariko Well - Middle"]->setRequirements(null);
+		$this->locations["Kakariko Well - Right"]->setRequirements(null);
+		$this->locations["Kakariko Well - Bottom"]->setRequirements(null);
 
 		$this->locations["Blind's Hideout - Left"]->setRequirements(function($locations, $items) {
 			return $items->has('MoonPearl') || $items->has('MagicMirror');


### PR DESCRIPTION
Previous commit attempting this failed because Callable hint requires a non-null value, but it appears that a default argument value of null gets around this (because obviously...)

I did not see any tests covering inverted light world north west overworld glitches. Please advice if you want me to add to the pull request.