### PR TITLE
Adjust canExtendMagic and canBunnyRevive

### DIFF
--- a/app/Boss.php
+++ b/app/Boss.php
@@ -69,8 +69,8 @@ class Boss
             new static("Armos Knights", "Armos", function ($locations, $items) use ($world) {
                 return $items->hasSword() || $items->has('Hammer') || $items->canShootArrows($world)
                     || $items->has('Boomerang') || $items->has('RedBoomerang')
-                    || ($items->canExtendMagic(4) && ($items->has('FireRod') || $items->has('IceRod')))
-                    || ($items->canExtendMagic(2) && ($items->has('CaneOfByrna') || $items->has('CaneOfSomaria')));
+                    || ($items->canExtendMagic($world, 4) && ($items->has('FireRod') || $items->has('IceRod')))
+                    || ($items->canExtendMagic($world, 2) && ($items->has('CaneOfByrna') || $items->has('CaneOfSomaria')));
             }),
             new static("Lanmolas", "Lanmola", function ($locations, $items) use ($world) {
                 return $items->hasSword() || $items->has('Hammer')
@@ -91,12 +91,12 @@ class Boss
             new static("Arrghus", "Arrghus", function ($locations, $items) use ($world) {
                 return ($world->config('itemPlacement') !== 'basic' || $world->config('mode.weapons') === 'swordless' || $items->hasSword(2))
                     && $items->has('Hookshot') && ($items->has('Hammer') || $items->hasSword()
-                        || (($items->canExtendMagic(2) || $items->canShootArrows($world)) && ($items->has('FireRod') || $items->has('IceRod'))));
+                        || (($items->canExtendMagic($world, 2) || $items->canShootArrows($world)) && ($items->has('FireRod') || $items->has('IceRod'))));
             }),
             new static("Mothula", "Mothula", function ($locations, $items) use ($world) {
-                return ($world->config('itemPlacement') !== 'basic' || $items->hasSword(2) || ($items->canExtendMagic(2) && $items->has('FireRod')))
+                return ($world->config('itemPlacement') !== 'basic' || $items->hasSword(2) || ($items->canExtendMagic($world, 2) && $items->has('FireRod')))
                     && ($items->hasSword() || $items->has('Hammer')
-                        || ($items->canExtendMagic(2) && ($items->has('FireRod') || $items->has('CaneOfSomaria')
+                        || ($items->canExtendMagic($world, 2) && ($items->has('FireRod') || $items->has('CaneOfSomaria')
                             || $items->has('CaneOfByrna')))
                         || $items->canGetGoodBee());
             }),
@@ -106,11 +106,11 @@ class Boss
                         || $items->has('CaneOfSomaria') || $items->has('CaneOfByrna'));
             }),
             new static("Kholdstare", "Kholdstare", function ($locations, $items) use ($world) {
-                return ($world->config('itemPlacement') !== 'basic' || $items->hasSword(2) || ($items->canExtendMagic(3) && $items->has('FireRod'))
-                    || ($items->has('Bombos') && ($world->config('mode.weapons') === 'swordless' || $items->hasSword()) && $items->canExtendMagic(2) && $items->has('FireRod')))
+                return ($world->config('itemPlacement') !== 'basic' || $items->hasSword(2) || ($items->canExtendMagic($world, 3) && $items->has('FireRod'))
+                    || ($items->has('Bombos') && ($world->config('mode.weapons') === 'swordless' || $items->hasSword()) && $items->canExtendMagic($world, 2) && $items->has('FireRod')))
                     && $items->canMeltThings($world) && ($items->has('Hammer') || $items->hasSword()
-                        || ($items->canExtendMagic(3) && $items->has('FireRod'))
-                        || ($items->canExtendMagic(2) && $items->has('FireRod') && $items->has('Bombos') && $world->config('mode.weapons') === 'swordless'));
+                        || ($items->canExtendMagic($world, 3) && $items->has('FireRod'))
+                        || ($items->canExtendMagic($world, 2) && $items->has('FireRod') && $items->has('Bombos') && $world->config('mode.weapons') === 'swordless'));
             }),
             new static("Vitreous", "Vitreous", function ($locations, $items) use ($world) {
                 return ($world->config('itemPlacement') !== 'basic' || $items->hasSword(2) || $items->canShootArrows($world))
@@ -118,10 +118,10 @@ class Boss
             }),
             new static("Trinexx", "Trinexx", function ($locations, $items) use ($world) {
                 return $items->has('FireRod') && $items->has('IceRod')
-                    && ($world->config('itemPlacement') !== 'basic' || $world->config('mode.weapons') === 'swordless' || $items->hasSword(3) || ($items->canExtendMagic(2) && $items->hasSword(2)))
+                    && ($world->config('itemPlacement') !== 'basic' || $world->config('mode.weapons') === 'swordless' || $items->hasSword(3) || ($items->canExtendMagic($world, 2) && $items->hasSword(2)))
                     && ($items->hasSword(3) || $items->has('Hammer')
-                        || ($items->canExtendMagic(2) && $items->hasSword(2))
-                        || ($items->canExtendMagic(4) && $items->hasSword()));
+                        || ($items->canExtendMagic($world, 2) && $items->hasSword(2))
+                        || ($items->canExtendMagic($world, 4) && $items->hasSword()));
             }),
             new static("Agahnim2", "Agahnim2", function ($locations, $items) {
                 return $items->hasSword() || $items->has('Hammer') || $items->has('BugCatchingNet');

--- a/app/Region/Inverted/DarkWorld/DeathMountain/West.php
+++ b/app/Region/Inverted/DarkWorld/DeathMountain/West.php
@@ -36,10 +36,10 @@ class West extends Region\Standard\DarkWorld\DeathMountain\West
             return $items->has('Hammer')
                 && $items->canLiftRocks()
                 && (
-                    ($items->canExtendMagic()
+                    ($items->canExtendMagic($this->world)
                         && $items->has('Cape')) || (
                         (!$this->world->config('region.cantTakeDamage', false)
-                            || $items->canExtendMagic()) &&
+                            || $items->canExtendMagic($this->world)) &&
                         $items->has('CaneOfByrna')));
         });
 

--- a/app/Region/Inverted/DarkWorld/DeathMountain/West.php
+++ b/app/Region/Inverted/DarkWorld/DeathMountain/West.php
@@ -36,10 +36,10 @@ class West extends Region\Standard\DarkWorld\DeathMountain\West
             return $items->has('Hammer')
                 && $items->canLiftRocks()
                 && (
-                    ($items->canExtendMagic($this->world)
+                    ($items->canExtendMagic()
                         && $items->has('Cape')) || (
                         (!$this->world->config('region.cantTakeDamage', false)
-                            || $items->canExtendMagic($this->world)) &&
+                            || $items->canExtendMagic()) &&
                         $items->has('CaneOfByrna')));
         });
 

--- a/app/Region/Inverted/DarkWorld/NorthEast.php
+++ b/app/Region/Inverted/DarkWorld/NorthEast.php
@@ -45,7 +45,7 @@ class NorthEast extends Region\Standard\DarkWorld\NorthEast
                     || ( //Quirn-Jump
                         !$this->world->config('region.cantTakeDamage', false)
                         && $this->world->config('canFakeFlipper', false)) || ($this->world->config('canBunnyRevive', false)
-                        && $items->canBunnyRevive())) || ($this->world->config('canWaterWalk', false)
+                        && $items->canBunnyRevive($this->world))) || ($this->world->config('canWaterWalk', false)
                     && $items->has('PegasusBoots'));
         });
 
@@ -92,7 +92,7 @@ class NorthEast extends Region\Standard\DarkWorld\NorthEast
                     && $items->has('PegasusBoots')) || ($this->world->config('canSuperSpeed', false)
                     && $items->canSpinSpeed()) || (!$this->world->config('region.cantTakeDamage', false)
                     && $this->world->config('canFakeFlipper', false)) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) ||
+                    && $items->canBunnyRevive($this->world)) ||
                 $this->world->config('canOneFrameClipOW', false);
         };
 

--- a/app/Region/Inverted/DarkWorld/South.php
+++ b/app/Region/Inverted/DarkWorld/South.php
@@ -59,7 +59,7 @@ class South extends Region\Standard\DarkWorld\South
                                 && ($items->has('Hammer')
                                     || $items->canLiftRocks()))
                             || ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()))
+                                && $items->canBunnyRevive($this->world)))
                         || ($this->world->getRegion('North West Dark World')->canEnter($locations, $items)
                             && $this->world->config('region.cantTakeDamage', false))));
         });
@@ -80,7 +80,7 @@ class South extends Region\Standard\DarkWorld\South
                                 && ($items->has('Hammer')
                                     || $items->canLiftRocks()))
                             || ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()))
