### PR TITLE
V31.0.5 - Fix quickswap when patch is retrieved via S3

### DIFF
--- a/resources/js/views/HashLoader.vue
+++ b/resources/js/views/HashLoader.vue
@@ -170,7 +170,7 @@ export default {
           .then(response => {
             this.rom.parsePatch(response.data).then(() => {
               console.log("loaded from s3 :)");
-              if (this.rom.shuffle || this.rom.spoilers == "mystery") {
+              if (this.rom.shuffle || this.rom.spoilers == "mystery" || this.rom.allow_quickswap) {
                 this.rom.allowQuickSwap = true;
               }
               this.gameLoaded = true;


### PR DESCRIPTION
I forgot to add `|| this.rom.allow_quickswap` to the logic condition for showing the Item Quickswap option when the game is loaded from s3.