### PR TITLE
Ensure setStartScreenHash is ran when generating dailies

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -51,6 +51,8 @@ Artisan::command('alttp:dailies {days=7}', function ($days) {
 			$hash = $rand->saveSeedRecord();
 
 			$rom->setSeedString(str_pad(sprintf("VT TOURNEY %s", $hash), 21, ' '));
+			$rom->setStartScreenHash($rand->getSeedRecord()->hashArray());
+			
 			$rom->rummageTable();
 			$patch = patch_merge_minify($rom->getWriteLog());
 			$rand->updateSeedRecordPatch($patch);


### PR DESCRIPTION
This patch runs "setStartScreenHash" so each daily game has a unique code on the start screen.

This fixes https://github.com/sporchia/alttp_vt_randomizer/issues/655