+                                && $items->canBunnyRevive($this->world)))
                         || ($this->world->getRegion('North West Dark World')->canEnter($locations, $items)
                             && $this->world->config('region.cantTakeDamage', false))));
         });
@@ -100,7 +100,7 @@ class South extends Region\Standard\DarkWorld\South
                             ($this->world->getRegion('North East Dark World')->canEnter($locations, $items)
                                 && ($items->has('Hammer')
                                     || $items->canLiftRocks())) || ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()))
+                                && $items->canBunnyRevive($this->world)))
                         || ($this->world->getRegion('North West Dark World')->canEnter($locations, $items)
                             && $this->world->config('region.cantTakeDamage', false))));
         });

--- a/app/Region/Inverted/DesertPalace.php
+++ b/app/Region/Inverted/DesertPalace.php
@@ -31,7 +31,7 @@ class DesertPalace extends Region\Standard\DesertPalace
                     ($items->has('MoonPearl')
                         || ($this->world->config('canOWYBA', false)
                             && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                            && $items->canBunnyRevive())) && (
+                            && $items->canBunnyRevive($this->world))) && (
                         ($this->world->config('canBootsClip', false)
                             && $items->has('PegasusBoots')))) &&
                 $this->world->getRegion('South Light World')->canEnter($locations, $items);
@@ -51,7 +51,7 @@ class DesertPalace extends Region\Standard\DesertPalace
                 && ($items->has('MoonPearl')
                     || $this->world->config('canDungeonRevive', false)
                     || ($this->world->config('canBunnyRevive', false)
-                        && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                        && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                         && $items->hasABottle()) || $items->hasSword());
         });
 
@@ -61,7 +61,7 @@ class DesertPalace extends Region\Standard\DesertPalace
                 && (
                     ($items->has('MoonPearl')
                         || ($this->world->config('canBunnyRevive', false)
-                            && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                            && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                             && $items->hasABottle())) || ($this->world->config('canOneFrameClipOW', false)
                         && $this->world->config('canDungeonRevive', false)))
                 && ($items->canLiftRocks() || ($this->world->config('canBootsClip', false)
@@ -83,7 +83,7 @@ class DesertPalace extends Region\Standard\DesertPalace
             return ($this->world->config('canDungeonRevive', false)
                 || ($this->world->config('canSuperBunny', false)
                     && $items->has('MagicMirror')) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()) ||
                 $items->has('MoonPearl')) && ($main($locations, $items)
                 || $side($locations, $items)

--- a/app/Region/Inverted/EasternPalace.php
+++ b/app/Region/Inverted/EasternPalace.php
@@ -24,7 +24,7 @@ class EasternPalace extends Region\Standard\EasternPalace
             return $items->hasSword()
                 || $this->world->config('canDungeonRevive', false)
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()) ||
                 $items->has('MoonPearl');
         });
@@ -33,7 +33,7 @@ class EasternPalace extends Region\Standard\EasternPalace
             return ($items->hasSword()
                 || $this->world->config('canDungeonRevive', false)
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()) ||
                 $items->has('MoonPearl')) &&
                 $items->has('BigKeyP1');
@@ -44,7 +44,7 @@ class EasternPalace extends Region\Standard\EasternPalace
                 ||
                 $this->world->config('canDungeonRevive', false)
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()) ||
                 $items->has('MoonPearl')) && $items->has('Lamp', $this->world->config('item.require.Lamp', 1));
         });
@@ -53,7 +53,7 @@ class EasternPalace extends Region\Standard\EasternPalace
             return $items->canShootArrows($this->world)
                 && ($this->world->config('canDungeonRevive', false)
                     || ($this->world->config('canBunnyRevive', false)
-                        && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                        && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                         && $items->hasABottle()) ||
                     $items->has('MoonPearl')) && ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
                     || ($this->world->config('itemPlacement') === 'advanced'
@@ -70,7 +70,7 @@ class EasternPalace extends Region\Standard\EasternPalace
             return ($this->world->config('canDungeonRevive', false)
                 || ($this->world->config('canSuperBunny', false)
                     && $items->has('MagicMirror')) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()) ||
                 $items->has('MoonPearl')) &&
                 $this->world->getRegion('North East Light World')->canEnter($locations, $items);

--- a/app/Region/Inverted/GanonsTower.php
+++ b/app/Region/Inverted/GanonsTower.php
@@ -29,7 +29,7 @@ class GanonsTower extends Region\Standard\GanonsTower
                             || ($this->world->config('canBootsClip', false)
                                 && $items->has('PegasusBoots'))) && (
                             ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                                && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                                 && $items->hasABottle()))));
         });
 
@@ -42,7 +42,7 @@ class GanonsTower extends Region\Standard\GanonsTower
                             || ($this->world->config('canBootsClip', false)
                                 && $items->has('PegasusBoots'))) && (
                             ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                                && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                                 && $items->hasABottle()))));
         });
 
@@ -55,7 +55,7 @@ class GanonsTower extends Region\Standard\GanonsTower
                             || ($this->world->config('canBootsClip', false)
                                 && $items->has('PegasusBoots'))) && (
                             ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                                && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                                 && $items->hasABottle()))));
         });
 
@@ -68,7 +68,7 @@ class GanonsTower extends Region\Standard\GanonsTower
                             || ($this->world->config('canBootsClip', false)
                                 && $items->has('PegasusBoots'))) && (
                             ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                                && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                                 && $items->hasABottle()))));
         });
 
@@ -89,7 +89,7 @@ class GanonsTower extends Region\Standard\GanonsTower
                             || ($this->world->config('canBootsClip', false)
                                 && $items->has('PegasusBoots'))) && (
                             ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                                && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                                 && $items->hasABottle()))));
         });
 
@@ -110,7 +110,7 @@ class GanonsTower extends Region\Standard\GanonsTower
                             || ($this->world->config('canBootsClip', false)
                                 && $items->has('PegasusBoots'))) && (
                             ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                                && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                                 && $items->hasABottle()))));
         });
 
@@ -131,7 +131,7 @@ class GanonsTower extends Region\Standard\GanonsTower
                             || ($this->world->config('canBootsClip', false)
                                 && $items->has('PegasusBoots'))) && (
                             ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                                && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                                 && $items->hasABottle()))));
         });
 
@@ -152,7 +152,7 @@ class GanonsTower extends Region\Standard\GanonsTower
                             || ($this->world->config('canBootsClip', false)
                                 && $items->has('PegasusBoots'))) && (
                             ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                                && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                                 && $items->hasABottle()))));
         });
 
@@ -175,7 +175,7 @@ class GanonsTower extends Region\Standard\GanonsTower
                             || ($this->world->config('canBootsClip', false)
                                 && $items->has('PegasusBoots'))) && (
                             ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                                && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                                 && $items->hasABottle()))));
         });
 
@@ -197,7 +197,7 @@ class GanonsTower extends Region\Standard\GanonsTower
                             || ($this->world->config('canBootsClip', false)
                                 && $items->has('PegasusBoots'))) && (
                             ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                                && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                                 && $items->hasABottle()))));
         })->setAlwaysAllow(function ($item, $items) {
             return $this->world->config('accessibility') !== 'locations'
@@ -221,7 +221,7 @@ class GanonsTower extends Region\Standard\GanonsTower
                             || ($this->world->config('canBootsClip', false)
                                 && $items->has('PegasusBoots'))) && (
                             ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                                && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                                 && $items->hasABottle()))));
         })->setFillRules(function ($item, $locations, $items) {
             return $item != Item::get('BigKeyA2', $this->world);
@@ -237,7 +237,7 @@ class GanonsTower extends Region\Standard\GanonsTower
                             || ($this->world->config('canBootsClip', false)
                                 && $items->has('PegasusBoots'))) && (
                             ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                                && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                                 && $items->hasABottle()))));
         });
 
@@ -249,7 +249,7 @@ class GanonsTower extends Region\Standard\GanonsTower
                             || ($this->world->config('canBootsClip', false)
                                 && $items->has('PegasusBoots'))) && (
                             ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                                && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                                 && $items->hasABottle()))));
         });
 
@@ -270,7 +270,7 @@ class GanonsTower extends Region\Standard\GanonsTower
                             || ($this->world->config('canBootsClip', false)
                                 && $items->has('PegasusBoots'))) && (
                             ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                                && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                                 && $items->hasABottle()))));
         });
 
@@ -291,7 +291,7 @@ class GanonsTower extends Region\Standard\GanonsTower
                             || ($this->world->config('canBootsClip', false)
                                 && $items->has('PegasusBoots'))) && (
                             ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                                && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                                 && $items->hasABottle()))));
         });
 
@@ -310,7 +310,7 @@ class GanonsTower extends Region\Standard\GanonsTower
                             || ($this->world->config('canBootsClip', false)
                                 && $items->has('PegasusBoots'))) && (
                             ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                                && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                                 && $items->hasABottle()))));
         });
 
