### PR TITLE
Retro Key Logic

### DIFF
--- a/app/Support/ItemCollection.php
+++ b/app/Support/ItemCollection.php
@@ -267,7 +267,7 @@ class ItemCollection extends Collection
         // @TODO: this check is expensive, as this function is called A LOT, can we reduce it somehow?
         // assuming if there are ShopKey's available then we are in generic key mode, this is a really bad assumption
         // but we need to make it until we can rewrite this class
-        if (($this->item_counts['ShopKey'] ?? false) && strpos($key, 'Key') === 0) {
+        if (($this->item_counts["ShopKey:$this->checks_for_world"] ?? false) && strpos($key, 'Key') === 0) {
             return true;
         }
 

--- a/app/World/Retro.php
+++ b/app/World/Retro.php
@@ -21,5 +21,24 @@ class Retro extends Open
             'region.takeAnys' => true,
             'region.wildKeys' => true,
         ]));
+        
+        if ($this->config('difficulty') !== 'custom') {
+            switch ($this->config('item.pool')) {
+            case 'hard':
+            case 'expert':
+            case 'crowd_control':
+                $this->config['item.count.KeyD1'] = 0;
+                $this->config['item.count.KeyA2'] = 0;
+                $this->config['item.count.KeyD7'] = 0;
+                $this->config['item.count.KeyD2'] = 0;
+
+                $this->config['item.count.TwentyRupees2'] = 15 + $this->config('item.count.TwentyRupees2', 0);
+                break;
+            case 'normal':
+                $this->config['item.count.KeyD1'] = 0;
+                $this->config['item.count.KeyA2'] = 0;
+                $this->config['item.count.TwentyRupees2'] = 10 + $this->config('item.count.TwentyRupees2', 0);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes issue #769 where retro mode required all keys.
Remove 10 keys from normal retro, and 15 from hard/expert/crowd item pools.