### PR TITLE
Set proper Content-Type on saved ROM

### DIFF
--- a/resources/js/rom.js
+++ b/resources/js/rom.js
@@ -91,7 +91,7 @@ export default class ROM {
     this.setMusicVolume(musicOn);
 
     this.updateChecksum().then(() => {
-      FileSaver.saveAs(new Blob([this.u_array]), filename);
+      FileSaver.saveAs(new Blob([this.u_array], {type: 'application/octet-stream'}), filename);
 
       // undo any presave processing we did.
       this.arrayBuffer = preProcess;


### PR DESCRIPTION
This prevents the .txt extension from showing up on ROMs saved from mobile Chrome.