@@ -330,7 +330,7 @@ class GanonsTower extends Region\Standard\GanonsTower
                             || ($this->world->config('canBootsClip', false)
                                 && $items->has('PegasusBoots'))) && (
                             ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                                && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                                 && $items->hasABottle()))));
         });
 
@@ -346,7 +346,7 @@ class GanonsTower extends Region\Standard\GanonsTower
                             || ($this->world->config('canBootsClip', false)
                                 && $items->has('PegasusBoots'))) && (
                             ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                                && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                                 && $items->hasABottle()))));
         });
 
@@ -361,7 +361,7 @@ class GanonsTower extends Region\Standard\GanonsTower
                             || ($this->world->config('canBootsClip', false)
                                 && $items->has('PegasusBoots'))) && (
                             ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                                && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                                 && $items->hasABottle()))));
         });
 
@@ -376,7 +376,7 @@ class GanonsTower extends Region\Standard\GanonsTower
                             || ($this->world->config('canBootsClip', false)
                                 && $items->has('PegasusBoots'))) && (
                             ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                                && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                                 && $items->hasABottle()))));
         });
 
@@ -392,7 +392,7 @@ class GanonsTower extends Region\Standard\GanonsTower
                             || ($this->world->config('canBootsClip', false)
                                 && $items->has('PegasusBoots'))) && (
                             ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                                && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                                 && $items->hasABottle()))));
         })->setFillRules(function ($item, $locations, $items) {
             return $item != Item::get('BigKeyA2', $this->world);
@@ -410,7 +410,7 @@ class GanonsTower extends Region\Standard\GanonsTower
                             || ($this->world->config('canBootsClip', false)
                                 && $items->has('PegasusBoots'))) && (
                             ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                                && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                                 && $items->hasABottle()))));
         })->setFillRules(function ($item, $locations, $items) {
             return $item != Item::get('BigKeyA2', $this->world);
@@ -428,7 +428,7 @@ class GanonsTower extends Region\Standard\GanonsTower
                             || ($this->world->config('canBootsClip', false)
                                 && $items->has('PegasusBoots'))) && (
                             ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                                && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                                 && $items->hasABottle()))));
         })->setFillRules(function ($item, $locations, $items) {
             return $item != Item::get('BigKeyA2', $this->world);
@@ -448,7 +448,7 @@ class GanonsTower extends Region\Standard\GanonsTower
                             || ($this->world->config('canBootsClip', false)
                                 && $items->has('PegasusBoots'))) && (
                             ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                                && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                                 && $items->hasABottle()))));
         })->setFillRules(function ($item, $locations, $items) {
             return $item != Item::get('KeyA2', $this->world)
@@ -479,7 +479,7 @@ class GanonsTower extends Region\Standard\GanonsTower
                         || ($this->world->config('canBootsClip', false)
                             && $items->has('PegasusBoots'))) && (
                         ($this->world->config('canBunnyRevive', false)
-                            && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                            && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                             && $items->hasABottle())))) && ($items->has('Crystal1')
                 + $items->has('Crystal2')
                 + $items->has('Crystal3')

--- a/app/Region/Inverted/HyruleCastleEscape.php
+++ b/app/Region/Inverted/HyruleCastleEscape.php
@@ -22,47 +22,47 @@ class HyruleCastleEscape extends Region\Open\HyruleCastleEscape
         
         $this->locations["Sewers - Secret Room - Left"]->setRequirements(function ($locations, $items) {
             return ($items->canLiftRocks() && ($items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world))
                 || ($this->world->config('canOWYBA', false) && $items->hasABottle())))
                 || ($items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && $items->has('KeyH2')
                 && ($this->world->config('canDungeonRevive', false) || $items->hasSword()
-                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world))
                     || ($this->world->config('canOWYBA', false) && $items->hasABottle())
                     || $items->has('MoonPearl')));
         });
 
         $this->locations["Sewers - Secret Room - Middle"]->setRequirements(function ($locations, $items) {
             return ($items->canLiftRocks() && ($items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world))
                 || ($this->world->config('canOWYBA', false) && $items->hasABottle())))
                 || ($items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && $items->has('KeyH2')
                 && ($this->world->config('canDungeonRevive', false) || $items->hasSword()
-                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world))
                     || ($this->world->config('canOWYBA', false) && $items->hasABottle())
                     || $items->has('MoonPearl')));
         });
 
         $this->locations["Sewers - Secret Room - Right"]->setRequirements(function ($locations, $items) {
             return ($items->canLiftRocks() && ($items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world))
                 || ($this->world->config('canOWYBA', false) && $items->hasABottle())))
                 || ($items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && $items->has('KeyH2')
                 && ($this->world->config('canDungeonRevive', false) || $items->hasSword()
-                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world))
                     || ($this->world->config('canOWYBA', false) && $items->hasABottle())
                     || $items->has('MoonPearl')));
         });
 
         $this->locations["Hyrule Castle - Boomerang Chest"]->setRequirements(function ($locations, $items) {
             return $items->has('KeyH2') && ($this->world->config('canDungeonRevive', false) || $items->hasSword()
-                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world))
                 || ($this->world->config('canOWYBA', false) && $items->hasABottle())
                 || $items->has('MoonPearl'));
         });
 
         $this->locations["Hyrule Castle - Zelda's Cell"]->setRequirements(function ($locations, $items) {
             return $items->has('KeyH2') && ($this->world->config('canDungeonRevive', false) || $items->hasSword()
-                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world))
                 || ($this->world->config('canOWYBA', false) && $items->hasABottle())
                 || $items->has('MoonPearl'));
         });
@@ -75,7 +75,7 @@ class HyruleCastleEscape extends Region\Open\HyruleCastleEscape
                     || ($this->world->config('canOWYBA', false)
                         && $items->hasABottle())
                     || ($this->world->config('canBunnyRevive', false)
-                        && $items->canBunnyRevive()))
+                        && $items->canBunnyRevive($this->world)))
                     && $this->world->getRegion('North West Light World')->canEnter($locations, $items));
         });
 
@@ -90,7 +90,7 @@ class HyruleCastleEscape extends Region\Open\HyruleCastleEscape
                             && $items->canSpinSpeed()) ||
                         $this->world->config('canOneFrameClipOW', false)) &&
                     $this->world->getRegion('West Death Mountain')->canEnter($locations, $items)) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()) ||
                 $items->has('MoonPearl')) &&
                 $this->world->getRegion('North East Light World')->canEnter($locations, $items);
@@ -111,7 +111,7 @@ class HyruleCastleEscape extends Region\Open\HyruleCastleEscape
                             && $items->canSpinSpeed()) ||
                         $this->world->config('canOneFrameClipOW', false)) &&
                     $this->world->getRegion('West Death Mountain')->canEnter($locations, $items)) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()) ||
                 $items->has('MoonPearl')) &&
                 $this->world->getRegion('North East Light World')->canEnter($locations, $items);
@@ -128,7 +128,7 @@ class HyruleCastleEscape extends Region\Open\HyruleCastleEscape
             return ($this->world->config('canDungeonRevive', false)
                 || ($this->world->config('canSuperBunny', false)
                     && $items->has('MagicMirror')) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()) ||
                 $items->has('MoonPearl')) &&
                 $this->world->getRegion('North East Light World')->canEnter($locations, $items);

--- a/app/Region/Inverted/LightWorld/NorthEast.php
+++ b/app/Region/Inverted/LightWorld/NorthEast.php
@@ -85,7 +85,7 @@ class NorthEast extends Region\Standard\LightWorld\NorthEast
                 || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle())
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive())
+                    && $items->canBunnyRevive($this->world))
                 || $this->world->config('canOneFrameClipOW', false)) &&
                 $items->has('Mushroom');
         });
