### PR TITLE
Bug fixes

### DIFF
--- a/app/Boss.php
+++ b/app/Boss.php
@@ -85,7 +85,8 @@ class Boss
             }),
             new static("Helmasaur King", "Helmasaur", function ($locations, $items) use ($world) {
                 return ($items->canBombThings() || $items->has('Hammer'))
-                    && ($items->hasSword(2) || $items->canShootArrows($world));
+                    && ($items->hasSword(2) || $items->canShootArrows($world)
+                        || ($world->config('itemPlacement') !== 'basic' && $items->hasSword()));
             }),
             new static("Arrghus", "Arrghus", function ($locations, $items) use ($world) {
                 return ($world->config('itemPlacement') !== 'basic' || $world->config('mode.weapons') === 'swordless' || $items->hasSword(2))

--- a/app/Http/Controllers/CustomizerController.php
+++ b/app/Http/Controllers/CustomizerController.php
@@ -157,6 +157,13 @@ class CustomizerController extends Controller
                 | ($custom_data['region.wildBigKeys'] << 1)
                 | $custom_data['region.wildKeys'];
         }
+        if ($custom_data['rom.freeItemText']) {
+            $custom_data['rom.freeItemText'] = 0x10
+                | ($custom_data['region.wildBigKeys'] << 3)
+                | ($custom_data['region.wildMaps'] << 2)
+                | ($custom_data['region.wildCompasses'] << 1)
+                | $custom_data['region.wildKeys'];
+        }
 
         $world = World::factory($request->input('mode', 'standard'), array_merge([
             'difficulty' => 'custom',

--- a/app/Http/Controllers/CustomizerController.php
+++ b/app/Http/Controllers/CustomizerController.php
@@ -152,8 +152,8 @@ class CustomizerController extends Controller
         $custom_data['item.require.Lamp'] = $custom_data['item.require.Lamp'] ? 0 : 1;
         if ($custom_data['rom.freeItemMenu']) {
             $custom_data['rom.freeItemMenu'] = 0x00
-                | ($custom_data['region.wildMaps'] << 3)
-                | ($custom_data['region.wildCompasses'] << 2)
+                | ($custom_data['region.wildCompasses'] << 3)
+                | ($custom_data['region.wildMaps'] << 2)
                 | ($custom_data['region.wildBigKeys'] << 1)
                 | $custom_data['region.wildKeys'];
         }

--- a/app/Location.php
+++ b/app/Location.php
@@ -240,15 +240,22 @@ class Location
 
         $item = $this->item;
 
-        if (
-            $item instanceof Item\Key && $this->region->isRegionItem($item)
-            && (!in_array($this->name, ["Secret Passage", "Link's Uncle"]) || $item != Item::get('KeyH2', $this->region->getWorld()))
-        ) { // special key-sanity case
+        if ($item instanceof Item\Key && $this->region->isRegionItem($item)
+            && (!in_array($this->name, ["Secret Passage", "Link's Uncle"]) || $item != Item::get('KeyH2', $this->region->getWorld()))) { // special key-sanity case
             $item = Item::get('Key', $this->region->getWorld());
         }
 
         if ($item instanceof Item\BigKey && $this->region->isRegionItem($item)) {
             $item = Item::get('BigKey', $this->region->getWorld());
+        }
+
+        if ($item instanceof Item\Map && $this->region->isRegionItem($item)
+            && (!in_array($this->name, ["Secret Passage", "Link's Uncle"]) || $item != Item::get('MapH2', $this->region->getWorld()))) { // special key-sanity case
+            $item = Item::get('Map', $this->region->getWorld());
+        }
+
+        if ($item instanceof Item\Compass && $this->region->isRegionItem($item)) {
+            $item = Item::get('Compass', $this->region->getWorld());
         }
 
         if ($this->region->getWorld()->config('rom.genericKeys', false) && $item instanceof Item\Key) {

--- a/app/Randomizer.php
+++ b/app/Randomizer.php
@@ -370,7 +370,7 @@ class Randomizer implements RandomizerContract
         ];
 
         if ($world->config('mode.weapons') == 'swordless') {
-            array_splice($boss_locations, 8, 1); // remove Ice Palace
+            array_splice($boss_locations, 9, 1); // remove Ice Palace
             $world->getRegion('Ice Palace')->setBoss(Boss::get("Kholdstare", $world));
         }
 

--- a/tests/InvertedOverworldGlitches/EasternPalaceTest.php
+++ b/tests/InvertedOverworldGlitches/EasternPalaceTest.php
@@ -92,9 +92,9 @@ class EasternPalaceTest extends TestCase
             ["Eastern Palace - Compass Chest", true, ['DefeatAgahnim']],
 
             ["Eastern Palace - Cannonball Chest", false, []],
-            ["Eastern Palace - Compass Chest", true, ['MoonPearl', 'PegasusBoots']],
-            ["Eastern Palace - Compass Chest", true, ['MagicMirror', 'PegasusBoots']],
-            ["Eastern Palace - Compass Chest", true, ['DefeatAgahnim']],
+            ["Eastern Palace - Cannonball Chest", true, ['MoonPearl', 'PegasusBoots']],
+            ["Eastern Palace - Cannonball Chest", true, ['MagicMirror', 'PegasusBoots']],
+            ["Eastern Palace - Cannonball Chest", true, ['DefeatAgahnim']],
 
             ["Eastern Palace - Big Chest", false, []],
             ["Eastern Palace - Big Chest", false, [], ['BigKeyP1']],
@@ -103,9 +103,9 @@ class EasternPalaceTest extends TestCase
             ["Eastern Palace - Big Chest", true, ['BigKeyP1', 'DefeatAgahnim']],
 
             ["Eastern Palace - Map Chest", false, []],
-            ["Eastern Palace - Compass Chest", true, ['MoonPearl', 'PegasusBoots']],
-            ["Eastern Palace - Compass Chest", true, ['MagicMirror', 'PegasusBoots']],
-            ["Eastern Palace - Compass Chest", true, ['DefeatAgahnim']],
+            ["Eastern Palace - Map Chest", true, ['MoonPearl', 'PegasusBoots']],
+            ["Eastern Palace - Map Chest", true, ['MagicMirror', 'PegasusBoots']],
+            ["Eastern Palace - Map Chest", true, ['DefeatAgahnim']],
 
             ["Eastern Palace - Big Key Chest", false, []],
             ["Eastern Palace - Big Key Chest", false, [], ['Lamp']],

--- a/tests/RandomizerTest.php
+++ b/tests/RandomizerTest.php
@@ -162,4 +162,184 @@ class RandomizerTest extends TestCase
             $this->world->getLocation("Master Sword Pedestal")->getItem(),
         ]);
     }
+    
+    public function testSimpleBossShuffle()
+    {
+        $this->world = World::factory('standard', ['difficulty' => 'test_rules', 'enemizer.bossShuffle' => 'simple']);
+        $this->randomizer = new Randomizer([$this->world]);
+        
+        $this->randomizer->placeBosses($this->world);
+        
+        $bosses = array_count_values ([ 
+                    $this->world->getRegion('Eastern Palace')->getBoss('')->getEName(),
+                    $this->world->getRegion('Desert Palace')->getBoss('')->getEName(),
+                    $this->world->getRegion('Tower of Hera')->getBoss('')->getEName(),
+                    $this->world->getRegion('Palace of Darkness')->getBoss('')->getEName(),
+                    $this->world->getRegion('Swamp Palace')->getBoss('')->getEName(),
+                    $this->world->getRegion('Skull Woods')->getBoss('')->getEName(),
+                    $this->world->getRegion('Thieves Town')->getBoss('')->getEName(),
+                    $this->world->getRegion('Ice Palace')->getBoss('')->getEName(),
+                    $this->world->getRegion('Misery Mire')->getBoss('')->getEName(),
+                    $this->world->getRegion('Turtle Rock')->getBoss('')->getEName(),
+                    $this->world->getRegion('Ganons Tower')->getBoss('bottom')->getEName(),
+                    $this->world->getRegion('Ganons Tower')->getBoss('middle')->getEName(),
+                    $this->world->getRegion('Ganons Tower')->getBoss('top')->getEName()]);
+        
+        $this->assertEquals([2, 2, 2, 1, 1, 1, 1, 1, 1, 1],
+        [
+            $bosses['Armos'],
+            $bosses['Lanmola'],
+            $bosses['Moldorm'],
+            $bosses['Helmasaur'],
+            $bosses['Arrghus'],
+            $bosses['Mothula'],
+            $bosses['Blind'],
+            $bosses['Kholdstare'],
+            $bosses['Vitreous'],
+            $bosses['Trinexx']
+        ]);
+    }
+    
+    public function testFullBossShuffle()
+    {
+        $this->world = World::factory('standard', ['difficulty' => 'test_rules', 'enemizer.bossShuffle' => 'full']);
+        $this->randomizer = new Randomizer([$this->world]);
+        
+        $this->randomizer->placeBosses($this->world);
+        
+        $bosses = array_count_values ([ 
+                    $this->world->getRegion('Eastern Palace')->getBoss('')->getEName(),
+                    $this->world->getRegion('Desert Palace')->getBoss('')->getEName(),
+                    $this->world->getRegion('Tower of Hera')->getBoss('')->getEName(),
+                    $this->world->getRegion('Palace of Darkness')->getBoss('')->getEName(),
+                    $this->world->getRegion('Swamp Palace')->getBoss('')->getEName(),
+                    $this->world->getRegion('Skull Woods')->getBoss('')->getEName(),
+                    $this->world->getRegion('Thieves Town')->getBoss('')->getEName(),
+                    $this->world->getRegion('Ice Palace')->getBoss('')->getEName(),
+                    $this->world->getRegion('Misery Mire')->getBoss('')->getEName(),
+                    $this->world->getRegion('Turtle Rock')->getBoss('')->getEName(),
+                    $this->world->getRegion('Ganons Tower')->getBoss('bottom')->getEName(),
+                    $this->world->getRegion('Ganons Tower')->getBoss('middle')->getEName(),
+                    $this->world->getRegion('Ganons Tower')->getBoss('top')->getEName()]);
+        
+        $this->assertGreaterThanOrEqual(1, $bosses['Armos']);
+        $this->assertGreaterThanOrEqual(1, $bosses['Lanmola']);
+        $this->assertGreaterThanOrEqual(1, $bosses['Moldorm']);
+        $this->assertGreaterThanOrEqual(1, $bosses['Helmasaur']);
+        $this->assertGreaterThanOrEqual(1, $bosses['Arrghus']);
+        $this->assertGreaterThanOrEqual(1, $bosses['Mothula']);
+        $this->assertGreaterThanOrEqual(1, $bosses['Blind']);
+        $this->assertGreaterThanOrEqual(1, $bosses['Kholdstare']);
+        $this->assertGreaterThanOrEqual(1, $bosses['Vitreous']);
+        $this->assertGreaterThanOrEqual(1, $bosses['Trinexx']);
+    }
+    
+    public function testNoBossShuffle()
+    {
+        $this->world = World::factory('standard', ['difficulty' => 'test_rules', 'enemizer.bossShuffle' => 'none']);
+        $this->randomizer = new Randomizer([$this->world]);
+        
+        $this->randomizer->placeBosses($this->world);
+        
+        $this->assertEquals([ 
+            'Armos', 
+            'Lanmola', 
+            'Moldorm', 
+            'Helmasaur', 
+            'Arrghus', 
+            'Mothula', 
+            'Blind', 
+            'Kholdstare', 
+            'Vitreous', 
+            'Trinexx', 
+            'Armos', 
+            'Lanmola', 
+            'Moldorm'
+          ], [ 
+            $this->world->getRegion('Eastern Palace')->getBoss('')->getEName(),
+            $this->world->getRegion('Desert Palace')->getBoss('')->getEName(),
+            $this->world->getRegion('Tower of Hera')->getBoss('')->getEName(),
+            $this->world->getRegion('Palace of Darkness')->getBoss('')->getEName(),
+            $this->world->getRegion('Swamp Palace')->getBoss('')->getEName(),
+            $this->world->getRegion('Skull Woods')->getBoss('')->getEName(),
+            $this->world->getRegion('Thieves Town')->getBoss('')->getEName(),
+            $this->world->getRegion('Ice Palace')->getBoss('')->getEName(),
+            $this->world->getRegion('Misery Mire')->getBoss('')->getEName(),
+            $this->world->getRegion('Turtle Rock')->getBoss('')->getEName(),
+            $this->world->getRegion('Ganons Tower')->getBoss('bottom')->getEName(),
+            $this->world->getRegion('Ganons Tower')->getBoss('middle')->getEName(),
+            $this->world->getRegion('Ganons Tower')->getBoss('top')->getEName()
+          ]);
+    }
+    
+    public function testSwordlessSimpleBossShuffle()
+    {
+        $this->world = World::factory('standard', ['difficulty' => 'test_rules', 'enemizer.bossShuffle' => 'simple', 'mode.weapons' => 'swordless']);
+        $this->randomizer = new Randomizer([$this->world]);
+        
+        $this->randomizer->placeBosses($this->world);
+        
+        $bosses = array_count_values ([ 
+                    $this->world->getRegion('Eastern Palace')->getBoss('')->getEName(),
+                    $this->world->getRegion('Desert Palace')->getBoss('')->getEName(),
+                    $this->world->getRegion('Tower of Hera')->getBoss('')->getEName(),
+                    $this->world->getRegion('Palace of Darkness')->getBoss('')->getEName(),
+                    $this->world->getRegion('Swamp Palace')->getBoss('')->getEName(),
+                    $this->world->getRegion('Skull Woods')->getBoss('')->getEName(),
+                    $this->world->getRegion('Thieves Town')->getBoss('')->getEName(),
+                    $this->world->getRegion('Ice Palace')->getBoss('')->getEName(),
+                    $this->world->getRegion('Misery Mire')->getBoss('')->getEName(),
+                    $this->world->getRegion('Turtle Rock')->getBoss('')->getEName(),
+                    $this->world->getRegion('Ganons Tower')->getBoss('bottom')->getEName(),
+                    $this->world->getRegion('Ganons Tower')->getBoss('middle')->getEName(),
+                    $this->world->getRegion('Ganons Tower')->getBoss('top')->getEName()]);
+        
+        $this->assertEquals([2, 2, 2, 1, 1, 1, 1, 1, 1, 1],
+        [
+            $bosses['Armos'],
+            $bosses['Lanmola'],
+            $bosses['Moldorm'],
+            $bosses['Helmasaur'],
+            $bosses['Arrghus'],
+            $bosses['Mothula'],
+            $bosses['Blind'],
+            $bosses['Kholdstare'],
+            $bosses['Vitreous'],
+            $bosses['Trinexx']
+        ]);
+    }
+    
+    public function testSwordlessFullBossShuffle()
+    {
+        $this->world = World::factory('standard', ['difficulty' => 'test_rules', 'enemizer.bossShuffle' => 'full', 'mode.weapons' => 'swordless']);
+        $this->randomizer = new Randomizer([$this->world]);
+        
+        $this->randomizer->placeBosses($this->world);
+        
+        $bosses = array_count_values ([ 
+                    $this->world->getRegion('Eastern Palace')->getBoss('')->getEName(),
+                    $this->world->getRegion('Desert Palace')->getBoss('')->getEName(),
+                    $this->world->getRegion('Tower of Hera')->getBoss('')->getEName(),
+                    $this->world->getRegion('Palace of Darkness')->getBoss('')->getEName(),
+                    $this->world->getRegion('Swamp Palace')->getBoss('')->getEName(),
+                    $this->world->getRegion('Skull Woods')->getBoss('')->getEName(),
+                    $this->world->getRegion('Thieves Town')->getBoss('')->getEName(),
+                    $this->world->getRegion('Ice Palace')->getBoss('')->getEName(),
+                    $this->world->getRegion('Misery Mire')->getBoss('')->getEName(),
+                    $this->world->getRegion('Turtle Rock')->getBoss('')->getEName(),
+                    $this->world->getRegion('Ganons Tower')->getBoss('bottom')->getEName(),
+                    $this->world->getRegion('Ganons Tower')->getBoss('middle')->getEName(),
+                    $this->world->getRegion('Ganons Tower')->getBoss('top')->getEName()]);
+        
+        $this->assertGreaterThanOrEqual(1, $bosses['Armos']);
+        $this->assertGreaterThanOrEqual(1, $bosses['Lanmola']);
+        $this->assertGreaterThanOrEqual(1, $bosses['Moldorm']);
+        $this->assertGreaterThanOrEqual(1, $bosses['Helmasaur']);
+        $this->assertGreaterThanOrEqual(1, $bosses['Arrghus']);
+        $this->assertGreaterThanOrEqual(1, $bosses['Mothula']);
+        $this->assertGreaterThanOrEqual(1, $bosses['Blind']);
+        $this->assertGreaterThanOrEqual(1, $bosses['Kholdstare']);
+        $this->assertGreaterThanOrEqual(1, $bosses['Vitreous']);
+        $this->assertGreaterThanOrEqual(1, $bosses['Trinexx']);
+    }
 }

--- a/tests/RandomizerTest.php
+++ b/tests/RandomizerTest.php
@@ -294,6 +294,8 @@ class RandomizerTest extends TestCase
                     $this->world->getRegion('Ganons Tower')->getBoss('middle')->getEName(),
                     $this->world->getRegion('Ganons Tower')->getBoss('top')->getEName()]);
         
