### PR TITLE
Allow creation of games where only the initial generator can see the spoiler log.

### DIFF
--- a/app/Http/Controllers/EntranceRandomizerController.php
+++ b/app/Http/Controllers/EntranceRandomizerController.php
@@ -11,7 +11,7 @@ class EntranceRandomizerController extends Controller {
 		$payload = $this->prepSeed($request, $seed_id, true);
 		$save_data = json_encode(array_except($payload, ['current_rom_hash', 'seed']));
 		SendPatchToDisk::dispatch($payload['seed']);
-		cache(['hash.' . $payload['hash'] => $save_data], now()->addDays(7));
+		// cache(['hash.' . $payload['hash'] => $save_data], now()->addDays(7));
 		return json_encode(array_except($payload, ['seed']));
 	}
 
@@ -30,14 +30,17 @@ class EntranceRandomizerController extends Controller {
 		$shuffle = $request->input('shuffle', 'full') ?: 'full';
 		$enemizer = $request->input('enemizer', false);
 		$spoilers = $request->input('spoilers', false);
+		$spoilersongenerate = $request->input('spoilersongenerate', false);
 		$tournament = $request->filled('tournament') && $request->input('tournament') == 'true';
 		$spoiler_meta = [
 			'_meta' => [
 				'enemizer' => $enemizer,
 				'size' => $enemizer ? 4 : 2,
 				'spoilers' => $spoilers,
+				'spoilersongenerate' => $spoilersongenerate,
 			],
 			'tournament' => $tournament,
+			'spoilersongenerate' => $spoilersongenerate,
 		];
 		if ($enemizer && $enemizer['bosses']) {
 			config(['alttp.boss_shuffle' => $enemizer['bosses']]);
@@ -79,7 +82,7 @@ class EntranceRandomizerController extends Controller {
 		if ($tournament) {
 			$rom->setSeedString(str_pad(sprintf("ER TOURNEY %s", $hash), 21, ' '));
 			$patch = $rom->getWriteLog();
-			if ($spoilers) {
+			if ($spoilers || $spoilersongenerate) {
 				$spoiler = array_except($spoiler, ['playthrough']);
 			} else {
 				$spoiler = array_except(array_only($spoiler, ['meta']), ['meta.seed']);

--- a/app/Http/Controllers/EntranceRandomizerController.php
+++ b/app/Http/Controllers/EntranceRandomizerController.php
@@ -11,7 +11,6 @@ class EntranceRandomizerController extends Controller {
 		$payload = $this->prepSeed($request, $seed_id, true);
 		$save_data = json_encode(array_except($payload, ['current_rom_hash', 'seed']));
 		SendPatchToDisk::dispatch($payload['seed']);
-		// cache(['hash.' . $payload['hash'] => $save_data], now()->addDays(7));
 		return json_encode(array_except($payload, ['seed']));
 	}
 

--- a/app/Http/Controllers/ItemRandomizerController.php
+++ b/app/Http/Controllers/ItemRandomizerController.php
@@ -22,7 +22,6 @@ class ItemRandomizerController extends Controller {
 			$payload = $this->prepSeed($request, $seed_id, true);
 			$save_data = json_encode(array_except($payload, ['current_rom_hash', 'seed']));
 			SendPatchToDisk::dispatch($payload['seed']);
-			// cache(['hash.' . $payload['hash'] => $save_data], now()->addDays(7));
 
 			return json_encode(array_except($payload, ['seed']));
 		} catch (Exception $e) {

--- a/app/Jobs/SendPatchToDisk.php
+++ b/app/Jobs/SendPatchToDisk.php
@@ -43,7 +43,7 @@ class SendPatchToDisk implements ShouldQueue {
 		}
 		logger()->info("Sending file seed: {$this->seed->id}");
 
-		Storage::put("{$this->seed->hash}.json", gzencode(json_encode([
+		$save_data = json_encode([
 			'logic' => $this->seed->logic,
 			'difficulty' => $this->seed->rules,
 			'patch' => json_decode($this->seed->patch),
@@ -51,7 +51,10 @@ class SendPatchToDisk implements ShouldQueue {
 			'hash' => $this->seed->hash,
 			'size' => $spoiler['meta']['_meta']['size'] ?? 2,
 			'generated' => $this->seed->created_at ? $this->seed->created_at->toIso8601String() : now()->toIso8601String(),
-		])), ['ContentEncoding' => 'gzip', 'ContentType' => 'application/json']);
+		]);
+
+		Storage::put("{$this->seed->hash}.json", gzencode($save_data), ['ContentEncoding' => 'gzip', 'ContentType' => 'application/json']);
+		cache(['hash.' . $this->seed->hash => $save_data], now()->addDays(7));
 
 		if ($this->clear_record) {
 			$this->seed->clearPatch();

--- a/resources/assets/js/components/VTRomInfo.vue
+++ b/resources/assets/js/components/VTRomInfo.vue
@@ -1,5 +1,6 @@
 <template>
-	<div>
+	<div>	
+		<div v-if="rom.spoiler.meta.spoilersongenerate==true" class="spoiler-warning">WARNING: Generator of game viewed the spoiler log.</div>
 		<div v-if="rom.logic">{{ $t('rom.info.logic') }}: {{ rom.logic }}</div>
 		<div v-if="rom.build">{{ $t('rom.info.build') }}: {{ rom.build }}</div>
 		<div v-if="rom.difficulty">
@@ -32,3 +33,9 @@ export default {
 }
 </script>
 
+<style scoped>
+.spoiler-warning {
+	color: red;
+  	font-weight: bold;
+}
+</style>

--- a/resources/assets/js/components/VTRomInfo.vue
+++ b/resources/assets/js/components/VTRomInfo.vue
@@ -1,6 +1,6 @@
 <template>
 	<div>	
-		<div v-if="rom.spoiler.meta.spoilersongenerate==true" class="spoiler-warning">WARNING: Generator of game viewed the spoiler log.</div>
+		<div v-if="rom.spoiler.meta.spoilersongenerate==true" class="spoiler-warning">{{ $t('rom.info.spoilerwarning') }}</div>
 		<div v-if="rom.logic">{{ $t('rom.info.logic') }}: {{ rom.logic }}</div>
 		<div v-if="rom.build">{{ $t('rom.info.build') }}: {{ rom.build }}</div>
 		<div v-if="rom.difficulty">

--- a/resources/lang/de/rom.php
+++ b/resources/lang/de/rom.php
@@ -11,7 +11,7 @@ return [
 			. '</ol>',
 	],
 	'info' => [
-		'spoilerwarning' => 'WARNUNG: Der Generator des Spiels hat das Spoilerprotokoll angezeigt.',
+		'spoilerwarning' => 'WARNUNG: Der Ersteller dieses Spiel hat den Spoiler Log angesehen.',
 		'logic' => __('randomizer.logic.title'),
 		'build' => 'ROM build',
 		'difficulty' => __('randomizer.difficulty.title'),

--- a/resources/lang/de/rom.php
+++ b/resources/lang/de/rom.php
@@ -11,6 +11,7 @@ return [
 			. '</ol>',
 	],
 	'info' => [
+		'spoilerwarning' => 'WARNUNG: Der Generator des Spiels hat das Spoilerprotokoll angezeigt.',
 		'logic' => __('randomizer.logic.title'),
 		'build' => 'ROM build',
 		'difficulty' => __('randomizer.difficulty.title'),

--- a/resources/lang/en/rom.php
+++ b/resources/lang/en/rom.php
@@ -11,7 +11,7 @@ return [
 			. '</ol>',
 	],
 	'info' => [
-		'spoilerwarning' => 'WARNING: Generator of game viewed the spoiler log.',
+		'spoilerwarning' => 'WARNING: The generator of this game viewed the spoiler log.',
 		'logic' => __('randomizer.logic.title'),
 		'build' => 'ROM build',
 		'difficulty' => __('randomizer.difficulty.title'),

--- a/resources/lang/en/rom.php
+++ b/resources/lang/en/rom.php
@@ -11,6 +11,7 @@ return [
 			. '</ol>',
 	],
 	'info' => [
+		'spoilerwarning' => 'WARNING: Generator of game viewed the spoiler log.',
 		'logic' => __('randomizer.logic.title'),
 		'build' => 'ROM build',
 		'difficulty' => __('randomizer.difficulty.title'),

--- a/resources/lang/es/rom.php
+++ b/resources/lang/es/rom.php
@@ -11,7 +11,7 @@ return [
 			. '</ol>',
 	],
 	'info' => [
-		'spoilerwarning' => 'ADVERTENCIA: Generador de juego visto el registro de spoiler.',
+		'spoilerwarning' => 'ADVERTENCIA: El generador de este juego a visto el registro de spoiler.',
 		'logic' => __('randomizer.logic.title'),
 		'build' => 'Build de la ROM',
 		'difficulty' => __('randomizer.difficulty.title'),

--- a/resources/lang/es/rom.php
+++ b/resources/lang/es/rom.php
@@ -11,6 +11,7 @@ return [
 			. '</ol>',
 	],
 	'info' => [
+		'spoilerwarning' => 'ADVERTENCIA: Generador de juego visto el registro de spoiler.',
 		'logic' => __('randomizer.logic.title'),
 		'build' => 'Build de la ROM',
 		'difficulty' => __('randomizer.difficulty.title'),

--- a/resources/lang/fr/rom.php
+++ b/resources/lang/fr/rom.php
@@ -11,7 +11,7 @@ return [
 			. '</ol>',
 	],
 	'info' => [
-		'spoilerwarning' => 'AVERTISSEMENT: le générateur de jeu a consulté le journal du spoiler.',
+		'spoilerwarning' => 'AVERTISSEMENT : La personne qui a généré cette partie a regardé le spoiler log.',
 		'logic' => __('randomizer.logic.title'),
 		'build' => 'Création de ROM',
 		'difficulty' => __('randomizer.difficulty.title'),

--- a/resources/lang/fr/rom.php
+++ b/resources/lang/fr/rom.php
@@ -11,6 +11,7 @@ return [
 			. '</ol>',
 	],
 	'info' => [
+		'spoilerwarning' => 'AVERTISSEMENT: le générateur de jeu a consulté le journal du spoiler.',
 		'logic' => __('randomizer.logic.title'),
 		'build' => 'Création de ROM',
 		'difficulty' => __('randomizer.difficulty.title'),

--- a/routes/console.php
+++ b/routes/console.php
@@ -73,7 +73,6 @@ Artisan::command('alttp:dailies {days=7}', function ($days) {
 			]);
 
 			SendPatchToDisk::dispatch($seed_record);
-			cache(['hash.' . $hash => $save_data], now()->addDays(7));
 		}
 	}
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,10 +25,15 @@ Route::any('hash/{hash}', function(Request $request, $hash) {
 	$payload = cache($cache_hash);
 	if (!$payload) {
 		try {
-			cache([$cache_hash => Storage::get($hash . '.json')], now()->addDays(7));
+			cache([$cache_hash => gzdecode(Storage::get($hash . '.json'))], now()->addDays(7));
 			return cache($cache_hash);
 		} catch (\Exception $e) {
-			logger()->error($e);
+			try {
+				cache([$cache_hash => Storage::get($hash . '.json')], now()->addDays(7));
+				return cache($cache_hash);
+			} catch (\Exception $e) {
+				logger()->error($e);
+			}
 		}
 		abort(404);
 	}


### PR DESCRIPTION
This adds an additional option called "spoilersongenerate" that can be used by a bot to generate a game, but the game data written to storage does not have the spoiler log.  This is so we can do spoiler tournaments and races in the future where we can distribute the permalink in advance, then give the log to runners later.

This also fixes a small bug with the /hash/ endpoint where if you attempt to retrieve a game that has been evicted from cache, it doesn't gzip decode the retrieved json.  If it fails to gzip decode it, it'll fall back to retrieving the file without gzip decoding the file.

I also removed caching of the game data on initial generation.  This is so what gets cached was what was actually written.

Finally, it puts a warning banner on games generated using "spoilersongenerate" so others know the generator of the game viewed the spoiler log.  ~~I added an entry in the rom.php file for each language, however for fr, es, and de I used Google Translate.  I'm sure we'll want to get real translations for those.~~ I got a few people to provide Spanish, French, and German translations for the string.

Let me know if there is anything that should be changed or fixed with this pull request.  This feature will make it much easier for us to run future spoiler tournaments and races without needing to use a separate instance of the randomizer website.

Thanks!