@@ -93,7 +93,7 @@ class NorthEast extends Region\Standard\LightWorld\NorthEast
         $this->locations["Zora's Ledge"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle())) && ($items->has('Flippers')
                     || ($this->world->config('canWaterWalk', false)
                         && (($this->world->config('canFakeFlipper', false)
@@ -110,7 +110,7 @@ class NorthEast extends Region\Standard\LightWorld\NorthEast
         $this->locations["Waterfall Fairy - Left"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle())) && ($this->world->config('canFakeFlipper', false)
                 || ($this->world->config('canWaterWalk', false)
                     && ($items->has('PegasusBoots')
@@ -127,7 +127,7 @@ class NorthEast extends Region\Standard\LightWorld\NorthEast
         $this->locations["Waterfall Fairy - Right"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle())) && ($this->world->config('canFakeFlipper', false)
                 || ($this->world->config('canWaterWalk', false)
                     && ($items->has('PegasusBoots')
@@ -175,7 +175,7 @@ class NorthEast extends Region\Standard\LightWorld\NorthEast
 
             return ($items->has('MoonPearl')
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()) || (     // Invis Ganon fight sounds fun for logic :)
                     $this->world->config('canSuperBunny', false)
                     && $this->world->config('canDungeonRevive', false) // Just so it's not in logic for everyone. Don't care, just think it's better like this.

--- a/app/Region/Inverted/LightWorld/NorthEast.php
+++ b/app/Region/Inverted/LightWorld/NorthEast.php
@@ -189,20 +189,20 @@ class NorthEast extends Region\Standard\LightWorld\NorthEast
                     || $items->canShootArrows($this->world, 2)) && (
                     ($this->world->config('mode.weapons') == 'swordless'
                         && $items->has('Hammer') && ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
-                            || ($items->has('FireRod') && ($items->canExtendMagic(1)
-                                && $items->has('MoonPearl')) || $items->canExtendMagic(4)))) 
+                            || ($items->has('FireRod') && ($items->canExtendMagic($this->world, 1)
+                                && $items->has('MoonPearl')) || $items->canExtendMagic($this->world, 4)))) 
                     || (!$this->world->config('region.requireBetterSword', false)
                         && ($items->hasSword(2)
                             && ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
                                 || ($items->has('FireRod')
-                                    && ($items->canExtendMagic(3)
+                                    && ($items->canExtendMagic($this->world, 3)
                                         && $items->has('MoonPearl')) ||
-                                    $items->canExtendMagic(4))))) || ($items->hasSword(3)
+                                    $items->canExtendMagic($this->world, 4))))) || ($items->hasSword(3)
                         && ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
                             || ($items->has('FireRod')
-                                && ($items->canExtendMagic(2)
+                                && ($items->canExtendMagic($this->world, 2)
                                     && $items->has('MoonPearl')) ||
-                                $items->canExtendMagic(3)))));
+                                $items->canExtendMagic($this->world, 3)))));
         });
 
         $this->can_enter = function ($locations, $items) {

--- a/app/Region/Inverted/LightWorld/NorthWest.php
+++ b/app/Region/Inverted/LightWorld/NorthWest.php
@@ -20,14 +20,14 @@ class NorthWest extends Region\Standard\LightWorld\NorthWest
         $this->shops["Bush Covered House"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle());
         });
 
         $this->shops["Bomb Hut"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()) &&
                 $items->canBombThings();
         });
@@ -43,7 +43,7 @@ class NorthWest extends Region\Standard\LightWorld\NorthWest
             return $items->has('PegasusBoots')
                 && ($items->has('MoonPearl')
                     || ($this->world->config('canBunnyRevive', false)
-                        && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                        && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                         && $items->hasABottle())) && ($items->canLiftDarkRocks()
                     || ($this->world->config('canMirrorClip', false)
                         && $items->has('MagicMirror')
@@ -65,14 +65,14 @@ class NorthWest extends Region\Standard\LightWorld\NorthWest
                     && ($items->has('MagicMirror') || !$this->world->config('cantTakeDamage', false))) 
                     || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive());
+                    && $items->canBunnyRevive($this->world));
         });
 
         $this->locations["Chicken House"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
                 || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive());
+                    && $items->canBunnyRevive($this->world));
         });
 
         $this->locations["Kakariko Well - Top"]->setRequirements(function ($locations, $items) {
@@ -80,7 +80,7 @@ class NorthWest extends Region\Standard\LightWorld\NorthWest
                 && ($items->has('MoonPearl')
                     || ($this->world->config('canOWYBA', false)
                         && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                        && $items->canBunnyRevive()));
+                        && $items->canBunnyRevive($this->world)));
         });
 
         $this->locations["Kakariko Well - Left"]->setRequirements(function ($locations, $items) {
@@ -88,7 +88,7 @@ class NorthWest extends Region\Standard\LightWorld\NorthWest
                 || $this->world->config('canSuperBunny', false)
                 || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive());
+                    && $items->canBunnyRevive($this->world));
         });
 
         $this->locations["Kakariko Well - Middle"]->setRequirements(function ($locations, $items) {
@@ -96,7 +96,7 @@ class NorthWest extends Region\Standard\LightWorld\NorthWest
                 || $this->world->config('canSuperBunny', false)
                 || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive());
+                    && $items->canBunnyRevive($this->world));
         });
 
         $this->locations["Kakariko Well - Right"]->setRequirements(function ($locations, $items) {
@@ -104,7 +104,7 @@ class NorthWest extends Region\Standard\LightWorld\NorthWest
                 || $this->world->config('canSuperBunny', false)
                 || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive());
+                    && $items->canBunnyRevive($this->world));
         });
 
         $this->locations["Kakariko Well - Bottom"]->setRequirements(function ($locations, $items) {
@@ -112,7 +112,7 @@ class NorthWest extends Region\Standard\LightWorld\NorthWest
                 || $this->world->config('canSuperBunny', false)
                 || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive());
+                    && $items->canBunnyRevive($this->world));
         });
 
         $this->locations["Blind's Hideout - Top"]->setRequirements(function ($locations, $items) {
@@ -120,7 +120,7 @@ class NorthWest extends Region\Standard\LightWorld\NorthWest
                 && ($items->has('MoonPearl')
                     || ($this->world->config('canOWYBA', false)
                         && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                        && $items->canBunnyRevive()));
+                        && $items->canBunnyRevive($this->world)));
         });
 
         $this->locations["Blind's Hideout - Left"]->setRequirements(function ($locations, $items) {
@@ -128,7 +128,7 @@ class NorthWest extends Region\Standard\LightWorld\NorthWest
                 || ($this->world->config('canSuperBunny', false)
                     && $items->has('MagicMirror')) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive());
+                    && $items->canBunnyRevive($this->world));
         });
 
         $this->locations["Blind's Hideout - Right"]->setRequirements(function ($locations, $items) {
@@ -136,7 +136,7 @@ class NorthWest extends Region\Standard\LightWorld\NorthWest
                 || ($this->world->config('canSuperBunny', false)
                     && $items->has('MagicMirror')) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive());
+                    && $items->canBunnyRevive($this->world));
         });
 
         $this->locations["Blind's Hideout - Far Left"]->setRequirements(function ($locations, $items) {
@@ -144,7 +144,7 @@ class NorthWest extends Region\Standard\LightWorld\NorthWest
                 || ($this->world->config('canSuperBunny', false)
                     && $items->has('MagicMirror')) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive());
+                    && $items->canBunnyRevive($this->world));
         });
 
         $this->locations["Blind's Hideout - Far Right"]->setRequirements(function ($locations, $items) {
@@ -152,7 +152,7 @@ class NorthWest extends Region\Standard\LightWorld\NorthWest
                 || ($this->world->config('canSuperBunny', false)
                     && $items->has('MagicMirror')) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive());
+                    && $items->canBunnyRevive($this->world));
         });
 
         $this->locations["Pegasus Rocks"]->setRequirements(function ($locations, $items) {
@@ -160,7 +160,7 @@ class NorthWest extends Region\Standard\LightWorld\NorthWest
                 && ($items->has('MoonPearl')
                     || ($this->world->config('canOWYBA', false)
                         && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                        && $items->canBunnyRevive()));
+                        && $items->canBunnyRevive($this->world)));
         });
 
         $this->locations["Magic Bat"]->setRequirements(function ($locations, $items) {
@@ -168,7 +168,7 @@ class NorthWest extends Region\Standard\LightWorld\NorthWest
                 && ($items->has('MoonPearl')
                     || ($this->world->config('canOWYBA', false)
                         && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                        && $items->canBunnyRevive())) && ($items->has('Hammer')
+                        && $items->canBunnyRevive($this->world))) && ($items->has('Hammer')
                     || (
                         ($this->world->config('canBootsClip', false)
                             && $items->has('PegasusBoots')) ||
@@ -185,7 +185,7 @@ class NorthWest extends Region\Standard\LightWorld\NorthWest
                 && ($items->has('PegasusBoots')
                     && ($items->has('MoonPearl')
                         || ($this->world->config('canBunnyRevive', false)
-                            && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                            && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                             && $items->hasABottle())) ||
                     $this->world->config('canOneFrameClipOW', false)
                     || ($this->world->config('canMirrorWrap', false)
@@ -195,7 +195,7 @@ class NorthWest extends Region\Standard\LightWorld\NorthWest
         $this->locations["Graveyard Ledge"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle())) &&
                 $items->canBombThings();
         });
@@ -203,14 +203,14 @@ class NorthWest extends Region\Standard\LightWorld\NorthWest
         $this->locations["Mushroom"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle());
         });
 
         $this->locations["Lost Woods Hideout"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle());
         });
 