+        $this->assertEquals('Kholdstare', $this->world->getRegion('Ice Palace')->getBoss('')->getEName());
+        
         $this->assertEquals([2, 2, 2, 1, 1, 1, 1, 1, 1, 1],
         [
             $bosses['Armos'],
@@ -331,6 +333,8 @@ class RandomizerTest extends TestCase
                     $this->world->getRegion('Ganons Tower')->getBoss('middle')->getEName(),
                     $this->world->getRegion('Ganons Tower')->getBoss('top')->getEName()]);
         
+        $this->assertEquals('Kholdstare', $this->world->getRegion('Ice Palace')->getBoss('')->getEName());
+        
         $this->assertGreaterThanOrEqual(1, $bosses['Armos']);
         $this->assertGreaterThanOrEqual(1, $bosses['Lanmola']);
         $this->assertGreaterThanOrEqual(1, $bosses['Moldorm']);
@@ -338,7 +342,7 @@ class RandomizerTest extends TestCase
         $this->assertGreaterThanOrEqual(1, $bosses['Arrghus']);
         $this->assertGreaterThanOrEqual(1, $bosses['Mothula']);
         $this->assertGreaterThanOrEqual(1, $bosses['Blind']);
-        $this->assertGreaterThanOrEqual(1, $bosses['Kholdstare']);
+        $this->assertEquals(1, $bosses['Kholdstare']);
         $this->assertGreaterThanOrEqual(1, $bosses['Vitreous']);
         $this->assertGreaterThanOrEqual(1, $bosses['Trinexx']);
     }


### PR DESCRIPTION
Make customizer dungeon item text only apply to dungeon items that can be shuffled outside dungeons.
Fix customizer dungeon item menu swapping the toggles for Compass and Maps.
Replace Maps and Compasses with the generic version when they are in dungeons.

Added tests for Boss Shuffle, and fixed Kholdstare to always appear in Ice Palace in swordless mode.

Add logic for fighter's sword Helma.