### PR TITLE
Add check for Randomized Enemy Health

### DIFF
--- a/app/Region/Inverted/DesertPalace.php
+++ b/app/Region/Inverted/DesertPalace.php
@@ -47,7 +47,7 @@ class DesertPalace extends Region\Standard\DesertPalace
 
 
         $this->locations["Desert Palace - Big Key Chest"]->setRequirements(function ($locations, $items) {
-            return $items->has('KeyP2')
+            return $items->has('KeyP2') && $items->canKillMostThings($this->world)
                 && ($items->has('MoonPearl')
                     || $this->world->config('canDungeonRevive')
                     || ($this->world->config('canBunnyRevive', false)

--- a/app/Region/Inverted/LightWorld/South.php
+++ b/app/Region/Inverted/LightWorld/South.php
@@ -106,7 +106,7 @@ class South extends Region\Standard\LightWorld\South
                 || ($this->world->config('canBunnyRevive', false)
                     && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle())) &&
-                $items->canBombThings();
+                $items->canBombThings() && $items->canKillMostThings($this->world);
         });
 
         $this->locations["Mini Moldorm Cave - Left"]->setRequirements(function ($locations, $items) {
@@ -114,7 +114,7 @@ class South extends Region\Standard\LightWorld\South
                 || ($this->world->config('canBunnyRevive', false)
                     && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle())) &&
-                $items->canBombThings();
+                $items->canBombThings() && $items->canKillMostThings($this->world);
         });
 
         $this->locations["Mini Moldorm Cave - Right"]->setRequirements(function ($locations, $items) {
@@ -122,7 +122,7 @@ class South extends Region\Standard\LightWorld\South
                 || ($this->world->config('canBunnyRevive', false)
                     && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle())) &&
-                $items->canBombThings();
+                $items->canBombThings() && $items->canKillMostThings($this->world);
         });
 
         $this->locations["Mini Moldorm Cave - Far Right"]->setRequirements(function ($locations, $items) {
@@ -130,7 +130,7 @@ class South extends Region\Standard\LightWorld\South
                 || ($this->world->config('canBunnyRevive', false)
                     && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle())) &&
-                $items->canBombThings();
+                $items->canBombThings() && $items->canKillMostThings($this->world);
         });
 
         $this->locations["Ice Rod Cave"]->setRequirements(function ($locations, $items) {
@@ -181,7 +181,7 @@ class South extends Region\Standard\LightWorld\South
                 || ($this->world->config('canBunnyRevive', false)
                     && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle())) &&
-                $items->canBombThings();
+                $items->canBombThings() && $items->canKillMostThings($this->world);
         });
 
         $this->locations["Library"]->setRequirements(function ($locations, $items) {

--- a/app/Region/Open/HyruleCastleEscape.php
+++ b/app/Region/Open/HyruleCastleEscape.php
@@ -22,15 +22,18 @@ class HyruleCastleEscape extends Region\Standard\HyruleCastleEscape
     public function initalize()
     {
         $this->locations["Sewers - Secret Room - Left"]->setRequirements(function ($locations, $items) {
-            return $items->canLiftRocks() || ($items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && $items->has('KeyH2'));
+            return $items->canLiftRocks() || ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
+                && $items->has('KeyH2') && $items->canKillMostThings($this->world));
         });
 
         $this->locations["Sewers - Secret Room - Middle"]->setRequirements(function ($locations, $items) {
-            return $items->canLiftRocks() || ($items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && $items->has('KeyH2'));
+            return $items->canLiftRocks() || ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
+                && $items->has('KeyH2') && $items->canKillMostThings($this->world));
         });
 
         $this->locations["Sewers - Secret Room - Right"]->setRequirements(function ($locations, $items) {
-            return $items->canLiftRocks() || ($items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && $items->has('KeyH2'));
+            return $items->canLiftRocks() || ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
+                && $items->has('KeyH2') && $items->canKillMostThings($this->world));
         });
 
         $this->locations["Sewers - Dark Cross"]->setRequirements(function ($locations, $items) {
@@ -39,11 +42,11 @@ class HyruleCastleEscape extends Region\Standard\HyruleCastleEscape
         });
 
         $this->locations["Hyrule Castle - Boomerang Chest"]->setRequirements(function ($locations, $items) {
-            return $items->has('KeyH2');
+            return $items->has('KeyH2') && $items->canKillMostThings($this->world);
         });
 
         $this->locations["Hyrule Castle - Zelda's Cell"]->setRequirements(function ($locations, $items) {
-            return $items->has('KeyH2');
+            return $items->has('KeyH2') && $items->canKillMostThings($this->world);
         });
 
         $this->locations["Secret Passage"]->setFillRules(function ($item, $locations, $items) {

--- a/app/Region/Standard/DesertPalace.php
+++ b/app/Region/Standard/DesertPalace.php
@@ -76,7 +76,7 @@ class DesertPalace extends Region
         });
 
         $this->locations["Desert Palace - Big Key Chest"]->setRequirements(function ($locations, $items) {
-            return $items->has('KeyP2');
+            return $items->has('KeyP2') && $items->canKillMostThings($this->world);
         });
 
         $this->locations["Desert Palace - Compass Chest"]->setRequirements(function ($locations, $items) {

--- a/app/Region/Standard/LightWorld/South.php
+++ b/app/Region/Standard/LightWorld/South.php
@@ -107,6 +107,26 @@ class South extends Region
         $this->locations["Aginah's Cave"]->setRequirements(function ($locations, $items) {
             return $items->canBombThings();
         });
+        
+        $this->locations["Mini Moldorm Cave - Far Left"]->setRequirements(function ($locations, $items) {
+            return $items->canBombThings() && $items->canKillMostThings($this->world);
+        });
+        
+        $this->locations["Mini Moldorm Cave - Left"]->setRequirements(function ($locations, $items) {
+            return $items->canBombThings() && $items->canKillMostThings($this->world);
+        });
+
+        $this->locations["Mini Moldorm Cave - Right"]->setRequirements(function ($locations, $items) {
+            return $items->canBombThings() && $items->canKillMostThings($this->world);
+        });
+
+        $this->locations["Mini Moldorm Cave - Far Right"]->setRequirements(function ($locations, $items) {
+            return $items->canBombThings() && $items->canKillMostThings($this->world);
+        });
+
+        $this->locations["Mini Moldorm Cave - NPC"]->setRequirements(function ($locations, $items) {
+            return $items->canBombThings() && $items->canKillMostThings($this->world);
+        });
 
         $this->locations["Hobo"]->setRequirements(function ($locations, $items) {
             return ($this->world->config('canWaterWalk', false) && $items->has('PegasusBoots'))

--- a/app/Support/ItemCollection.php
+++ b/app/Support/ItemCollection.php
@@ -536,8 +536,10 @@ class ItemCollection extends Collection
     {
         return $this->has('UncleSword')
             || $this->has('CaneOfSomaria')
-            || $this->has('TenBombs')
-            || $this->has('CaneOfByrna')
+            || ($this->has('TenBombs')
+                && $world->config('enemizer.enemyHealth', 'default') == 'default')
+            || ($this->has('CaneOfByrna')
+                && $world->config('enemizer.enemyHealth', 'default') == 'default')
             || $this->canShootArrows($world)
             || $this->has('Hammer')
             || $this->has('FireRod');
@@ -555,8 +557,10 @@ class ItemCollection extends Collection
     {
         return $this->hasSword()
             || $this->has('CaneOfSomaria')
-            || ($this->has('TenBombs') && $enemies < 6)
-            || ($this->has('CaneOfByrna') && ($enemies < 6 || $this->canExtendMagic()))
+            || ($this->canBombThings() && $enemies < 6
+                && $world->config('enemizer.enemyHealth', 'default') == 'default')
+            || ($this->has('CaneOfByrna') && ($enemies < 6 || $this->canExtendMagic())
+                && $world->config('enemizer.enemyHealth', 'default') == 'default')
             || $this->canShootArrows($world)
             || $this->has('Hammer')
             || $this->has('FireRod');


### PR DESCRIPTION
There was a Daily Recently which forced progression behind high Health Mini Moldorms in Mini Moldorm Cave before Weapons were available (or Flippers for the Upgrade Fairy).

This prevents the issue from reappearing by forcing a weapon that can kill anything before those locations that require you to kill enemies, if Enemy Health is randomized. (not caring if the enemies are set to 1 heart or 8)