--- a/app/Region/Inverted/LightWorld/South.php
+++ b/app/Region/Inverted/LightWorld/South.php
@@ -40,7 +40,7 @@ class South extends Region\Standard\LightWorld\South
         $this->shops["20 Rupee Cave"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle())) &&
                 $items->canLiftRocks();
         });
@@ -48,7 +48,7 @@ class South extends Region\Standard\LightWorld\South
         $this->shops["50 Rupee Cave"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle())) &&
                 $items->canLiftRocks();
         });
@@ -56,7 +56,7 @@ class South extends Region\Standard\LightWorld\South
         $this->shops["Bonk Fairy (Light)"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle())) &&
                 $items->has('PegasusBoots');
         });
@@ -64,7 +64,7 @@ class South extends Region\Standard\LightWorld\South
         $this->shops["Light Hype Fairy"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle())) &&
                 $items->canBombThings();
         });
@@ -76,14 +76,14 @@ class South extends Region\Standard\LightWorld\South
                 ($this->world->config('canFakeFlipper', false)
                     || $items->has('Flippers')) || ($this->world->config('canWaterWalk', false)
                     && $items->has('PegasusBoots'))) || ($this->world->config('canBunnyRevive', false)
-                && $items->canBunnyRevive());
+                && $items->canBunnyRevive($this->world));
         });
 
         $this->locations["Floodgate Chest"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
                 || ($this->world->config('canSuperBunny', false)
                     && $items->has('MagicMirror')) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()));
         });
 
@@ -97,14 +97,14 @@ class South extends Region\Standard\LightWorld\South
             return ($items->has('MoonPearl')
                 || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive())) &&
+                    && $items->canBunnyRevive($this->world))) &&
                 $items->canBombThings();
         });
 
         $this->locations["Mini Moldorm Cave - Far Left"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle())) &&
                 $items->canBombThings() && $items->canKillMostThings($this->world);
         });
@@ -112,7 +112,7 @@ class South extends Region\Standard\LightWorld\South
         $this->locations["Mini Moldorm Cave - Left"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle())) &&
                 $items->canBombThings() && $items->canKillMostThings($this->world);
         });
@@ -120,7 +120,7 @@ class South extends Region\Standard\LightWorld\South
         $this->locations["Mini Moldorm Cave - Right"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle())) &&
                 $items->canBombThings() && $items->canKillMostThings($this->world);
         });
@@ -128,7 +128,7 @@ class South extends Region\Standard\LightWorld\South
         $this->locations["Mini Moldorm Cave - Far Right"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle())) &&
                 $items->canBombThings() && $items->canKillMostThings($this->world);
         });
@@ -136,7 +136,7 @@ class South extends Region\Standard\LightWorld\South
         $this->locations["Ice Rod Cave"]->setRequirements(function ($locations, $items) {
             return (($items->has('MoonPearl')
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle())) &&
                 $items->canBombThings()) || ($items->has('BigRedBomb')
                 && $this->world->config('canSuperBunny', false)
@@ -146,7 +146,7 @@ class South extends Region\Standard\LightWorld\South
         $this->locations["Hobo"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle())) && (
                 ($this->world->config('canFakeFlipper', false)
                     || $items->has('Flippers')) || ($this->world->config('canWaterWalk', false)
@@ -165,13 +165,13 @@ class South extends Region\Standard\LightWorld\South
                 || ($this->world->config('canSuperBunny', false)
                     && $items->has('MagicMirror')) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive());
+                    && $items->canBunnyRevive($this->world));
         });
 
         $this->locations["Checkerboard Cave"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()))
                 && $items->canLiftRocks();
         });
@@ -179,7 +179,7 @@ class South extends Region\Standard\LightWorld\South
         $this->locations["Mini Moldorm Cave - NPC"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle())) &&
                 $items->canBombThings() && $items->canKillMostThings($this->world);
         });
@@ -187,7 +187,7 @@ class South extends Region\Standard\LightWorld\South
         $this->locations["Library"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()) || ($this->world->config('canSuperBunny', false)
                     && $items->has('MagicMirror'))) 
                 && $items->has('PegasusBoots');
@@ -214,7 +214,7 @@ class South extends Region\Standard\LightWorld\South
         $this->locations["Lake Hylia Island"]->setRequirements(function ($locations, $items) {
             return (($items->has('MoonPearl')
                 || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle())) && ($items->has('Flippers')
                     || ($this->world->config('canBootsClip', false)
                         && $items->has('PegasusBoots')) || ($this->world->config('canSuperSpeed', false)
@@ -226,7 +226,7 @@ class South extends Region\Standard\LightWorld\South
             return $items->has('MoonPearl')
                 || ($this->world->config('canSuperBunny', false)
                     && $items->has('MagicMirror')) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
+                    && $items->canBunnyRevive($this->world)) || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle());
         });
 
@@ -234,7 +234,7 @@ class South extends Region\Standard\LightWorld\South
             return ($items->has('MoonPearl')
                 || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive())) && $items->has('Shovel');
+                    && $items->canBunnyRevive($this->world))) && $items->has('Shovel');
         });
 
         $this->can_enter = function ($locations, $items) {

--- a/app/Region/Inverted/SwampPalace.php
+++ b/app/Region/Inverted/SwampPalace.php
@@ -138,7 +138,7 @@ class SwampPalace extends Region\Standard\SwampPalace
                     || ($this->world->config('canOWYBA', false)
                         && $items->hasABottle())
                     || ($this->world->config('canBunnyRevive', false)
-                        && $items->canBunnyRevive()))
+                        && $items->canBunnyRevive($this->world)))
                     || ($this->world->config('canSuperBunny', false)
                         && $items->has('MagicMirror')))
                 && ($items->has('MagicMirror')

--- a/app/Region/Inverted/TowerOfHera.php
+++ b/app/Region/Inverted/TowerOfHera.php
@@ -27,7 +27,7 @@ class TowerOfHera extends Region\Standard\TowerOfHera
                     && ((($items->has('MoonPearl')
                         || ($this->world->config('canOWYBA', false) && $items->hasBottle(2))
                             || ((($this->world->config('canOWYBA', false) && $items->hasABottle())
-                            || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()))
+                            || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world)))
                                 && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
                                     || $this->world->config('canOneFrameClipOW', false))))
                             && ($this->world->config('canOneFrameClipOW', false)
@@ -54,7 +54,7 @@ class TowerOfHera extends Region\Standard\TowerOfHera
                 && (($items->has('KeyP3')
                     && ($items->has('MoonPearl') || ($this->world->config('canOWYBA', false)
                     && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()))) || $mire($locations, $items));
+                    && $items->canBunnyRevive($this->world)))) || $mire($locations, $items));
         })->setAlwaysAllow(function ($item, $items) {
             return $this->world->config('accessibility') !== 'locations' && $item == Item::get('KeyP3', $this->world);
         });

--- a/app/Region/Standard/DarkWorld/DeathMountain/West.php
+++ b/app/Region/Standard/DarkWorld/DeathMountain/West.php
@@ -57,12 +57,12 @@ class West extends Region
                     || ($this->world->config('canOWYBA', false) && $items->hasABottle()
                         && (($items->has('PegasusBoots') && $this->world->config('canBootsClip', false))
                             || $this->world->config('canOneFrameClipOW', false))
-                        && (($items->has('Cape') && $items->canExtendMagic(3))
-                            || ((!$this->world->config('region.cantTakeDamage', false) || $items->canExtendMagic(3))
+                        && (($items->has('Cape') && $items->canExtendMagic($this->world, 3))
+                            || ((!$this->world->config('region.cantTakeDamage', false) || $items->canExtendMagic($this->world, 3))
                                 && $items->has('CaneOfByrna')))))
                 && $items->has('Hammer') && $items->canLiftRocks()
-                && (($items->canExtendMagic() && $items->has('Cape'))
-                    || ((!$this->world->config('region.cantTakeDamage', false) || $items->canExtendMagic()) && $items->has('CaneOfByrna')));
+                && (($items->canExtendMagic($this->world) && $items->has('Cape'))
+                    || ((!$this->world->config('region.cantTakeDamage', false) || $items->canExtendMagic($this->world)) && $items->has('CaneOfByrna')));
         });
 
         $this->can_enter = function ($locations, $items) {

--- a/app/Region/Standard/DarkWorld/DeathMountain/West.php
+++ b/app/Region/Standard/DarkWorld/DeathMountain/West.php
@@ -57,12 +57,12 @@ class West extends Region
                     || ($this->world->config('canOWYBA', false) && $items->hasABottle()
                         && (($items->has('PegasusBoots') && $this->world->config('canBootsClip', false))
                             || $this->world->config('canOneFrameClipOW', false))
-                        && (($items->has('Cape') && $items->canExtendMagic($this->world, 3))
-                            || ((!$this->world->config('region.cantTakeDamage', false) || $items->canExtendMagic($this->world, 3))
+                        && (($items->has('Cape') && $items->canExtendMagic(null, 3))
+                            || ((!$this->world->config('region.cantTakeDamage', false) || $items->canExtendMagic(null, 3))
                                 && $items->has('CaneOfByrna')))))
                 && $items->has('Hammer') && $items->canLiftRocks()
-                && (($items->canExtendMagic($this->world) && $items->has('Cape'))
-                    || ((!$this->world->config('region.cantTakeDamage', false) || $items->canExtendMagic($this->world)) && $items->has('CaneOfByrna')));
+                && (($items->canExtendMagic() && $items->has('Cape'))
+                    || ((!$this->world->config('region.cantTakeDamage', false) || $items->canExtendMagic()) && $items->has('CaneOfByrna')));
         });
 
         $this->can_enter = function ($locations, $items) {

--- a/app/Region/Standard/DarkWorld/Mire.php
+++ b/app/Region/Standard/DarkWorld/Mire.php
@@ -88,7 +88,7 @@ class Mire extends Region
                 && (($items->canLiftDarkRocks() && ($items->canFly($this->world)
                     || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))))
                     || $this->world->config('canOneFrameClipOW', false)
