### PR TITLE
Fix Dungeon Item Menu/Text Box and Hints options in Customizer

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,18 +1,39 @@
+DO NOT ATTACH ROM FILES TO ISSUES
+
 Console or Emulator:
 
  If emulator state which emulator and version.
 
 Original Filename:
 
-Item, Entrance or Custom:
 
-Mode:
-Logic:
+Permalink:
+
+- OR list settings -
+
+Settings
+---
+Glitches Required:
+Item Placement:
+Dungeon Item Shuffle:
+Accessibility:
+
 Goal:
-Difficulty:
-Variation:
-Enemizer Options:
+Open Tower:
+Ganon Vulnerable:
 
+World State:
+Entrance Shuffle:
+Boss Shuffle:
+Enemy Shuffle:
+Hints:
+
+Swords:
+Item Pool:
+Item Functionality:
+Enemy Damage:
+Enemy Health:
+
+---
 Description of problem:
 
-Spoiler (if available):

--- a/app/Http/Controllers/CustomizerController.php
+++ b/app/Http/Controllers/CustomizerController.php
@@ -124,6 +124,9 @@ class CustomizerController extends Controller
             $spoiler_meta['notes'] = $purifier->purify($markdowned);
         }
 
+        // Fix for hints option not working in Customizer. We overwrite any potential stale
+        // spoil.Hints value in custom data because it's not hooked up to the Hints dropdown.
+        $custom_data['spoil.Hints'] = $request->input('hints', 'on');
         $custom_data['item.require.Lamp'] = $custom_data['item.require.Lamp'] ? 0 : 1;
         if ($custom_data['rom.freeItemMenu']) {
             $custom_data['rom.freeItemMenu'] = 0x00
@@ -146,7 +149,6 @@ class CustomizerController extends Controller
             'tournament' => $request->input('tournament', true),
             'spoilers' => $request->input('spoilers', false),
             'spoilers_ongen' => $request->input('spoilers_ongen', false),
-            'spoil.Hints' => $request->input('hints', 'on'),
             'logic' => $logic,
             'item.pool' => $request->input('item.pool', 'normal'),
             'item.functionality' => $request->input('item.functionality', 'normal'),

--- a/app/World.php
+++ b/app/World.php
@@ -106,8 +106,8 @@ abstract class World
         };
 
         // Handle configuration options that map to switches.
-        $free_item_text = 0x00;
-        $free_item_menu = 0x00;
+        $free_item_text = $this->config('rom.freeItemText', 0x00);
+        $free_item_menu = $this->config('rom.freeItemMenu', 0x00);
         switch ($this->config('dungeonItems')) {
             case 'full':
                 $this->config['region.wildBigKeys'] = true;

--- a/resources/js/store/modules/context.js
+++ b/resources/js/store/modules/context.js
@@ -26,8 +26,7 @@ export default {
       "rom.timerStart": "",
       "rom.rupeeBow": false,
       "rom.genericKeys": false,
-      "spoil.BootsLocation": false,
-      "spoil.Hints": true
+      "spoil.BootsLocation": false
     },
     initializing: true
   },

--- a/resources/js/views/Customizer.vue
+++ b/resources/js/views/Customizer.vue
@@ -483,6 +483,7 @@ export default {
                 tower: this.towerOpen.value
               },
               mode: this.worldState.value,
+              hints: this.hints.value,
               weapons: this.weapons.value,
               item: {
                 pool: this.itemPool.value,


### PR DESCRIPTION
Tested locally by saving and loading Customizer templates with and without these options, generating custom games with and without hints, and with and without dungeon item menu and item text boxes turned on. Also generated a few regular Randomizer seeds to test for regressions. All PHPUnit tests pass.

I kept this in two separate atomic commits, but I can squash them into one if you'd prefer.

The menu and text box fix was straightforward, but the hints bug was more complex, and I welcome feedback on my approach.

So, hints weren't working for a few reasons: 

- the hints value was not being sent in the POST request
- the hints dropdown is attached to a value called randomizer.hints, but there is a redundant value in vt.custom.settings called spoil.Hints that is not updated when the dropdown is changed
- this spoil.Hints value (set to true/1 instead of "on", thus making hints always disabled) was not being updated with the dropdown, and when the custom data array was flattened, then merged, this was overwriting the correct hints value passed in

My instinct was to remove the spoil.Hints value in vt.custom.settings rather than try to hook it up to the dropdown, since vt.custom.settings handles everything in the settings tab, while the randomizer.js file/namespace handles the main options page with the hints dropdown. However, vuex keeps the stale value around, and continued to pass it in the POST. So I added a line to overwrite spoil.Hints with the correct value before merging the array.

Is there a better way to deprecate spoil.Hints in vt.custom.settings? And do you agree with removing that variable? (The randomizer.hints variable is successfully saved and loaded, and works fine after I added it to the customizer POST.)