### PR TITLE
Add a chance of a daily games being a mystery

### DIFF
--- a/app/Http/Controllers/CustomizerController.php
+++ b/app/Http/Controllers/CustomizerController.php
@@ -46,6 +46,8 @@ class CustomizerController extends Controller
                     case "mystery":
                         $return_payload['spoiler'] = array_only($return_payload['spoiler'], ['meta']);
                         $return_payload['spoiler']['meta'] = array_only($return_payload['spoiler']['meta'], [
+                            'name',
+                            'notes',
                             'logic',
                             'build',
                             'tournament',

--- a/app/Http/Controllers/RandomizerController.php
+++ b/app/Http/Controllers/RandomizerController.php
@@ -42,6 +42,8 @@ class RandomizerController extends Controller
                     case "mystery":
                         $return_payload['spoiler'] = array_only($return_payload['spoiler'], ['meta']);
                         $return_payload['spoiler']['meta'] = array_only($return_payload['spoiler']['meta'], [
+                            'name',
+                            'notes',
                             'logic',
                             'build',
                             'tournament',

--- a/config/alttp.php
+++ b/config/alttp.php
@@ -264,6 +264,12 @@ return [
                 'hard' => 'Hard',
                 'expert' => 'Expert',
             ],
+            'spoilers' => [
+                'on' => 'On',
+                'off' => 'Off',
+                'generate' => 'Generate',
+                'mystery' => 'Mystery',
+            ],
         ],
         'daily_weights' => [
             'glitches_required' => [
@@ -372,6 +378,12 @@ return [
                 'hard' => 5,
                 'expert' => 1,
             ],
+            'spoilers' => [
+                'on' => 0,
+                'off' => 95,
+                'generate' => 0,
+                'mystery' => 5
+            ]
         ],
     ],
 ];

--- a/resources/js/components/VTRomInfo.vue
+++ b/resources/js/components/VTRomInfo.vue
@@ -4,6 +4,7 @@
       v-if="rom.spoiler.meta.spoilers_ongen==true || rom.spoilers=='generate'"
       class="spoiler-warning"
     >{{ $t('rom.info.spoilerwarning') }}</div>
+    <div v-if="rom.spoilers=='mystery'" class="mystery" >{{ $t('rom.info.mystery') }}</div>
     <div v-if="rom.logic">{{ $t('rom.info.logic') }}: {{ rom.logic }}</div>
     <div v-if="rom.build">{{ $t('rom.info.build') }}: {{ rom.build }}</div>
     <div v-if="rom.difficulty">
@@ -60,6 +61,9 @@ export default {
 <style scoped>
 .spoiler-warning {
   color: red;
+  font-weight: bold;
+}
+.mystery {
   font-weight: bold;
 }
 </style>

--- a/resources/js/vue-i18n-locales.generated.js
+++ b/resources/js/vue-i18n-locales.generated.js
@@ -634,6 +634,7 @@ export default {
             },
             "info": {
                 "spoilerwarning": "WARNUNG: Der Ersteller dieses Spiel hat den Spoiler Log angesehen.",
+                "mystery": "Dies ist ein geheimnissvolles Spiel. Die Einstellungen sind unbekannt und müssen beim Spielen herausgefunden werden!",
                 "logic": "Vorausgesetzte Glitches",
                 "accessibility": "Zugänglichkeit",
                 "build": "ROM build",
@@ -1339,6 +1340,7 @@ export default {
             },
             "info": {
                 "spoilerwarning": "WARNING: The generator of this game viewed the spoiler log.",
+                "mystery": "This is a mystery game.  The settings must be discovered while you play!",
                 "logic": "Glitches Required",
                 "accessibility": "Accessibility",
                 "build": "ROM build",
@@ -2265,6 +2267,7 @@ export default {
             },
             "info": {
                 "spoilerwarning": "ADVERTENCIA: El generador de este juego ha visto el registro de spoiler.",
+                "mystery": "Este es un juego de misterios. Debes descubrir las configuraciones mientras lo juegas!",
                 "logic": "Glitches Requeridos",
                 "accessibility": "Accesibilidad",
                 "build": "Build de la ROM",
@@ -2946,6 +2949,7 @@ export default {
             },
             "info": {
                 "spoilerwarning": "AVERTISSEMENT : La personne qui a généré cette partie a regardé le spoiler log.",
+                "mystery": "Ceci est une partie mystère. Les paramètres seront à découvrir pendant que vous jouez!",
                 "logic": "Glitchs requis",
                 "accessibility": "Accessibilité",
                 "build": "Création de ROM",

--- a/resources/lang/de/rom.php
+++ b/resources/lang/de/rom.php
@@ -12,6 +12,7 @@ return [
     ],
     'info' => [
         'spoilerwarning' => 'WARNUNG: Der Ersteller dieses Spiel hat den Spoiler Log angesehen.',
+        'mystery' => 'Dies ist ein geheimnissvolles Spiel. Die Einstellungen sind unbekannt und müssen beim Spielen herausgefunden werden!',
         'logic' => __('randomizer.glitches_required.title'),
         'accessibility' => __('randomizer.accessibility.title'),
         'build' => 'ROM build',

--- a/resources/lang/en/rom.php
+++ b/resources/lang/en/rom.php
@@ -12,6 +12,7 @@ return [
     ],
     'info' => [
         'spoilerwarning' => 'WARNING: The generator of this game viewed the spoiler log.',
+        'mystery' => 'This is a mystery game.  The settings must be discovered while you play!',
         'logic' => __('randomizer.glitches_required.title'),
         'accessibility' => __('randomizer.accessibility.title'),
         'build' => 'ROM build',

--- a/resources/lang/es/rom.php
+++ b/resources/lang/es/rom.php
@@ -12,6 +12,7 @@ return [
     ],
     'info' => [
         'spoilerwarning' => 'ADVERTENCIA: El generador de este juego ha visto el registro de spoiler.',
+        'mystery' => 'Este es un juego de misterios. Debes descubrir las configuraciones mientras lo juegas!',
         'logic' => __('randomizer.glitches_required.title'),
         'accessibility' => __('randomizer.accessibility.title'),
         'build' => 'Build de la ROM',

--- a/resources/lang/fr/rom.php
+++ b/resources/lang/fr/rom.php
@@ -12,6 +12,7 @@ return [
     ],
     'info' => [
         'spoilerwarning' => 'AVERTISSEMENT : La personne qui a généré cette partie a regardé le spoiler log.',
+        'mystery' => 'Ceci est une partie mystère. Les paramètres seront à découvrir pendant que vous jouez!',
         'logic' => __('randomizer.glitches_required.title'),
         'accessibility' => __('randomizer.accessibility.title'),
         'build' => 'Création de ROM',

--- a/routes/console.php
+++ b/routes/console.php
@@ -41,8 +41,6 @@ Artisan::command('alttp:dailies {days=7}', function ($days) {
                 'no_logic' => 'None',
             ][getWeighted('glitches_required')];
 
-            $spoilers = getWeighted('spoilers');
-
             $world = World::factory(getWeighted('world_state'), [
                 'itemPlacement' => getWeighted('item_placement'),
                 'dungeonItems' => getWeighted('dungeon_items'),
@@ -54,7 +52,7 @@ Artisan::command('alttp:dailies {days=7}', function ($days) {
                 'mode.weapons' => getWeighted('weapons'),
                 'tournament' => true,
                 'spoil.Hints' => getWeighted('hints'),
-                'spoilers' => $spoilers,
+                'spoilers' => getWeighted('spoilers'),
                 'logic' => $logic,
                 'item.pool' => getWeighted('item_pool'),
                 'item.functionality' => getWeighted('item_functionality'),

--- a/routes/console.php
+++ b/routes/console.php
@@ -41,6 +41,8 @@ Artisan::command('alttp:dailies {days=7}', function ($days) {
                 'no_logic' => 'None',
             ][getWeighted('glitches_required')];
 
+            $spoilers = getWeighted('spoilers');
+
             $world = World::factory(getWeighted('world_state'), [
                 'itemPlacement' => getWeighted('item_placement'),
                 'dungeonItems' => getWeighted('dungeon_items'),
@@ -52,6 +54,7 @@ Artisan::command('alttp:dailies {days=7}', function ($days) {
                 'mode.weapons' => getWeighted('weapons'),
                 'tournament' => true,
                 'spoil.Hints' => getWeighted('hints'),
+                'spoilers' => $spoilers,
                 'logic' => $logic,
                 'item.pool' => getWeighted('item_pool'),
                 'item.functionality' => getWeighted('item_functionality'),
@@ -88,8 +91,33 @@ Artisan::command('alttp:dailies {days=7}', function ($days) {
                 'entry_crystals_ganon' => $entry_crystals_ganon,
                 'entry_crystals_tower' => $entry_crystals_tower,
                 'worlds' => 1,
-                'spoilers' => "off",
             ]);
+
+            switch ($spoiler['meta']['spoilers']) {
+                case "on":
+                case "generate":
+                    $spoiler = array_except($spoiler, [
+                        'spoiler.playthrough',
+                    ]);
+                    break;
+                case "mystery":
+                    $spoiler = array_only($spoiler, ['meta']);
+                    $spoiler['meta'] = array_only($spoiler['meta'], [
+                        'name',
+                        'notes',
+                        'logic',
+                        'build',
+                        'tournament',
+                        'spoilers',
+                        'size'
+                    ]);
+                    break;
+                case "off":
+                default:
+                    $spoiler = array_except(array_only($spoiler, [
+                        'meta',
+                    ]), ['meta.seed']);    
+            }
 
             if ($world->isEnemized()) {
                 $en = new Enemizer($world, $patch);


### PR DESCRIPTION
Adds a 5% chance that a daily challenge will be a mystery.  The game is rolled using the same weights as other dailies.

Do not filter out name and notes in the spoiler meta.

Add a message to VTRomInfo.vue informing the player that it is a mystery game.  Message is translated in FR, DE, and ES.

This is setup in a way where we could eventually have spoiler dailies, however it is not turned on at this time.  Generate is also weighted at 0 because it won't work at this time and instead just behave like spoilers were on.