-                    || (((($items->has('MoonPearl') || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()))
+                    || (((($items->has('MoonPearl') || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world)))
                         && ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
                         || ($this->world->config('canMirrorWrap', false) && $items->has('MagicMirror')))
                         && $this->world->getRegion('South Dark World')->canEnter($locations, $items))

--- a/app/Region/Standard/DarkWorld/NorthEast.php
+++ b/app/Region/Standard/DarkWorld/NorthEast.php
@@ -220,9 +220,9 @@ class NorthEast extends Region
                 && (
                     ($this->world->config('mode.weapons') == 'swordless' && $items->has('Hammer')
                         && ($items->has('Lamp', $this->world->config('item.require.Lamp', 1)) || (
-                            $items->has('FireRod') && $items->canExtendMagic(1))))
-                    || (!$this->world->config('region.requireBetterSword', false) && ($items->hasSword(2) && ($items->has('Lamp', $this->world->config('item.require.Lamp', 1)) || ($items->has('FireRod') && $items->canExtendMagic(3)))))
-                    || ($items->hasSword(3) && ($items->has('Lamp', $this->world->config('item.require.Lamp', 1)) || ($items->has('FireRod') && $items->canExtendMagic(2)))));
+                            $items->has('FireRod') && $items->canExtendMagic($this->world, 1))))
+                    || (!$this->world->config('region.requireBetterSword', false) && ($items->hasSword(2) && ($items->has('Lamp', $this->world->config('item.require.Lamp', 1)) || ($items->has('FireRod') && $items->canExtendMagic($this->world, 3)))))
+                    || ($items->hasSword(3) && ($items->has('Lamp', $this->world->config('item.require.Lamp', 1)) || ($items->has('FireRod') && $items->canExtendMagic($this->world, 2)))));
         });
 
         return $this;

--- a/app/Region/Standard/DarkWorld/NorthEast.php
+++ b/app/Region/Standard/DarkWorld/NorthEast.php
@@ -72,7 +72,7 @@ class NorthEast extends Region
     public function initalize()
     {
         $this->shops["Dark World Potion Shop"]->setRequirements(function ($locations, $items) {
-            return ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+            return ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world))
                 || (($items->has('MoonPearl') || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
                     && ($this->world->config('canOneFrameClipOW', false)
                         || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
@@ -83,17 +83,17 @@ class NorthEast extends Region
         $this->shops["East Dark World Hint"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
                 || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive());
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world));
         });
 
         $this->shops["Palace of Darkness Hint"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
                 || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive());
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world));
         });
 
         $this->locations["Catfish"]->setRequirements(function ($locations, $items) {
-            return (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+            return (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world))
                 || $items->has('MoonPearl') || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
                 && ($this->world->config('canOneFrameClipOW', false)
                     || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
@@ -161,12 +161,12 @@ class NorthEast extends Region
                     || ($items->has('MagicMirror') && $this->world->config('canMirrorClip', false)
                         && $this->world->getRegion('West Death Mountain')->canEnter($locations, $items)
                         && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
-                            || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world))
                             || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())
                             || ($items->has('MoonPearl') && $this->world->config('canFakeFlipper', false))))
                     || $items->has('DefeatAgahnim')
                     || ($items->has('MagicMirror') && $this->world->config('canMirrorWrap', false)
-                        && $this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()
+                        && $this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world)
                         && (($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())
                             || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
                             || $this->world->config('canMirrorClip', false))
@@ -177,7 +177,7 @@ class NorthEast extends Region
                         && $items->has('MoonPearl')
                         && ($items->has('Hammer') || $items->has('Flippers')
                             || ($items->has('MagicMirror') && $this->world->config('canMirrorWrap', false) && $items->canLiftRocks())
-                            || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world))
                             || ($this->world->config('canWaterWalk', false) && $items->has('PegasusBoots'))
                             || ($this->world->config('canFakeFlipper', false) && !$this->world->config('region.cantTakeDamage', false)))));
         };

--- a/app/Region/Standard/DarkWorld/NorthWest.php
+++ b/app/Region/Standard/DarkWorld/NorthWest.php
@@ -72,31 +72,31 @@ class NorthWest extends Region
         $this->shops["Dark World Outcasts Shop"]->setRequirements(function ($locations, $items) {
             return $items->has('Hammer') && ($items->has('MoonPearl')
                 || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()));
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world)));
         });
 
         $this->locations["Brewery"]->setRequirements(function ($locations, $items) {
             return $items->canBombThings() && ($items->has('MoonPearl')
                 || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()));
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world)));
         });
 
         $this->locations["C-Shaped House"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl') || $this->world->config('canSuperBunny', false)
                 || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive());
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world));
         });
 
         $this->locations["Chest Game"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl') || $this->world->config('canSuperBunny', false)
                 || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive());
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world));
         });
 
         $this->locations["Hammer Pegs"]->setRequirements(function ($locations, $items) {
             return $items->has('Hammer') && ($items->has('MoonPearl')
                 || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()))
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world)))
                 && ($items->canLiftDarkRocks()
                     || ($items->has('MagicMirror') && $this->world->config('canMirrorWrap', false))
                     || (($this->world->config('canFakeFlipper', false) || $items->has('Flippers'))
@@ -109,7 +109,7 @@ class NorthWest extends Region
             return $this->world->config('canOneFrameClipOW', false)
                 || (($items->has('MoonPearl')
                     || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()))
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world)))
                     && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
                         || (($this->world->config('itemPlacement') !== 'basic' || $items->has('Hookshot'))
                             && $items->canLiftRocks() && $items->has('Cape'))));
@@ -119,7 +119,7 @@ class NorthWest extends Region
             return ($this->world->config('itemPlacement') !== 'basic' || $items->has('MagicMirror'))
                 && ((($items->has('MoonPearl')
                     || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()))
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world)))
                     && $items->canLiftDarkRocks())
                     || (($this->world->config('canOWYBA', false) && $items->hasABottle())
                         && ($this->world->config('canOneFrameClipOW', false)
@@ -132,7 +132,7 @@ class NorthWest extends Region
                 && (($items->has('MagicMirror') && $this->world->config('canMirrorWrap', false))
                     || (($items->has('MoonPearl')
                         || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                        || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()))
+                        || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world)))
                         && ($items->canLiftDarkRocks()
                             || (($this->world->config('canFakeFlipper', false) || $items->has('Flippers'))
                                 && ($this->world->config('canOneFrameClipOW', false)
@@ -156,7 +156,7 @@ class NorthWest extends Region
                             && (($items->has('Hookshot') || ($this->world->config('canMirrorWrap', false) && $items->has('MagicMirror')))
                                 && ($items->canLiftRocks() || $items->has('Hammer')
                                     || ($items->has('Flippers')
-                                        || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())))))
+                                        || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world))))))
                             || ($items->has('Hammer') && $items->canLiftRocks())
                             || $items->canLiftDarkRocks()
                             || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))

