### PR TITLE
Add pot shuffle and API throttling whitelist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,9 @@ QUEUE_PREFIX=
 
 ENEMIZER_BASE=
 
+# Comma-separated list of values that bypass API throttling.
+API_THROTTLE_WHITELIST='127.0.0.1'
+
 REDIS_HOST=127.0.0.1
 REDIS_PASSWORD=null
 REDIS_PORT=6379

--- a/app/Console/Commands/Distribution.php
+++ b/app/Console/Commands/Distribution.php
@@ -77,6 +77,7 @@ class Distribution extends Command
             'enemizer.enemyShuffle' => 'none',
             'enemizer.enemyDamage' => 'default',
             'enemizer.enemyHealth' => 'default',
+            'enemizer.potShuffle' => 'off',
         ];
 
         $locations = [];

--- a/app/Console/Commands/Randomize.php
+++ b/app/Console/Commands/Randomize.php
@@ -166,6 +166,7 @@ class Randomize extends Command
                 'enemizer.enemyShuffle' => 'none',
                 'enemizer.enemyDamage' => 'default',
                 'enemizer.enemyHealth' => 'default',
+                'enemizer.potShuffle' => 'off',
             ]);
 
             $rand = new Randomizer([$world]);

--- a/app/Enemizer.php
+++ b/app/Enemizer.php
@@ -247,8 +247,6 @@ class Enemizer
             ]);
         }
 
-        Log::debug($options);
-
         file_put_contents($this->options_file, json_encode($options));
     }
 

--- a/app/Enemizer.php
+++ b/app/Enemizer.php
@@ -194,7 +194,7 @@ class Enemizer
             "GrayscaleMode" => false,
             "GenerateSpoilers" => false,
             "RandomizeLinkSpritePalette" => false,
-            "RandomizePots" => false,
+            "RandomizePots" => $this->world->config('enemizer.potShuffle') === 'on',
             "ShuffleMusic" => false,
             "BootlegMagic" => true,
             "CustomBosses" => false,
@@ -246,6 +246,8 @@ class Enemizer
                 ],
             ]);
         }
+
+        Log::debug($options);
 
         file_put_contents($this->options_file, json_encode($options));
     }

--- a/app/Http/Controllers/CustomizerController.php
+++ b/app/Http/Controllers/CustomizerController.php
@@ -188,6 +188,7 @@ class CustomizerController extends Controller
             'enemizer.enemyShuffle' => $request->input('enemizer.enemy_shuffle', 'none'),
             'enemizer.enemyDamage' => $request->input('enemizer.enemy_damage', 'default'),
             'enemizer.enemyHealth' => $request->input('enemizer.enemy_health', 'default'),
+            'enemizer.potShuffle' => $request->input('enemizer.pot_shuffle', 'off'),
             'ignoreCanKillEscapeThings' => array_key_exists(base64_encode("Link's Uncle:1"), $request->input('l')),
             'customPrizePacks' => true,
         ], $custom_data));

--- a/app/Http/Controllers/MultiworldController.php
+++ b/app/Http/Controllers/MultiworldController.php
@@ -80,6 +80,7 @@ class MultiworldController extends Controller
                 'enemizer.enemyShuffle' => 'none',
                 'enemizer.enemyDamage' => 'default',
                 'enemizer.enemyHealth' => 'default',
+                'enemizer.potShuffle' => 'off',
                 'multiworld' => true,
             ]);
         }

--- a/app/Http/Controllers/RandomizerController.php
+++ b/app/Http/Controllers/RandomizerController.php
@@ -143,6 +143,7 @@ class RandomizerController extends Controller
             'enemizer.enemyShuffle' => $request->input('enemizer.enemy_shuffle', 'none'),
             'enemizer.enemyDamage' => $request->input('enemizer.enemy_damage', 'default'),
             'enemizer.enemyHealth' => $request->input('enemizer.enemy_health', 'default'),
