### PR TITLE
Logic Fixes

### DIFF
--- a/app/Boss.php
+++ b/app/Boss.php
@@ -109,7 +109,7 @@ class Boss
                     || ($items->has('Bombos') && ($world->config('mode.weapons') === 'swordless' || $items->hasSword()) && $items->canExtendMagic(2) && $items->has('FireRod')))
                     && $items->canMeltThings($world) && ($items->has('Hammer') || $items->hasSword()
                         || ($items->canExtendMagic(3) && $items->has('FireRod'))
-                        || ($items->canExtendMagic(2) && $items->has('FireRod') && $items->has('Bombos')));
+                        || ($items->canExtendMagic(2) && $items->has('FireRod') && $items->has('Bombos') && $world->config('mode.weapons') === 'swordless'));
             }),
             new static("Vitreous", "Vitreous", function ($locations, $items) use ($world) {
                 return ($world->config('itemPlacement') !== 'basic' || $items->hasSword(2) || $items->canShootArrows())

--- a/app/Randomizer.php
+++ b/app/Randomizer.php
@@ -235,8 +235,14 @@ class Randomizer implements RandomizerContract
             $uncle_sword = Item::get('UncleSword', $world)->setTarget(array_pop($nice_items_swords));
             $world->getLocation("Link's Uncle")->setItem($uncle_sword);
 
-            foreach (["Pyramid Fairy - Left", "Blacksmith", "Master Sword Pedestal"] as $location) {
+            foreach (["Pyramid Fairy - Left", "Blacksmith"] as $location) {
                 $world->getLocation($location)->setItem(array_pop($nice_items_swords));
+            }
+            if (!$world->getLocation("Master Sword Pedestal")->hasItem(Item::get('Triforce', $world))) {
+                $world->getLocation($location)->setItem(array_pop($nice_items_swords));
+            } else {
+                array_pop($nice_items_swords);
+                array_push($trash_items, Item::get('TwentyRupees', $world));
             }
         } else {
             // put uncle sword back

--- a/app/Randomizer.php
+++ b/app/Randomizer.php
@@ -828,6 +828,15 @@ class Randomizer implements RandomizerContract
 
         return $this;
     }
+    
+     function getTextArray(string $file)
+    {
+        return array_filter(explode(
+                    "\n-\n",
+                    (string) preg_replace('/^-\n/', '', 
+                    (string) preg_replace('/\r\n/', "\n", (string) file_get_contents(base_path($file))))
+                ));
+    }
 
     /**
      * Set all texts for this randomization
@@ -840,26 +849,11 @@ class Randomizer implements RandomizerContract
     {
         $strings = cache()->rememberForever('strings', function () {
             return [
-                'uncle' => array_filter(explode(
-                    "\n-\n",
-                    (string) preg_replace('/^-\n/', '', (string) file_get_contents(base_path('strings/uncle.txt')))
-                )),
-                'tavern_man' => array_filter(explode(
-                    "\n-\n",
-                    (string) preg_replace('/^-\n/', '', (string) file_get_contents(base_path('strings/tavern_man.txt')))
-                )),
-                'blind' => array_filter(explode(
-                    "\n-\n",
-                    (string) preg_replace('/^-\n/', '', (string) file_get_contents(base_path('strings/blind.txt')))
-                )),
-                'ganon_1' => array_filter(explode(
-                    "\n-\n",
-                    (string) preg_replace('/^-\n/', '', (string) file_get_contents(base_path('strings/ganon_1.txt')))
-                )),
-                'triforce' => array_filter(explode(
-                    "\n-\n",
-                    (string) preg_replace('/^-\n/', '', (string) file_get_contents(base_path('strings/triforce.txt')))
-                )),
+                'uncle' => $this->getTextArray('strings/uncle.txt'),
+                'tavern_man' => $this->getTextArray('strings/tavern_man.txt'),
+                'blind' => $this->getTextArray('strings/blind.txt'),
+                'ganon_1' => $this->getTextArray('strings/ganon_1.txt'),
+                'triforce' => $this->getTextArray('strings/triforce.txt'),
             ];
         });
 

--- a/app/Region/Inverted/GanonsTower.php
+++ b/app/Region/Inverted/GanonsTower.php
@@ -26,13 +26,13 @@ class GanonsTower extends Region\Standard\GanonsTower
 
         $this->can_enter = function ($locations, $items) {
             return ($this->world->config('canDungeonRevive', false) || $items->has('MoonPearl'))
-                && $items->has('Crystal1')
-                && $items->has('Crystal2')
-                && $items->has('Crystal3')
-                && $items->has('Crystal4')
-                && $items->has('Crystal5')
-                && $items->has('Crystal6')
-                && $items->has('Crystal7')
+                && (($items->has('Crystal1')
+                   + $items->has('Crystal2')
+                   + $items->has('Crystal3')
+                   + $items->has('Crystal4')
+                   + $items->has('Crystal5')
+                   + $items->has('Crystal6')
+                   + $items->has('Crystal7')) >= $this->world->config('crystals.tower', 7))
                 && $this->world->getRegion('North East Light World')->canEnter($locations, $items);
         };
 

--- a/app/Region/Standard/PalaceOfDarkness.php
+++ b/app/Region/Standard/PalaceOfDarkness.php
@@ -99,6 +99,8 @@ class PalaceOfDarkness extends Region
         $this->locations["Palace of Darkness - Big Chest"]->setRequirements(function ($locations, $items) {
             return $items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && $items->has('BigKeyD1')
                 && ((($items->has('Hammer') && $items->canShootArrows()) || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 6) : $items->has('KeyD1', 5));
+        })->setFillRules(function ($item, $locations, $items) {
+            return $item != Item::get('KeyD1', $this->world);
         });
 
         $this->locations["Palace of Darkness - Compass Chest"]->setRequirements(function ($locations, $items) {
@@ -140,10 +142,14 @@ class PalaceOfDarkness extends Region
 
         $this->locations["Palace of Darkness - Dark Maze - Top"]->setRequirements(function ($locations, $items) {
             return $items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && ((($items->has('Hammer') && $items->canShootArrows()) || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 6) : $items->has('KeyD1', 5));
+        })->setFillRules(function ($item, $locations, $items) {
+            return $item != Item::get('KeyD1', $this->world);
         });
 
         $this->locations["Palace of Darkness - Dark Maze - Bottom"]->setRequirements(function ($locations, $items) {
             return $items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && ((($items->has('Hammer') && $items->canShootArrows()) || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 6) : $items->has('KeyD1', 5));
+        })->setFillRules(function ($item, $locations, $items) {
+            return $item != Item::get('KeyD1', $this->world);
         });
 
         $this->can_complete = function ($locations, $items) {

--- a/app/Region/Standard/PalaceOfDarkness.php
+++ b/app/Region/Standard/PalaceOfDarkness.php
@@ -84,7 +84,7 @@ class PalaceOfDarkness extends Region
                 return $items->has('KeyD1');
             }
 
-            return (($items->has('Hammer') && $items->canShootArrows() && $items->has('Lamp', $this->world->config('item.require.Lamp', 1))) ? $items->has('KeyD1', 6) : $items->has('KeyD1', 5));
+            return ((($items->has('Hammer') && $items->canShootArrows() && $items->has('Lamp', $this->world->config('item.require.Lamp', 1))) || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 6) : $items->has('KeyD1', 5));
         })->setAlwaysAllow(function ($item, $items) {
             return $this->world->config('accessibility') !== 'locations' && $item == Item::get('KeyD1', $this->world) && $items->has('KeyD1', 5);
         })->setFillRules(function ($item, $locations, $items) {
@@ -98,19 +98,19 @@ class PalaceOfDarkness extends Region
 
         $this->locations["Palace of Darkness - Big Chest"]->setRequirements(function ($locations, $items) {
             return $items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && $items->has('BigKeyD1')
-                && (($items->has('Hammer') && $items->canShootArrows()) ? $items->has('KeyD1', 6) : $items->has('KeyD1', 5));
+                && ((($items->has('Hammer') && $items->canShootArrows()) || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 6) : $items->has('KeyD1', 5));
         });
 
         $this->locations["Palace of Darkness - Compass Chest"]->setRequirements(function ($locations, $items) {
-            return ($items->has('Hammer') && $items->canShootArrows() && $items->has('Lamp', $this->world->config('item.require.Lamp', 1))) ? $items->has('KeyD1', 4) : $items->has('KeyD1', 3);
+            return (($items->has('Hammer') && $items->canShootArrows() && $items->has('Lamp', $this->world->config('item.require.Lamp', 1))) || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 4) : $items->has('KeyD1', 3);
         });
 
         $this->locations["Palace of Darkness - Harmless Hellway"]->setRequirements(function ($locations, $items) {
             if ($locations["Palace of Darkness - Harmless Hellway"]->hasItem(Item::get('KeyD1', $this->world))) {
-                return ($items->has('Hammer') && $items->canShootArrows() && $items->has('Lamp', $this->world->config('item.require.Lamp', 1))) ? $items->has('KeyD1', 4) : $items->has('KeyD1', 3);
+                return (($items->has('Hammer') && $items->canShootArrows() && $items->has('Lamp', $this->world->config('item.require.Lamp', 1))) || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 4) : $items->has('KeyD1', 3);
             }
 
-            return (($items->has('Hammer') && $items->canShootArrows() && $items->has('Lamp', $this->world->config('item.require.Lamp', 1))) ? $items->has('KeyD1', 6) : $items->has('KeyD1', 5));
+            return ((($items->has('Hammer') && $items->canShootArrows() && $items->has('Lamp', $this->world->config('item.require.Lamp', 1))) || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 6) : $items->has('KeyD1', 5));
         })->setAlwaysAllow(function ($item, $items) {
             return $this->world->config('accessibility') !== 'locations' && $item == Item::get('KeyD1', $this->world) && $items->has('KeyD1', 5);
         })->setFillRules(function ($item, $locations, $items) {
@@ -125,13 +125,13 @@ class PalaceOfDarkness extends Region
         $this->locations["Palace of Darkness - Dark Basement - Left"]->setRequirements(function ($locations, $items) {
             return ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
                 || ($this->world->config('itemPlacement') === 'advanced' && $items->has('FireRod')))
-                && (($items->has('Hammer') && $items->canShootArrows()) ? $items->has('KeyD1', 4) : $items->has('KeyD1', 3));
+                && ((($items->has('Hammer') && $items->canShootArrows() && $items->has('Lamp', $this->world->config('item.require.Lamp', 1))) || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 4) : $items->has('KeyD1', 3));
         });
 
         $this->locations["Palace of Darkness - Dark Basement - Right"]->setRequirements(function ($locations, $items) {
             return ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
                 || ($this->world->config('itemPlacement') === 'advanced' && $items->has('FireRod')))
-                && (($items->has('Hammer') && $items->canShootArrows()) ? $items->has('KeyD1', 4) : $items->has('KeyD1', 3));
+                && ((($items->has('Hammer') && $items->canShootArrows() && $items->has('Lamp', $this->world->config('item.require.Lamp', 1))) || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 4) : $items->has('KeyD1', 3));
         });
 
         $this->locations["Palace of Darkness - Map Chest"]->setRequirements(function ($locations, $items) {
@@ -139,11 +139,11 @@ class PalaceOfDarkness extends Region
         });
 
         $this->locations["Palace of Darkness - Dark Maze - Top"]->setRequirements(function ($locations, $items) {
-            return $items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && (($items->has('Hammer') && $items->canShootArrows()) ? $items->has('KeyD1', 6) : $items->has('KeyD1', 5));
+            return $items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && ((($items->has('Hammer') && $items->canShootArrows()) || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 6) : $items->has('KeyD1', 5));
         });
 
         $this->locations["Palace of Darkness - Dark Maze - Bottom"]->setRequirements(function ($locations, $items) {
-            return $items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && (($items->has('Hammer') && $items->canShootArrows()) ? $items->has('KeyD1', 6) : $items->has('KeyD1', 5));
+            return $items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && ((($items->has('Hammer') && $items->canShootArrows()) || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 6) : $items->has('KeyD1', 5));
         });
 
         $this->can_complete = function ($locations, $items) {

--- a/app/Services/HintService.php
+++ b/app/Services/HintService.php
@@ -32,9 +32,10 @@ class HintService
         $this->advancement_items = $advancement_items;
         $this->joke_hints = cache()->rememberForever('joke_hints', function () {
             return array_filter(explode(
-                "\n-\n",
-                (string) preg_replace('/^-\n/', '', (string) file_get_contents(base_path('strings/hint.txt')))
-            ));
+                    "\n-\n",
+                    (string) preg_replace('/^-\n/', '', 
+                    (string) preg_replace('/\r\n/', "\n", (string) file_get_contents(base_path('strings/hint.txt'))))
+                ));
         });
     }
 


### PR DESCRIPTION
Account for GT required crystals in Inverted mode #718 .

PoD dark maze etc to always require 6 keys in keysanity mode (since the logic can't determine if the bow/hammer is completely inaccessible).  And also add some fill rules to make sure the customizer doesn't put keys in dark maze.  #658 

Allow Pedestal Goal and Vanilla Swords to be used (sword on pedestal is replaced with Triforce).

Kholdstare is not beatable with only Fire Rod, Bombos and a bottle unless this is swordless mode and Bombos can actually be used.

Fix Windows line endings when parsing the hints / text.