--- a/app/Region/Standard/DarkWorld/South.php
+++ b/app/Region/Standard/DarkWorld/South.php
@@ -65,51 +65,51 @@ class South extends Region
         $this->locations["Hype Cave - Top"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
                 || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive());
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world));
         });
 
         $this->locations["Hype Cave - Middle Right"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
                 || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive());
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world));
         });
 
         $this->locations["Hype Cave - Middle Left"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
                 || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive());
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world));
         });
 
         $this->locations["Hype Cave - Bottom"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
                 || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive());
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world));
         });
 
         $this->locations["Hype Cave - NPC"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
                 || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive());
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world));
         });
 
         $this->locations["Stumpy"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
                 || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world))
                 || ($items->has('MagicMirror') && $this->world->config('canMirrorWrap', false));
         });
 
         $this->locations["Digging Game"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
                 || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive());
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world));
         });
 
         $this->shops["Bonk Fairy (Dark)"]->setRequirements(function ($locations, $items) {
             return $items->has('PegasusBoots')
                 && ($items->has('MoonPearl')
                     || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()));
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world)));
         });
 
         $this->shops["Dark Lake Hylia Ledge Fairy"]->setRequirements(function ($locations, $items) {
@@ -117,20 +117,20 @@ class South extends Region
                 && ($items->has('Flippers')
                     || ($this->world->getRegion('North West Dark World')->canEnter($locations, $items)
                         && $this->world->config('canFakeFlipper', false) && (!$this->world->config('region.cantTakeDamage', false)))
-                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()))
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world)))
                 && ($items->has('MoonPearl')
                     || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()));
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world)));
         });
 
         $this->shops["Dark Lake Hylia Ledge Hint"]->setRequirements(function ($locations, $items) {
             return ($items->has('Flippers')
                 || ($this->world->getRegion('North West Dark World')->canEnter($locations, $items)
                     && $this->world->config('canFakeFlipper', false) && (!$this->world->config('region.cantTakeDamage', false)))
-                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()))
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world)))
                 && ($items->has('MoonPearl')
                     || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()));
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world)));
         });
 
         $this->shops["Dark Lake Hylia Ledge Spike Cave"]->setRequirements(function ($locations, $items) {
@@ -138,16 +138,16 @@ class South extends Region
                 && ($items->has('Flippers')
                     || ($this->world->getRegion('North West Dark World')->canEnter($locations, $items)
                         && $this->world->config('canFakeFlipper', false) && (!$this->world->config('region.cantTakeDamage', false)))
-                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()))
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world)))
                 && ($items->has('MoonPearl')
                     || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()));
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world)));
         });
 
         $this->can_enter = function ($locations, $items) {
             return $items->has('RescueZelda')
                 && (($this->world->config('canOWYBA', false) && $items->hasABottle())
-                    || (($items->has('MoonPearl') || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()))
+                    || (($items->has('MoonPearl') || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world)))
                         && ($this->world->getRegion('North East Dark World')->canEnter($locations, $items)
                             && ($items->has('Hammer')
                                 || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed()

--- a/app/Region/Standard/IcePalace.php
+++ b/app/Region/Standard/IcePalace.php
@@ -142,7 +142,7 @@ class IcePalace extends Region
                     || ($this->world->getRegion('South Dark World')->canEnter($locations, $items)
                         && ((($items->has('MoonPearl')
                             || ($items->hasABottle() && $this->world->config('canOWYBA', false))
-                            || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()))
+                            || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world)))
                         && (($this->world->config('canMirrorWrap', false) && $items->has('MagicMirror')
                             && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
                                 || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())))

--- a/app/Region/Standard/LightWorld/NorthWest.php
+++ b/app/Region/Standard/LightWorld/NorthWest.php
@@ -98,7 +98,7 @@ class NorthWest extends Region
                     || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())
                     || ($items->has('MagicMirror') && $this->world->getRegion('North West Dark World')->canEnter($locations, $items)
                         && ($items->has('MoonPearl') || ($items->hasABottle() && $this->world->config('canOWYBA', false))
-                            || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()))));
+                            || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world)))));
         });
 
         $this->locations["Pegasus Rocks"]->setRequirements(function ($locations, $items) {
@@ -114,7 +114,7 @@ class NorthWest extends Region
                     || ($items->has('MagicMirror')
                         && (($this->world->config('canMirrorWrap', false) && $this->world->getRegion('North West Dark World')->canEnter($locations, $items))
                             || (($items->has('MoonPearl') || ($items->hasABottle() && $this->world->config('canOWYBA', false))
-                                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()))
+                                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world)))
                                 && (($items->canLiftDarkRocks() && $this->world->getRegion('North West Dark World')->canEnter($locations, $items))
                                     || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed()
                                         && ($items->has('Flippers') || $this->world->config('canFakeFlipper', false))
@@ -135,7 +135,7 @@ class NorthWest extends Region
                 || $this->world->config('canOneFrameClipOW', false)
                 || ($items->has('MagicMirror') && $this->world->getRegion('North West Dark World')->canEnter($locations, $items)
                     && ($items->has('MoonPearl') || ($items->hasABottle() && $this->world->config('canOWYBA', false))
-                        || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())));
+                        || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world))));
         });
 
         $this->can_enter = function ($locations, $items) {

--- a/app/Region/Standard/PalaceOfDarkness.php
+++ b/app/Region/Standard/PalaceOfDarkness.php
@@ -184,7 +184,7 @@ class PalaceOfDarkness extends Region
                     || (($this->world->config('mode.weapons') === 'swordless' || $items->hasSword()) && $items->hasHealth(7) && $items->hasABottle()))
                 && ((($items->has('MoonPearl')
                     || (($this->world->config('canOWYBA', false) && $items->hasABottle())
-                        || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())))
+                        || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world))))
                     && $this->world->getRegion('North East Dark World')->canEnter($locations, $items))
                     || ($this->world->config('canOneFrameClipUW', false) && $this->world->config('canDungeonRevive', false)
                         && $this->world->getRegion('West Death Mountain')->canEnter($locations, $items)));

--- a/app/Region/Standard/SkullWoods.php
+++ b/app/Region/Standard/SkullWoods.php
@@ -150,7 +150,7 @@ class SkullWoods extends Region
                     || (($this->world->config('mode.weapons') === 'swordless' || $items->hasSword()) && $items->hasHealth(7) && $items->hasABottle()))
                 && ($this->world->config('canDungeonRevive', false) || $items->has('MoonPearl')
                     || (($items->hasABottle() && $this->world->config('canOWYBA', false))
-                        || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())))
+                        || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive($this->world))))
                 && $this->world->getRegion('North West Dark World')->canEnter($locations, $items);
         };
 

--- a/app/Support/ItemCollection.php
+++ b/app/Support/ItemCollection.php
@@ -438,15 +438,37 @@ class ItemCollection extends Collection
     }
 
     /**
+     * Requirements for acquiring a fairy
+     */
+    public function canAcquireFairy($world = null)
+    {
+        if ($world !== null)
+        {
+            if ($world->config('rom.HardMode') >= 1)
+            {
+                return False;
+            }
+        }
+        return True;
+    }
+
+    /**
      * Requirements for water (bunny) revival
      *
      * @return bool
      */
-    public function canBunnyRevive(): bool
+    public function canBunnyRevive($world = null): bool
     {
-        return $this->hasABottle() && $this->has('BugCatchingNet');
-    }
+        $canBunnyRevive = $this->hasABottle() && $this->has('BugCatchingNet');
 
+        if ($world !== null)
+        {
+            $canBunnyRevive = $canBunnyRevive && $this->canAcquireFairy($world);
+        }
+
+        return $canBunnyRevive;
+    }   
+    
     /**
      * Requirements for lobbing arrows at things
      *
@@ -485,17 +507,30 @@ class ItemCollection extends Collection
             || $this->has('ProgressiveShield', 3);
     }
 
-    /**
+   /**
      * Requirements for magic usage
      *
      * @param float $bars number of magic bars
      *
      * @return bool
      */
-    public function canExtendMagic($bars = 2.0)
+    public function canExtendMagic($world = null, $bars = 2.0)
     {
-        return ($this->has('QuarterMagic') ? 4 : ($this->has('HalfMagic') ? 2 : 1))
-            * ($this->bottleCount() + 1) >= $bars;
+        $magicModifier = 1.0;
+        if ($world !== null)
+        {
+
+            $difficultyLevel = $world->config('rom.HardMode');
+            if ($difficultyLevel === 1) {
+                $magicModifier = 0.5;
+            }
+            else if ($difficultyLevel === 2) {
+                $magicModifier = 0.25;
+            }
+        }
+        $baseMagic = ($this->has('QuarterMagic') ? 4 : ($this->has('HalfMagic') ? 2 : 1))
+            * ($this->bottleCount() + 1);
+        return ($baseMagic * $magicModifier) >= $bars;
     }
 
     /**

--- a/app/Support/ItemCollection.php
+++ b/app/Support/ItemCollection.php
@@ -442,12 +442,9 @@ class ItemCollection extends Collection
      */
     public function canAcquireFairy($world = null)
     {
-        if ($world !== null)
+        if ($world !== null && $world->config('rom.HardMode') >= 1)
         {
-            if ($world->config('rom.HardMode') >= 1)
-            {
-                return False;
-            }
+            return False;
         }
         return True;
     }
@@ -507,7 +504,7 @@ class ItemCollection extends Collection
             || $this->has('ProgressiveShield', 3);
     }
 