+            'enemizer.potShuffle' => $request->input('enemizer.pot_shuffle', 'off'),
         ]);
 
         $rom = new Rom(config('alttp.base_rom'));

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -29,7 +29,7 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-            'throttle:60,1',
+            'throttleIp:60,1',
             'bindings',
         ],
     ];
@@ -47,5 +47,6 @@ class Kernel extends HttpKernel
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \ALttP\Http\Middleware\RedirectIfAuthenticated::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'throttleIp' => \ALttP\Http\Middleware\ThrottleRequestsWithIp::class,
     ];
 }

--- a/app/Http/Middleware/ThrottleRequestsWithIp.php
+++ b/app/Http/Middleware/ThrottleRequestsWithIp.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace ALttP\Http\Middleware;
+
+use Closure;
+use Illuminate\Support\Facades\Log;
+
+class ThrottleRequestsWithIp extends \Illuminate\Routing\Middleware\ThrottleRequests
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next, $maxAttempts = 60, $decayMinutes = 1, $prefix = '')
+    {
+        if(in_array($request->ip(), config('alttp.api_throttle_whitelist'))) 
+            return $next($request);
+
+        return parent::handle($request, $next, $maxAttempts, $decayMinutes, $prefix);
+    }
+}

--- a/app/Http/Middleware/ThrottleRequestsWithIp.php
+++ b/app/Http/Middleware/ThrottleRequestsWithIp.php
@@ -16,8 +16,9 @@ class ThrottleRequestsWithIp extends \Illuminate\Routing\Middleware\ThrottleRequ
      */
     public function handle($request, Closure $next, $maxAttempts = 60, $decayMinutes = 1, $prefix = '')
     {
-        if(in_array($request->ip(), config('alttp.api_throttle_whitelist'))) 
+        if(in_array($request->ip(), config('alttp.api_throttle_whitelist'))) {
             return $next($request);
+        }
 
         return parent::handle($request, $next, $maxAttempts, $decayMinutes, $prefix);
     }

--- a/app/Http/Middleware/ThrottleRequestsWithIp.php
+++ b/app/Http/Middleware/ThrottleRequestsWithIp.php
@@ -3,7 +3,6 @@
 namespace ALttP\Http\Middleware;
 
 use Closure;
