### PR TITLE
Allow override of Start Screen Code

### DIFF
--- a/app/Http/Controllers/CustomizerController.php
+++ b/app/Http/Controllers/CustomizerController.php
@@ -181,6 +181,7 @@ class CustomizerController extends Controller
             'tournament' => $request->input('tournament', true),
             'spoilers' => $spoilers,
             'allow_quickswap' => $request->input('allow_quickswap', false),
+            'override_start_screen' => $request->input('override_start_screen', false),
             'logic' => $logic,
             'item.pool' => $request->input('item.pool', 'normal'),
             'item.functionality' => $request->input('item.functionality', 'normal'),

--- a/app/Http/Controllers/RandomizerController.php
+++ b/app/Http/Controllers/RandomizerController.php
@@ -135,6 +135,7 @@ class RandomizerController extends Controller
             'tournament' => $request->input('tournament', false),
             'spoilers' => $spoilers,
             'allow_quickswap' => $request->input('allow_quickswap', false),
+            'override_start_screen' => $request->input('override_start_screen', false),
             'spoil.Hints' => $request->input('hints', 'on'),
             'logic' => $logic,
             'item.pool' => $request->input('item.pool', 'normal'),

--- a/app/Http/Requests/CreateRandomizedGame.php
+++ b/app/Http/Requests/CreateRandomizedGame.php
@@ -4,6 +4,7 @@ namespace ALttP\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use ALttP\Rules\OverrideStartScreenRule;
 
 class CreateRandomizedGame extends FormRequest
 {
@@ -85,6 +86,9 @@ class CreateRandomizedGame extends FormRequest
             'enemizer.enemy_health' => [
                 Rule::in($valid_settings['enemy_health']),
             ],
+            'override_start_screen' => [
+                new OverrideStartScreenRule
+            ]
         ];
     }
 }

--- a/app/Rules/OverrideStartScreenRule.php
+++ b/app/Rules/OverrideStartScreenRule.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ALttP\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class OverrideStartScreenRule implements Rule
+{
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        if (is_array($value)) {
+            return count($value) === 5 && min($value) >= 0x00 && max($value) <= 0x1F;
+        } else if ($value === false) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'Value of :attribute must be a five integer array between 0 and 31!';
+    }
+}

--- a/app/Rules/OverrideStartScreenRule.php
+++ b/app/Rules/OverrideStartScreenRule.php
@@ -17,9 +17,8 @@ class OverrideStartScreenRule implements Rule
     {
         if (is_array($value)) {
             return count($value) === 5 && min($value) >= 0x00 && max($value) <= 0x1F;
-        } else if ($value === false) {
-            return true;
         }
+
         return false;
     }
 

--- a/app/World.php
+++ b/app/World.php
@@ -947,12 +947,6 @@ abstract class World
      */
     public function writeToRom(Rom $rom, bool $save = false): Rom
     {
-        if ($override_start_screen = $this->config('override_start_screen', false)) {
-            if (!(count($override_start_screen) === 5 && min($override_start_screen) >= 0x00 && max($override_start_screen) <= 0x1F)) {
-                throw new \Exception('Start screen array must be a 5 integer array between 0 and 31!');
-            }
-        }
-
         if ($this->override_patch !== null) {
             foreach ($this->override_patch as $writes) {
                 foreach ($writes as $address => $bytes) {
@@ -965,7 +959,7 @@ abstract class World
 
                 $rom->setSeedString(str_pad(sprintf("VT %s", $hash), 21, ' '));
 
-                $rom->setStartScreenHash($override_start_screen ?: $this->seed->hashArray());
+                $rom->setStartScreenHash($this->config('override_start_screen', false) ?: $this->seed->hashArray());
 
                 $this->seed->patch = json_encode($rom->getWriteLog());
                 $this->seed->save();
@@ -1165,7 +1159,7 @@ abstract class World
 
             $rom->setSeedString(str_pad(sprintf("VT %s", $hash), 21, ' '));
 
-            $rom->setStartScreenHash($override_start_screen ?: $this->seed->hashArray());
+            $rom->setStartScreenHash($this->config('override_start_screen', false) ?: $this->seed->hashArray());
 
             $this->seed->patch = json_encode($rom->getWriteLog());
             $this->seed->save();

--- a/app/World.php
+++ b/app/World.php
@@ -947,6 +947,12 @@ abstract class World
      */
     public function writeToRom(Rom $rom, bool $save = false): Rom
     {
+        if ($override_start_screen = $this->config('override_start_screen', false)) {
+            if (!(count($override_start_screen) === 5 && min($override_start_screen) >= 0x00 && max($override_start_screen) <= 0x1F)) {
+                throw new \Exception('Start screen array must be a 5 integer array between 0 and 31!');
+            }
+        }
+
         if ($this->override_patch !== null) {
             foreach ($this->override_patch as $writes) {
                 foreach ($writes as $address => $bytes) {
@@ -955,7 +961,11 @@ abstract class World
             }
 
             if ($save) {
-                $this->saveSeedRecord();
+                $hash = $this->saveSeedRecord();
+
+                $rom->setSeedString(str_pad(sprintf("VT %s", $hash), 21, ' '));
+
+                $rom->setStartScreenHash($override_start_screen ?: $this->seed->hashArray());
 
                 $this->seed->patch = json_encode($rom->getWriteLog());
                 $this->seed->save();
@@ -1155,7 +1165,7 @@ abstract class World
 
             $rom->setSeedString(str_pad(sprintf("VT %s", $hash), 21, ' '));
 
-            $rom->setStartScreenHash($this->seed->hashArray());
+            $rom->setStartScreenHash($override_start_screen ?: $this->seed->hashArray());
 
             $this->seed->patch = json_encode($rom->getWriteLog());
             $this->seed->save();

--- a/package-lock.json
+++ b/package-lock.json
@@ -5036,7 +5036,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -5991,7 +5991,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -6004,7 +6004,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -6595,7 +6595,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {

--- a/routes/console.php
+++ b/routes/console.php
@@ -67,7 +67,7 @@ Artisan::command('alttp:dailies {days=7}', function ($days) {
                 'enemizer.enemyShuffle' => getWeighted('enemy_shuffle'),
                 'enemizer.enemyDamage' => getWeighted('enemy_damage'),
                 'enemizer.enemyHealth' => getWeighted('enemy_health'),
-                'enemizer.potShuffle' => false,
+                'enemizer.potShuffle' => 'off',
             ]);
 
             $rom = new Rom(config('alttp.base_rom'));


### PR DESCRIPTION
This PR will allow an API request to override the start screen code.  The primary use case for this is the ALTTPR Ladder, as they need a way to ensure that all ladder seeds in a given race have the same code.