-   /**
+    /**
      * Requirements for magic usage
      *
      * @param float $bars number of magic bars
@@ -519,7 +516,6 @@ class ItemCollection extends Collection
         $magicModifier = 1.0;
         if ($world !== null)
         {
-
             $difficultyLevel = $world->config('rom.HardMode');
             if ($difficultyLevel === 1) {
                 $magicModifier = 0.5;

--- a/app/Support/ItemCollection.php
+++ b/app/Support/ItemCollection.php
@@ -517,16 +517,25 @@ class ItemCollection extends Collection
         if ($world !== null)
         {
             $difficultyLevel = $world->config('rom.HardMode');
-            if ($difficultyLevel === 1) {
-                $magicModifier = 0.5;
-            }
-            else if ($difficultyLevel === 2) {
-                $magicModifier = 0.25;
+            switch ($difficultyLevel)
+            {
+                case 1:
+                    $magicModifier = 0.5;
+                    break;
+                case 2:
+                    $magicModifier = 0.25;
+                    break;
+                case 3:
+                    $magicModifier = 0.0;
+                    break;
+                default:
+                    break;
             }
         }
-        $baseMagic = ($this->has('QuarterMagic') ? 4 : ($this->has('HalfMagic') ? 2 : 1))
-            * ($this->bottleCount() + 1);
-        return ($baseMagic * $magicModifier) >= $bars;
+
+        $baseMagic = ($this->has('QuarterMagic') ? 4 : ($this->has('HalfMagic') ? 2 : 1));
+        $bottleMagic = $baseMagic * $this->bottleCount() * $magicModifier;
+        return ($baseMagic + $bottleMagic) >= $bars;
     }
 
     /**

--- a/app/World.php
+++ b/app/World.php
@@ -1307,4 +1307,5 @@ abstract class World
             || $this->config('enemizer.enemyHealth') != 'default'
             || $this->config('enemizer.potShuffle') != 'off';
     }
+
 }

--- a/app/World.php
+++ b/app/World.php
@@ -1307,5 +1307,4 @@ abstract class World
             || $this->config('enemizer.enemyHealth') != 'default'
             || $this->config('enemizer.potShuffle') != 'off';
     }
-
 }

--- a/tests/Support/ItemCollectionTest.php
+++ b/tests/Support/ItemCollectionTest.php
@@ -155,6 +155,95 @@ class ItemCollectionTest extends TestCase
         ], $this->collection->values());
     }
 
+    public function canBunnyReviveDataProvider()
+    {
+        return [
+            [[], 'normal', False],
+            [['Bottle'], 'normal', False],
+            [['Bottle', 'BugCatchingNet'], 'normal', True],
+            [['BottleWithFairy', 'BugCatchingNet'], 'normal', True],
+            [['Bottle', 'BugCatchingNet'], 'hard', False],
+            [['Bottle', 'BugCatchingNet'], 'expert', False],
+        ];
+    }
+
+    /**
+     * @dataProvider canBunnyReviveDataProvider
+     */
+    public function testCanBunnyRevive($items, $difficultySetting, $expectedResult)
+    {
+        $this->world = World::factory('standard', ['item.functionality' => $difficultySetting]);
+        $this->collected->setChecksForWorld($this->world->id);
+
+        $this->addCollected($items);
+
+        $this->assertEquals($expectedResult, $this->collected->canBunnyRevive($this->world));
+    }
+
+    public function canAcquireFairyDataProvider()
+    {
+        return [
+            ["easy", True],
+            ["normal", True],
+            ["hard", False],
+            ["expert", False],
+            [null, True]
+        ];
+    }
+
+    /**
+     * @dataProvider canAcquireFairyDataProvider
+     */
+    public function testCanAcquireFairy($difficultySetting, $expectedResult)
+    {
+        $world = null;
+        if ($difficultySetting !== null)
+        {
+            $world = World::factory('standard', ['item.functionality' => $difficultySetting]);
+        }
+        else
+        {
+            $world = World::factory();
+        }
+        $this->assertEquals($expectedResult, $this->collection->canAcquireFairy($world));
+    }
+
+    public function canExtendMagicDataProvider()
+    {
+        return [
+            [['Bottle'], 'normal', 2, True],
+            [['Bottle'], 'normal', 3, False],
+            [['Bottle', 'HalfMagic'], 'normal', 4, True],
+            [['Bottle', 'HalfMagic'], 'normal', 5, False],
+            [['Bottle', 'HalfMagic'], 'hard', 2, True],
+            [['Bottle', 'HalfMagic'], 'hard', 3, False],
+            [['Bottle', 'Bottle', 'Bottle', 'Bottle', 'QuarterMagic'], 'expert', 5, True],
+            [['Bottle', 'Bottle', 'Bottle', 'Bottle', 'QuarterMagic'], 'expert', 6, False],
+        ];
+    }
+
+    /**
+     * @dataProvider canExtendMagicDataProvider
+     */
+    public function testCanExtendMagic($items, $difficultySetting, $magicBars, $expectedResult)
+    {
+        $this->world = null;
+        if ($difficultySetting !== null)
+        {
+            $this->world = World::factory('standard', ['item.functionality' => $difficultySetting]);
+        }
+        else
+        {
+            $this->world = World::factory();
+        }
+
+        $this->collected->setChecksForWorld($this->world->id);
+
+        $this->addCollected($items);
+
+        $this->assertEquals($expectedResult, $this->collected->canExtendMagic($this->world, $magicBars));
+    }
+
     /**
      * @dataProvider bottlesPool
      */

--- a/tests/Support/ItemCollectionTest.php
+++ b/tests/Support/ItemCollectionTest.php
@@ -211,14 +211,18 @@ class ItemCollectionTest extends TestCase
     public function canExtendMagicDataProvider()
     {
         return [
-            [['Bottle'], 'normal', 2, True],
-            [['Bottle'], 'normal', 3, False],
-            [['Bottle', 'HalfMagic'], 'normal', 4, True],
-            [['Bottle', 'HalfMagic'], 'normal', 5, False],
-            [['Bottle', 'HalfMagic'], 'hard', 2, True],
-            [['Bottle', 'HalfMagic'], 'hard', 3, False],
-            [['Bottle', 'Bottle', 'Bottle', 'Bottle', 'QuarterMagic'], 'expert', 5, True],
-            [['Bottle', 'Bottle', 'Bottle', 'Bottle', 'QuarterMagic'], 'expert', 6, False],
+            [[], 0, 1, True],
+            [[], 3, 2, False],
+            [['Bottle'], 0, 2, True],
+            [['Bottle'], 0, 3, False],
+            [['Bottle', 'HalfMagic'], 0, 4, True],
+            [['Bottle', 'HalfMagic'], 0, 5, False],
+            [['Bottle', 'HalfMagic'], 1, 3, True],
+            [['Bottle', 'HalfMagic'], 1, 4, False],
+            [['Bottle', 'Bottle', 'Bottle', 'Bottle', 'QuarterMagic'], 2, 8, True],
+            [['Bottle', 'Bottle', 'Bottle', 'Bottle', 'QuarterMagic'], 2, 9, False],
+            [['Bottle', 'Bottle', 'Bottle', 'Bottle', 'QuarterMagic'], 3, 4, True],
+            [['Bottle', 'Bottle', 'Bottle', 'Bottle', 'QuarterMagic'], 3, 5, False],
         ];
     }
 
@@ -227,7 +231,7 @@ class ItemCollectionTest extends TestCase
      */
     public function testCanExtendMagic($items, $difficultySetting, $magicBars, $expectedResult)
     {
-        $this->world = World::factory('standard', ['item.functionality' => $difficultySetting]);
+        $this->world = World::factory('standard', ['rom.HardMode' => $difficultySetting]);
 
         $this->collected->setChecksForWorld($this->world->id);
 

--- a/tests/Support/ItemCollectionTest.php
+++ b/tests/Support/ItemCollectionTest.php
@@ -227,15 +227,7 @@ class ItemCollectionTest extends TestCase
      */
     public function testCanExtendMagic($items, $difficultySetting, $magicBars, $expectedResult)
     {
-        $this->world = null;
-        if ($difficultySetting !== null)
-        {
-            $this->world = World::factory('standard', ['item.functionality' => $difficultySetting]);
-        }
-        else
-        {
-            $this->world = World::factory();
-        }
+        $this->world = World::factory('standard', ['item.functionality' => $difficultySetting]);
 
         $this->collected->setChecksForWorld($this->world->id);
 


### PR DESCRIPTION
This PR adjusts the two methods to take the difficulty setting into account as per #826 

- canExtendMagic will now apply a modifier of 0.5 and 0.25 for hard and expert mode respectively.  These values are guesses on my part so they might require adjustment.
- canBunnyRevive will now return false if the difficulty setting is hard or expert.