-use Illuminate\Support\Facades\Log;
 
 class ThrottleRequestsWithIp extends \Illuminate\Routing\Middleware\ThrottleRequests
 {

--- a/app/Http/Middleware/ThrottleRequestsWithIp.php
+++ b/app/Http/Middleware/ThrottleRequestsWithIp.php
@@ -15,7 +15,7 @@ class ThrottleRequestsWithIp extends \Illuminate\Routing\Middleware\ThrottleRequ
      */
     public function handle($request, Closure $next, $maxAttempts = 60, $decayMinutes = 1, $prefix = '')
     {
-        if(in_array($request->ip(), config('alttp.api_throttle_whitelist'))) {
+        if (in_array($request->ip(), config('alttp.api_throttle_whitelist'))) {
             return $next($request);
         }
 

--- a/app/Http/Requests/CreateRandomizedGame.php
+++ b/app/Http/Requests/CreateRandomizedGame.php
@@ -64,6 +64,9 @@ class CreateRandomizedGame extends FormRequest
             'enemizer.enemy_shuffle' => [
                 Rule::in($valid_settings['enemy_shuffle']),
             ],
+            'enemizer.pot_shuffle' => [
+                Rule::in($valid_settings['pot_shuffle']),
+            ],
             'hints' => [
                 Rule::in($valid_settings['hints']),
             ],

--- a/app/Rom.php
+++ b/app/Rom.php
@@ -12,7 +12,7 @@ use Log;
  */
 class Rom
 {
-    const BUILD = '2020-06-27';
+    const BUILD = '2020-08-03';
     const HASH = '11f68a2420b7ca44de97878582e6aa05';
     const SIZE = 2097152;
 

--- a/app/World.php
+++ b/app/World.php
@@ -892,6 +892,7 @@ abstract class World
             'enemizer.enemy_shuffle' => $this->config('enemizer.enemyShuffle'),
             'enemizer.enemy_damage' => $this->config('enemizer.enemyDamage'),
             'enemizer.enemy_health' => $this->config('enemizer.enemyHealth'),
+            'enemizer.pot_shuffle' => $this->config('enemizer.potShuffle'),
         ]);
 
         $this->spoiler['Bosses'] = [
@@ -1299,6 +1300,7 @@ abstract class World
         return $this->config('enemizer.bossShuffle') != 'none'
             || $this->config('enemizer.enemyShuffle') != 'none'
             || $this->config('enemizer.enemyDamage') != 'default'
-            || $this->config('enemizer.enemyHealth') != 'default';
+            || $this->config('enemizer.enemyHealth') != 'default'
+            || $this->config('enemizer.potShuffle') != 'off';
     }
 }

--- a/config/alttp.php
+++ b/config/alttp.php
@@ -233,6 +233,10 @@ return [
                 'shuffled' => 'Shuffled',
                 'random' => 'Random',
             ],
+            'pot_shuffle' => [
+                'on' => 'On',
+                'off' => 'Off',
+            ],
             'hints' => [
                 'on' => 'On',
                 'off' => 'Off',

--- a/config/alttp.php
+++ b/config/alttp.php
@@ -2,6 +2,7 @@
 
 return [
     'base_rom' => env('ENEMIZER_BASE', null),
+    'api_throttle_whitelist' => explode(',', env('API_THROTTLE_WHITELIST', '')),
     'custom' => [
         'prize' => [
             'crossWorld' => false,

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,15 +17,15 @@ Route::get('/user', function (Request $request) {
     return $request->user();
 })->middleware('auth:api');
 
-Route::post('randomizer', 'RandomizerController@generateSeed')->middleware('throttle:150,360');
+Route::post('randomizer', 'RandomizerController@generateSeed')->middleware('throttleIp:150,360');
 
-Route::post('multiworld', 'MultiworldController@generateSeed')->middleware('throttle:40,360');
+Route::post('multiworld', 'MultiworldController@generateSeed')->middleware('throttleIp:40,360');
 
-Route::post('randomizer/spoiler', 'RandomizerController@testGenerateSeed')->middleware('throttle:300,360');
+Route::post('randomizer/spoiler', 'RandomizerController@testGenerateSeed')->middleware('throttleIp:300,360');
 
-Route::post('customizer', 'CustomizerController@generateSeed')->middleware('throttle:50,360');
+Route::post('customizer', 'CustomizerController@generateSeed')->middleware('throttleIp:50,360');
 
-Route::post('customizer/test', 'CustomizerController@testGenerateSeed')->middleware('throttle:200,360');
+Route::post('customizer/test', 'CustomizerController@testGenerateSeed')->middleware('throttleIp:200,360');
 
 Route::get('daily', static function () {
     $featured = ALttP\FeaturedGame::today();

--- a/routes/console.php
+++ b/routes/console.php
@@ -67,6 +67,7 @@ Artisan::command('alttp:dailies {days=7}', function ($days) {
                 'enemizer.enemyShuffle' => getWeighted('enemy_shuffle'),
                 'enemizer.enemyDamage' => getWeighted('enemy_damage'),
                 'enemizer.enemyHealth' => getWeighted('enemy_health'),
+                'enemizer.potShuffle' => false,
             ]);
 
             $rom = new Rom(config('alttp.base_rom'));


### PR DESCRIPTION
This commit adds two features.

1) Adds pot shuffle as an API-only option in both the Randomizer and Customizer endpoints.
2) Adds a configuration option that lets us set a list of IP addresses to be whitelisted.  Whitelisted addresses bypass throttle limits.