### PR TITLE
Kholdstare Swordless Boss Shuffle Fix

### DIFF
--- a/app/Boss.php
+++ b/app/Boss.php
@@ -106,10 +106,11 @@ class Boss
             }),
             new static("Kholdstare", "Kholdstare", function ($locations, $items) use ($world) {
                 return ($world->config('itemPlacement') !== 'basic' || $items->hasSword(2) || ($items->canExtendMagic(3) && $items->has('FireRod'))
-                    || ($items->has('Bombos') && ($world->config('mode.weapons') === 'swordless' || $items->hasSword()) && $items->canExtendMagic(2) && $items->has('FireRod')))
-                    && $items->canMeltThings($world) && ($items->has('Hammer') || $items->hasSword()
+                    || ($items->has('Bombos') && (($world->config('mode.weapons') === 'swordless' && $world->config('enemizer.bossShuffle') == 'none') || $items->hasSword()) && $items->canExtendMagic(2) && $items->has('FireRod')))
+                    && ($this->has('FireRod') || ($this->has('Bombos') && (($world->config('mode.weapons') === 'swordless' && $world->config('enemizer.bossShuffle') == 'none') || $this->hasSword())))
+                    && ($items->has('Hammer') || $items->hasSword()
                         || ($items->canExtendMagic(3) && $items->has('FireRod'))
-                        || ($items->canExtendMagic(2) && $items->has('FireRod') && $items->has('Bombos') && $world->config('mode.weapons') === 'swordless'));
+                        || ($items->canExtendMagic(2) && $items->has('FireRod') && $items->has('Bombos') && ($world->config('mode.weapons') === 'swordless' && $world->config('enemizer.bossShuffle') == 'none')));
             }),
             new static("Vitreous", "Vitreous", function ($locations, $items) use ($world) {
                 return ($world->config('itemPlacement') !== 'basic' || $items->hasSword(2) || $items->canShootArrows($world))

--- a/app/Boss.php
+++ b/app/Boss.php
@@ -106,11 +106,11 @@ class Boss
             }),
             new static("Kholdstare", "Kholdstare", function ($locations, $items) use ($world) {
                 return ($world->config('itemPlacement') !== 'basic' || $items->hasSword(2) || ($items->canExtendMagic(3) && $items->has('FireRod'))
-                    || ($items->has('Bombos') && (($world->config('mode.weapons') === 'swordless' && $world->config('enemizer.bossShuffle') == 'none') || $items->hasSword()) && $items->canExtendMagic(2) && $items->has('FireRod')))
-                    && ($this->has('FireRod') || ($this->has('Bombos') && (($world->config('mode.weapons') === 'swordless' && $world->config('enemizer.bossShuffle') == 'none') || $this->hasSword())))
+                    || ($items->has('Bombos') && (($world->config('mode.weapons') === 'swordless' && $world->config('enemizer.bossShuffle') === 'none') || $items->hasSword()) && $items->canExtendMagic(2) && $items->has('FireRod')))
+                    && ($this->has('FireRod') || ($this->has('Bombos') && (($world->config('mode.weapons') === 'swordless' && $world->config('enemizer.bossShuffle') === 'none') || $this->hasSword())))
                     && ($items->has('Hammer') || $items->hasSword()
                         || ($items->canExtendMagic(3) && $items->has('FireRod'))
-                        || ($items->canExtendMagic(2) && $items->has('FireRod') && $items->has('Bombos') && ($world->config('mode.weapons') === 'swordless' && $world->config('enemizer.bossShuffle') == 'none')));
+                        || ($items->canExtendMagic(2) && $items->has('FireRod') && $items->has('Bombos') && ($world->config('mode.weapons') === 'swordless' && $world->config('enemizer.bossShuffle') === 'none')));
             }),
             new static("Vitreous", "Vitreous", function ($locations, $items) use ($world) {
                 return ($world->config('itemPlacement') !== 'basic' || $items->hasSword(2) || $items->canShootArrows($world))

--- a/app/Boss.php
+++ b/app/Boss.php
@@ -107,7 +107,7 @@ class Boss
             new static("Kholdstare", "Kholdstare", function ($locations, $items) use ($world) {
                 return ($world->config('itemPlacement') !== 'basic' || $items->hasSword(2) || ($items->canExtendMagic(3) && $items->has('FireRod'))
                     || ($items->has('Bombos') && (($world->config('mode.weapons') === 'swordless' && $world->config('enemizer.bossShuffle') === 'none') || $items->hasSword()) && $items->canExtendMagic(2) && $items->has('FireRod')))
-                    && ($this->has('FireRod') || ($this->has('Bombos') && (($world->config('mode.weapons') === 'swordless' && $world->config('enemizer.bossShuffle') === 'none') || $this->hasSword())))
+                    && ($items->has('FireRod') || ($items->has('Bombos') && (($world->config('mode.weapons') === 'swordless' && $world->config('enemizer.bossShuffle') === 'none') || $items->hasSword())))
                     && ($items->has('Hammer') || $items->hasSword()
                         || ($items->canExtendMagic(3) && $items->has('FireRod'))
                         || ($items->canExtendMagic(2) && $items->has('FireRod') && $items->has('Bombos') && ($world->config('mode.weapons') === 'swordless' && $world->config('enemizer.bossShuffle') === 'none')));

--- a/app/Randomizer.php
+++ b/app/Randomizer.php
@@ -369,15 +369,7 @@ class Randomizer implements RandomizerContract
             ['Ganons Tower', 'bottom'],
         ];
 
-        if ($world->config('mode.weapons') == 'swordless') {
-            array_splice($boss_locations, 8, 1); // remove Ice Palace
-            $world->getRegion('Ice Palace')->setBoss(Boss::get("Kholdstare", $world));
-        }
-
         $placeable_bosses = Boss::all($world)->filter(function ($boss) use ($world) {
-            if ($world->config('mode.weapons') == 'swordless' && $boss->getName() == "Kholdstare") {
-                return false;
-            }
             return !in_array($boss->getName(), [
                 "Agahnim",
                 "Agahnim2",

--- a/app/Region.php
+++ b/app/Region.php
@@ -97,13 +97,6 @@ class Region
      */
     public function canPlaceBoss(Boss $boss, string $level = 'top'): bool
     {
-        if (
-            $this->name != "Ice Palace" && $this->world->config('mode.weapons') == 'swordless'
-            && $boss->getName() == 'Kholdstare'
-        ) {
-            return false;
-        }
-
         return !in_array($boss->getName(), [
             "Agahnim",
             "Agahnim2",


### PR DESCRIPTION
This should allow kholdstare to be placed anywhere in Swordless Boss Shuffle, instead of making kholdstare only able to be placed at ice palace (and even then basically never), causing there to be no kholdstares in swordless boss shuffle in most cases.

Now, kholdstare will be able to be placed anywhere, because in swordless boss shuffle, kholdstare specifically will hard require fire rod, rather than getting restricted so strongly that it'll never spawn.

If there's a way to add the Bombos tiles in any boss room that kholdstare lands in, that would obviously be the preferred solution, but that sounds like a KatDevsGames situation and im but a mere fouton.