### PR TITLE
Add Load Custom Sprite entry to VTRomSettings/VTSpriteLoader

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -57,6 +57,7 @@ Vue.component(
   "vt-sprite-select",
   require("./components/VTSpriteSelect.vue").default
 );
+Vue.component("vt-sprite-loader", require("./components/VTSpriteLoader.vue").default);
 Vue.component("vt-text", require("./components/VTText.vue").default);
 //Vue.component("Streams", require("./components/Streams").default);
 

--- a/resources/js/components/VTRomSettings.vue
+++ b/resources/js/components/VTRomSettings.vue
@@ -19,7 +19,17 @@
           :rom="rom"
           storage-key="rom.sprite-gfx"
           :title="$t('rom.settings.play_as')"
+          @load-custom-sprite="loadCustomSprite"
         ></vt-sprite-select>
+      </div>
+    </div>
+    <div v-if="showLoadCustomSprite" class="row mb-3">
+      <div class="col-md-12">
+        <vt-sprite-loader
+          id="sprite-loader"
+          :rom="rom"
+          storage-key="rom.custom-sprite-gfx"
+        ></vt-sprite-loader>
       </div>
     </div>
     <div v-if="!rom.tournament" class="row mb-3">
@@ -78,6 +88,7 @@ export default {
   props: ["rom"],
   data() {
     return {
+      showLoadCustomSprite: false,
       settings: {
         heartSpeeds: [
           { value: "off", name: this.$i18n.t("rom.settings.heart_speeds.off") },
@@ -148,6 +159,13 @@ export default {
     };
   },
   methods: {
+    loadCustomSprite(e) {
+      if (e) {
+        this.showLoadCustomSprite = true;
+      } else {
+        this.showLoadCustomSprite = false;
+      }
+    },
     ...mapMutations("romSettings", [
       "setHeartSpeed",
       "setMenuSpeed",

--- a/resources/js/components/VTRomSettings.vue
+++ b/resources/js/components/VTRomSettings.vue
@@ -160,11 +160,7 @@ export default {
   },
   methods: {
     loadCustomSprite(e) {
-      if (e) {
-        this.showLoadCustomSprite = true;
-      } else {
-        this.showLoadCustomSprite = false;
-      }
+      this.showLoadCustomSprite = Boolean(e);
     },
     ...mapMutations("romSettings", [
       "setHeartSpeed",

--- a/resources/js/components/VTRomSettings.vue
+++ b/resources/js/components/VTRomSettings.vue
@@ -29,6 +29,7 @@
           id="sprite-loader"
           :rom="rom"
           storage-key="rom.custom-sprite-gfx"
+          @disallow-save-rom="disallowSaveRom"
         ></vt-sprite-loader>
       </div>
     </div>
@@ -161,6 +162,10 @@ export default {
   methods: {
     loadCustomSprite(e) {
       this.showLoadCustomSprite = Boolean(e);
+      this.$emit('disallow-save-rom', Boolean(e));
+    },
+    disallowSaveRom(e) {
+      this.$emit('disallow-save-rom', Boolean(e));
     },
     ...mapMutations("romSettings", [
       "setHeartSpeed",

--- a/resources/js/components/VTSpriteLoader.vue
+++ b/resources/js/components/VTSpriteLoader.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="row">
+    <div class="col">
+      <label class="btn btn-outline-primary btn-file">
+        {{ $t("rom.settings.sprite_file_select") }}
+        <input
+          type="file"
+          accept=".zspr"
+          @change="loadBlob"
+        />
+      </label>
+    </div>
+    <div class="col" v-if="fileSelected">{{ fileNameText }}</div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    rom: { default: null },
+  },
+  data() {
+    return {
+      fileSelected: false,
+      fileNameText: ""
+    };
+  },
+  methods: {
+    loadBlob(change) {
+      let blob = change.target.files[0];
+      const fileName = change.target.files[0].name;
+      const fileReader = new FileReader();
+
+      fileReader.onload = event => {
+        this.arrayBuffer = event.target.result;
+      };
+
+      fileReader.onloadend = () => {
+        this.fileSelected = true;
+
+        if (typeof this.arrayBuffer === "undefined") {
+          this.fileNameText = "Could not read .zspr file: " + fileName;
+          throw new Error("Could not read this.arrayBuffer");
+        }
+
+        new Promise((resolve, reject) => {
+          var zspr = new Uint8Array(this.arrayBuffer);
+
+          const headBytes =
+            String.fromCharCode(zspr[0]) +
+            String.fromCharCode(zspr[1]) +
+            String.fromCharCode(zspr[2]) +
+            String.fromCharCode(zspr[3]);
+          const gfx_offset =
+            (zspr[12] << 24) | (zspr[11] << 16) | (zspr[10] << 8) | zspr[9];
+          const palette_offset =
+            (zspr[18] << 24) | (zspr[17] << 16) | (zspr[16] << 8) | zspr[15];
+
+          if (("ZSPR" != headBytes) ||
+              ((gfx_offset + 28672) > palette_offset) ||
+              ((gfx_offset + 28672) > this.arrayBuffer.byteLength) ||
+              ((palette_offset + 124) > this.arrayBuffer.byteLength)) {
+            reject("Bad .zspr file: " + fileName);
+          }
+
+          localforage
+            .setItem("vt.sprites.custom_sprite", zspr)
+            .then(function(spr) {
+              resolve(spr);
+            })
+            .catch(function() {
+              reject("Could not save sprite to local storage: " + fileName);
+            });
+
+          this.fileNameText = "Loaded: " + fileName;
+
+        }).then(this.rom.parseSprGfx.bind(this.rom),
+                (reason) => { this.fileNameText = reason });
+      };
+
+      fileReader.readAsArrayBuffer(blob);
+    }
+  }
+};
+</script>

--- a/resources/js/components/VTSpriteLoader.vue
+++ b/resources/js/components/VTSpriteLoader.vue
@@ -28,6 +28,7 @@ export default {
     };
   },
   created() {
+    this.$emit('disallow-save-rom', true);
     localforage.getItem("rom.custom-sprite-gfx").then(value => {
       if (value === null) return;
       this.file = value;
@@ -85,10 +86,14 @@ export default {
               reject("Could not save sprite to local storage: " + fileName);
             });
 
+          this.$emit('disallow-save-rom', false);
           this.fileNameText = "Loaded: " + fileName;
 
         }).then(this.rom.parseSprGfx.bind(this.rom),
-                (reason) => { this.fileNameText = reason });
+                (reason) => {
+          this.$emit('disallow-save-rom', true);
+          this.fileNameText = reason;
+        });
       };
 
       fileReader.readAsArrayBuffer(this.file);

--- a/resources/js/components/VTSpriteLoader.vue
+++ b/resources/js/components/VTSpriteLoader.vue
@@ -18,17 +18,30 @@
 export default {
   props: {
     rom: { default: null },
+    storageKey: { default: null }
   },
   data() {
     return {
       fileSelected: false,
-      fileNameText: ""
+      fileNameText: "",
+      file: null
     };
+  },
+  created() {
+    localforage.getItem("rom.custom-sprite-gfx").then(value => {
+      if (value === null) return;
+      this.file = value;
+      this.loadFile()
+    });
   },
   methods: {
     loadBlob(change) {
       let blob = change.target.files[0];
-      const fileName = change.target.files[0].name;
+      this.file = blob;
+      this.loadFile();
+    },
+    loadFile() {
+      const fileName = this.file.name;
       const fileReader = new FileReader();
 
       fileReader.onload = event => {
@@ -78,7 +91,8 @@ export default {
                 (reason) => { this.fileNameText = reason });
       };
 
-      fileReader.readAsArrayBuffer(blob);
+      fileReader.readAsArrayBuffer(this.file);
+      localforage.setItem(this.storageKey, this.file);
     }
   }
 };

--- a/resources/js/components/VTSpriteSelect.vue
+++ b/resources/js/components/VTSpriteSelect.vue
@@ -93,9 +93,8 @@ export default {
       if (pickedSprite.name === "Load Custom Sprite") {
         vm.$emit('load-custom-sprite', true);
         return;
-      } else {
-        vm.$emit('load-custom-sprite', false);
       }
+      vm.$emit('load-custom-sprite', false);
 
       while (pickedSprite.file === null) {
         pickedSprite =

--- a/resources/js/components/VTSpriteSelect.vue
+++ b/resources/js/components/VTSpriteSelect.vue
@@ -90,6 +90,13 @@ export default {
         pickedSprite = vm.sprites[0];
       }
 
+      if (pickedSprite.name === "Load Custom Sprite") {
+        vm.$emit('load-custom-sprite', true);
+        return;
+      } else {
+        vm.$emit('load-custom-sprite', false);
+      }
+
       while (pickedSprite.file === null) {
         pickedSprite =
           vm.sprites[Math.floor(Math.random() * vm.sprites.length)];

--- a/resources/js/store/customizer.js
+++ b/resources/js/store/customizer.js
@@ -95,7 +95,8 @@ export default new Vuex.Store({
         });
         sprites.push({
           author: "none",
-          file: null,
+          // Fake filename for statistics/remembering user preference
+          file: "UserCustomSprite",
           name: "Load Custom Sprite"
         });
         commit("updateSprites", sprites);

--- a/resources/js/store/customizer.js
+++ b/resources/js/store/customizer.js
@@ -93,6 +93,11 @@ export default new Vuex.Store({
           file: null,
           name: "Random"
         });
+        sprites.push({
+          author: "none",
+          file: null,
+          name: "Load Custom Sprite"
+        });
         commit("updateSprites", sprites);
       });
     },

--- a/resources/js/views/Customizer.vue
+++ b/resources/js/views/Customizer.vue
@@ -275,13 +275,18 @@
                     >
                       <button
                         class="btn btn-success text-center"
+                        :disabled="disableSaveRomButton"
                         @click="saveRom"
                       >{{ $t('randomizer.details.save_rom') }}</button>
                     </div>
                   </div>
                 </div>
                 <div v-if="this.endpoint == '/api/customizer'" class="row">
-                  <vt-rom-settings class="col-12" :rom="rom"></vt-rom-settings>
+                  <vt-rom-settings
+                    class="col-12"
+                    :rom="rom"
+                    @disallow-save-rom="disallowSaveRom"
+                  ></vt-rom-settings>
                 </div>
               </div>
             </div>
@@ -379,6 +384,7 @@ export default {
       romLoaded: false,
       current_rom_hash: "",
       gameLoaded: false,
+      disableSaveRomButton: false,
       endpoint: "/api/customizer",
       choice: {
         name: "",
@@ -453,6 +459,9 @@ export default {
     });
   },
   methods: {
+    disallowSaveRom(e) {
+      this.disableSaveRomButton = Boolean(e);
+    },
     ...mapActions("randomizer", [
       "setPreset",
       "setGlitchesRequired",

--- a/resources/js/views/HashLoader.vue
+++ b/resources/js/views/HashLoader.vue
@@ -49,13 +49,18 @@
                 <div class="btn-group btn-flex" role="group">
                   <button
                     class="btn btn-success text-center"
+                    :disabled="disableSaveRomButton"
                     @click="saveRom"
                   >{{ $t('randomizer.details.save_rom') }}</button>
                 </div>
               </div>
             </div>
             <div class="row">
-              <vt-rom-settings class="col-12" :rom="rom"></vt-rom-settings>
+              <vt-rom-settings
+                class="col-12"
+                :rom="rom"
+                @disallow-save-rom="disallowSaveRom"
+              ></vt-rom-settings>
             </div>
           </div>
         </div>
@@ -101,6 +106,7 @@ export default {
       error: false,
       generating: false,
       romLoaded: false,
+      disableSaveRomButton: false,
       gameLoaded: false
     };
   },
@@ -120,6 +126,9 @@ export default {
     EventBus.$on("applyHash", this.applyHash);
   },
   methods: {
+    disallowSaveRom(e) {
+      this.disableSaveRomButton = Boolean(e);
+    },
     applyHash(e, second_attempt) {
       if (this.rom.checkMD5() != this.current_rom_hash) {
         if (second_attempt) {

--- a/resources/js/views/Randomizer.vue
+++ b/resources/js/views/Randomizer.vue
@@ -329,13 +329,18 @@
                 <div class="btn-group btn-flex" role="group" v-if="this.rom">
                   <button
                     class="btn btn-success text-center"
+                    :disabled="disableSaveRomButton"
                     @click="saveRom"
                   >{{ $t('randomizer.details.save_rom') }}</button>
                 </div>
               </div>
             </div>
             <div class="row">
-              <vt-rom-settings class="col-12" :rom="rom"></vt-rom-settings>
+              <vt-rom-settings
+                class="col-12"
+                :rom="rom"
+                @disallow-save-rom="disallowSaveRom"
+              ></vt-rom-settings>
             </div>
           </div>
         </div>
@@ -369,6 +374,7 @@ export default {
       gameLoaded: false,
       show_spoiler: false,
       tournament: false,
+      disableSaveRomButton: false,
       spoilers: "off"
     };
   },
@@ -408,6 +414,9 @@ export default {
       "setEnemyDamage",
       "setEnemyHealth"
     ]),
+    disallowSaveRom(e) {
+      this.disableSaveRomButton = Boolean(e);
+    },
     applyTournamentSeed() {
       this.tournament = true;
       this.spoilers = "off";

--- a/resources/js/vue-i18n-locales.generated.js
+++ b/resources/js/vue-i18n-locales.generated.js
@@ -221,6 +221,13 @@ export default {
                 }
             }
         },
+        "error": {
+            "title": "Fehler",
+            "429": "Auch wenn wir schätzen das du einen haufen Spiele generierst, andere Leute möchten dies aber auch. Bitte kommen später wieder wenn du mehr generieren möchtest.",
+            "failed_generation": "Fehler beim erstellen :(",
+            "bad_file": "Datei nicht erkannt",
+            "quota_exceeded_error": "Lokaler Cache Speicher ist voll."
+        },
         "enemizer": {
             "title": "Enemizer",
             "enable": "Aktiviere Enemizer",
@@ -255,6 +262,61 @@ export default {
             "palette_shuffle": "Palettenmischung",
             "pot_shuffle": "Topf mischen",
             "enemy_shuffle": "Gegner mischen"
+        },
+        "rom": {
+            "loader": {
+                "title": "Anfangen",
+                "file_select": "ROM Datei auswählen",
+                "content": "<ol><li>Wähle die Rom Datei und lade sie ihn den Browser (Bitte nutze die <strong>Zelda no Densetsu: Kamigami no Triforce v1.0</strong> ROM mit einer .smc oder .sfc Endung)</li><li>Wähle die <a href=\"/de/options\">Spieloptionen</a> um auszuwählen wie Zufällig dein Spiel sein soll</li><li>Klicke Generiere ROM für Rennen</li><li>Dann speichere deine Rom und fang an zu spielen</li></ol>"
+            },
+            "info": {
+                "spoilerwarning": "WARNUNG: Der Ersteller dieses Spiel hat den Spoiler Log angesehen.",
+                "mystery": "Dies ist ein geheimnissvolles Spiel. Die Einstellungen sind unbekannt und müssen beim Spielen herausgefunden werden!",
+                "logic": "Vorausgesetzte Glitches",
+                "accessibility": "Zugänglichkeit",
+                "build": "ROM build",
+                "difficulty": "Schwierigkeitsgrad",
+                "variation": "Variation",
+                "shuffle": "Entrance Shuffle",
+                "mode": "Zustand der Welt",
+                "weapons": "Schwerter",
+                "goal": "Ziel",
+                "permalink": "Permalink",
+                "special": "Spezial",
+                "notes": "Notizen",
+                "generated": "Erstellt"
+            },
+            "settings": {
+                "heart_speed": "Geschwindigkeit des Warnungston bei wenig Leben",
+                "heart_speeds": {
+                    "off": "Aus",
+                    "double": "Doppelte Geschwindigkeit",
+                    "normal": "Normale Geschwindigkeit",
+                    "half": "Halbe Geschwindigkeit",
+                    "quarter": "Viertel Geschwindigkeit"
+                },
+                "menu_speed": "Menü Geschwindigkeit",
+                "menu_speeds": {
+                    "instant": "Instant",
+                    "fast": "Schnell",
+                    "normal": "Normal",
+                    "slow": "Langsam"
+                },
+                "heart_color": "Farbe der Herzen",
+                "heart_colors": {
+                    "blue": "Blau",
+                    "green": "Grün",
+                    "red": "Rot",
+                    "yellow": "Gelb"
+                },
+                "play_as": "Spiele als",
+                "sprite_file_select": ".zspr Datei auswählen",
+                "music": "Hintergrundmusik",
+                "music_info": "(setze zu \"Keine\" für <a href=\"https://alttprlinks.page.link/SjiP\" target=\"_blank\" rel=\"noopener noreferrer\">MSU-1 Support</a>)",
+                "quickswap": "Gegenstand Schnellwechsel",
+                "palette_shuffle": "Palette Shuffle",
+                "race_warning": "Funktioniert nicht in einer Rom für Rennen"
+            }
         },
         "entrance": {
             "title": "Entrance Randomizer",
@@ -329,149 +391,6 @@ export default {
                 "save_spoiler": "Speichere Spoiler",
                 "save_rom": "Speichere Rom"
             }
-        },
-        "customizer": {
-            "settings": {
-                "timers": {
-                    "off": "Aus",
-                    "stopwatch": "Stoppuhr",
-                    "countdown-ohko": "Countdown OHKO",
-                    "countdown-continue": "Countdown fortführen",
-                    "countdown-stop": "Countdown stopp"
-                },
-                "dungeon_count": {
-                    "off": "Aus",
-                    "on": "Immer an",
-                    "pickup": "Beim aufheben des Kompass"
-                }
-            },
-            "glitches": {
-                "canBombJump": {
-                    "title": "Bomb Jump",
-                    "description": "Es kann vorausgesetz werden, dass man mit Bomben über Abgründe springt."
-                },
-                "canBootsClip": {
-                    "title": "Boots Clip",
-                    "description": "Wenn man die Pegasusstiefel besitzt könnte es vorausgesetz werden, dass man mit ihnen durch Wände clippt in der Overworld."
-                },
-                "canBunnyRevive": {
-                    "title": "Bunny Revive",
-                    "description": "Es kann vorausgesetz werden, dass man die Wiederbelebungs/Feenmechanik ausnutzt um Link zu werden ohne Mondperle in der Overworld."
-                },
-                "canBunnySurf": {
-                    "title": "Bunny Surf",
-                    "description": "Es kann vorausgesetz werden, dass man in der Hasenform auf dem Wassser läuft."
-                },
-                "canDungeonRevive": {
-                    "title": "Dungeon Revive",
-                    "description": "Es kann vorausgesetz werden, dass man die Wiederbelebungsmechanik nutzt um Link zu werden in einem Palast um Gegenstände aufzusammeln."
-                },
-                "canFakeFlipper": {
-                    "title": "Fake Flipper",
-                    "description": "Es kann vorausgesetz werden, dass man Fake Flipper nutzt um an gewissen Gegenstände zu kommen."
-                },
-                "canMirrorClip": {
-                    "title": "Mirror Clip",
-                    "description": "Es kann vorausgesetz werden, dass man Mirror Bounce ausnutzt um außerhalb der Spielwelt zu gelangen."
-                },
-                "canMirrorWrap": {
-                    "title": "Mirror Wrap",
-                    "description": "Es kann vorausgesetz werden, dass man den Spiegel nutzt um den Spielbildschirm zu scrollen damit man an einen anderen Ort kommt."
-                },
-                "canOneFrameClipOW": {
-                    "title": "One Frame Clip (overworld)",
-                    "description": "Du willst das hier nicht! Glaub mir."
-                },
-                "canOneFrameClipUW": {
-                    "title": "One Frame Clip (underworld)",
-                    "description": "Use 1 Frame Movement to clip between rooms of the underworld."
-                },
-                "canOWYBA": {
-                    "title": "YBA (overworld)",
-                    "description": "Es kann vorausgesetz werden, dass man Flaschen in der Overworld nutzt um damit an einen Ort zu telepotieren."
-                },
-                "canSuperBunny": {
-                    "title": "Super Bunny",
-                    "description": "Es kann vorausgesetz werden, dass man Super Bunny aktiviert um an gewisse Orte zu kommen."
-                },
-                "canSuperSpeed": {
-                    "title": "Super Speed",
-                    "description": "Es kann vorausgesetz werden, dass man Super Speed nutzt um durch die Ecken der Overworld durchzulaufen."
-                },
-                "canWaterFairyRevive": {
-                    "title": "Water Fairy Revive",
-                    "description": "Die vorbereitung hierfür ist einfach nur dumm und brauch viel zu viele Gegenstände."
-                },
-                "canWaterWalk": {
-                    "title": "Water walk",
-                    "description": "Es kann vorausgesetz werden, dass man auf Wasser läuft."
-                },
-                "noLogic": {
-                    "title": "Disable all logic checks",
-                    "description": "Wenn man diese Option aktiviert werden alle unteren Optionen ignoriert."
-                }
-            }
-        },
-        "rom": {
-            "loader": {
-                "title": "Anfangen",
-                "file_select": "ROM Datei auswählen",
-                "content": "<ol><li>Wähle die Rom Datei und lade sie ihn den Browser (Bitte nutze die <strong>Zelda no Densetsu: Kamigami no Triforce v1.0</strong> ROM mit einer .smc oder .sfc Endung)</li><li>Wähle die <a href=\"/de/options\">Spieloptionen</a> um auszuwählen wie Zufällig dein Spiel sein soll</li><li>Klicke Generiere ROM für Rennen</li><li>Dann speichere deine Rom und fang an zu spielen</li></ol>"
-            },
-            "info": {
-                "spoilerwarning": "WARNUNG: Der Ersteller dieses Spiel hat den Spoiler Log angesehen.",
-                "mystery": "Dies ist ein geheimnissvolles Spiel. Die Einstellungen sind unbekannt und müssen beim Spielen herausgefunden werden!",
-                "logic": "Vorausgesetzte Glitches",
-                "accessibility": "Zugänglichkeit",
-                "build": "ROM build",
-                "difficulty": "Schwierigkeitsgrad",
-                "variation": "Variation",
-                "shuffle": "Entrance Shuffle",
-                "mode": "Zustand der Welt",
-                "weapons": "Schwerter",
-                "goal": "Ziel",
-                "permalink": "Permalink",
-                "special": "Spezial",
-                "notes": "Notizen",
-                "generated": "Erstellt"
-            },
-            "settings": {
-                "heart_speed": "Geschwindigkeit des Warnungston bei wenig Leben",
-                "heart_speeds": {
-                    "off": "Aus",
-                    "double": "Doppelte Geschwindigkeit",
-                    "normal": "Normale Geschwindigkeit",
-                    "half": "Halbe Geschwindigkeit",
-                    "quarter": "Viertel Geschwindigkeit"
-                },
-                "menu_speed": "Menü Geschwindigkeit",
-                "menu_speeds": {
-                    "instant": "Instant",
-                    "fast": "Schnell",
-                    "normal": "Normal",
-                    "slow": "Langsam"
-                },
-                "heart_color": "Farbe der Herzen",
-                "heart_colors": {
-                    "blue": "Blau",
-                    "green": "Grün",
-                    "red": "Rot",
-                    "yellow": "Gelb"
-                },
-                "play_as": "Spiele als",
-                "music": "Hintergrundmusik",
-                "music_info": "(setze zu \"Keine\" für <a href=\"https://alttprlinks.page.link/SjiP\" target=\"_blank\" rel=\"noopener noreferrer\">MSU-1 Support</a>)",
-                "quickswap": "Gegenstand Schnellwechsel",
-                "palette_shuffle": "Palette Shuffle",
-                "race_warning": "Funktioniert nicht in einer Rom für Rennen"
-            }
-        },
-        "error": {
-            "title": "Fehler",
-            "429": "Auch wenn wir schätzen das du einen haufen Spiele generierst, andere Leute möchten dies aber auch. Bitte kommen später wieder wenn du mehr generieren möchtest.",
-            "failed_generation": "Fehler beim erstellen :(",
-            "bad_file": "Datei nicht erkannt",
-            "quota_exceeded_error": "Lokaler Cache Speicher ist voll."
         },
         "item": {
             "Random": "Zufällig",
@@ -688,409 +607,58 @@ export default {
             "Agahnim 2": "Agahnim 2",
             "Ganon": "Ganon",
             "Test": "Gegenstand fürs testen"
-        }
-    },
-    "en": {
-        "randomizer": {
-            "title": "Randomizer",
-            "preset": {
-                "title": "Select Preset",
-                "customize": "Customize",
-                "options": {
-                    "default": "Default",
-                    "beginner": "Beginner",
-                    "veetorp": "OWG (Veetorp’s Favorite)",
-                    "crosskeys": "Crosskeys",
-                    "quick": "Super Quick",
-                    "nightmare": "Nightmare",
-                    "custom": "Custom"
-                }
-            },
-            "placement": {
-                "title": "Item Placement"
-            },
-            "item_placement": {
-                "title": "Item Placement",
-                "options": {
-                    "basic": "Basic",
-                    "advanced": "Advanced"
-                }
-            },
-            "dungeon_items": {
-                "title": "Dungeon Item Shuffle",
-                "options": {
-                    "standard": "Standard",
-                    "mc": "Maps/Compasses",
-                    "mcs": "Maps/Compasses/Small Keys",
-                    "full": "Keysanity"
-                }
-            },
-            "accessibility": {
-                "title": "Accessibility",
-                "options": {
-                    "items": "100% Inventory",
-                    "locations": "100% Locations",
-                    "none": "Beatable"
-                }
-            },
-            "glitches_required": {
-                "title": "Glitches Required",
-                "options": {
-                    "none": "None",
-                    "overworld_glitches": "Overworld Glitches",
-                    "major_glitches": "Major Glitches",
-                    "no_logic": "No Logic"
-                },
-                "glitch_warning": "These settings require knowledge of Major Glitches<sup>**</sup>"
-            },
-            "goal": {
-                "title": "Goal",
-                "options": {
-                    "ganon": "Defeat Ganon",
-                    "fast_ganon": "Fast Ganon",
-                    "dungeons": "All Dungeons",
-                    "pedestal": "Master Sword Pedestal",
-                    "triforce-hunt": "Triforce Pieces"
-                }
-            },
-            "tower_open": {
-                "title": "Open Tower",
-                "options": {
-                    "0": "0 Crystals",
-                    "1": "1 Crystal",
-                    "2": "2 Crystals",
-                    "3": "3 Crystals",
-                    "4": "4 Crystals",
-                    "5": "5 Crystals",
-                    "6": "6 Crystals",
-                    "7": "7 Crystals",
-                    "random": "Random"
-                }
-            },
-            "ganon_open": {
-                "title": "Ganon Vulnerable",
-                "options": {
-                    "0": "0 Crystals",
-                    "1": "1 Crystal",
-                    "2": "2 Crystals",
-                    "3": "3 Crystals",
-                    "4": "4 Crystals",
-                    "5": "5 Crystals",
-                    "6": "6 Crystals",
-                    "7": "7 Crystals",
-                    "random": "Random"
-                }
-            },
-            "gameplay": {
-                "title": "Gameplay"
-            },
-            "world_state": {
-                "title": "World State",
-                "options": {
-                    "standard": "Standard",
-                    "open": "Open",
-                    "inverted": "Inverted",
-                    "retro": "Retro"
-                }
-            },
-            "entrance_shuffle": {
-                "title": "Entrance Shuffle",
-                "options": {
-                    "none": "None",
-                    "simple": "Simple",
-                    "restricted": "Restricted",
-                    "full": "Full",
-                    "crossed": "Crossed",
-                    "insanity": "Insanity"
-                }
-            },
-            "boss_shuffle": {
-                "title": "Boss Shuffle",
-                "options": {
-                    "none": "None",
-                    "simple": "Simple",
-                    "full": "Full",
-                    "random": "Random"
-                }
-            },
-            "enemy_shuffle": {
-                "title": "Enemy Shuffle",
-                "options": {
-                    "none": "None",
-                    "shuffled": "Shuffled",
-                    "random": "Random"
-                }
-            },
-            "hints": {
-                "title": "Hints",
-                "options": {
-                    "on": "On",
-                    "off": "Off"
-                }
-            },
-            "weapons": {
-                "title": "Swords",
-                "options": {
-                    "randomized": "Randomized",
-                    "assured": "Assured",
-                    "vanilla": "Vanilla",
-                    "swordless": "Swordless"
-                }
-            },
-            "item_pool": {
-                "title": "Item Pool",
-                "options": {
-                    "easy": "Easy",
-                    "normal": "Normal",
-                    "hard": "Hard",
-                    "expert": "Expert",
-                    "crowd_control": "Crowd Control"
-                },
-                "crowd_control_warning": "<sup>*</sup> This setting is meant to be used with the Crowd Control Twitch extension. find out more: <a href=\"https://crowdcontrol.live/\" target=\"_blank\" rel=”noopener noreferrer”>https://crowdcontrol.live/</a>"
-            },
-            "item_functionality": {
-                "title": "Item Functionality",
-                "options": {
-                    "easy": "Easy",
-                    "normal": "Normal",
-                    "hard": "Hard",
-                    "expert": "Expert"
-                }
-            },
-            "enemy_damage": {
-                "title": "Enemy Damage",
-                "options": {
-                    "default": "Default",
-                    "shuffled": "Shuffled",
-                    "random": "Random"
-                }
-            },
-            "enemy_health": {
-                "title": "Enemy Health",
-                "options": {
-                    "default": "Default",
-                    "easy": "Easy",
-                    "hard": "Hard",
-                    "expert": "Expert"
-                }
-            },
-            "spoiler": {
-                "title": "Spoilers",
-                "options": {
-                    "off": "Disabled",
-                    "on": "Enabled",
-                    "generate": "Only on Generate"
-                }
-            },
-            "generate": {
-                "race": "Generate Race ROM",
-                "race_warning": "Spoilers will <span class=\"running-now\">never</span> be available for this option.",
-                "spoiler_race": "Generate Normal ROM",
-                "back": "Change Settings",
-                "regenerate": "Generate Again",
-                "regenerate_tooltip": "Generate new game with same settings",
-                "generating": "Generating..."
-            },
-            "details": {
-                "title": "Game Details",
-                "save_spoiler": "Save Spoiler",
-                "save_rom": "Save Rom"
-            },
-            "variation": {
-                "title": "Variation"
-            },
-            "difficulty": {
-                "title": "Difficulty",
-                "options": {
-                    "easy": "Easy",
-                    "normal": "Normal",
-                    "hard": "Hard",
-                    "expert": "Expert",
-                    "insane": "Insane",
-                    "crowdControl": "Crowd Control"
-                }
-            }
-        },
-        "region": {
-            "all": "All Regions",
-            "Light World": "Light World",
-            "Hyrule Castle": "Hyrule Castle",
-            "Eastern Palace": "Eastern Palace",
-            "Desert Palace": "Desert Palace",
-            "Death Mountain": "Death Mountain",
-            "Tower Of Hera": "Tower Of Hera",
-            "Castle Tower": "Castle Tower",
-            "Dark World": "Dark World",
-            "Dark Palace": "Dark Palace",
-            "Swamp Palace": "Swamp Palace",
-            "Skull Woods": "Skull Woods",
-            "Thieves Town": "Thieves Town",
-            "Ice Palace": "Ice Palace",
-            "Misery Mire": "Misery Mire",
-            "Turtle Rock": "Turtle Rock",
-            "Ganons Tower": "Ganons Tower",
-            "Special": "Special"
-        },
-        "enemizer": {
-            "title": "Enemizer",
-            "enable": "Enable Enemizer",
-            "disable": "Disable Enemizer",
-            "enemy_health": {
-                "title": "Enemy Health",
-                "options": [
-                    "Default",
-                    "Easy (1-4 hp)",
-                    "Normal (2-15 hp)",
-                    "Hard (2-30 hp)",
-                    "Brick Wall (4-50 hp)"
-                ]
-            },
-            "enemy_damage": {
-                "title": "Enemy Damage",
-                "options": {
-                    "off": "Default",
-                    "shuffle": "Shuffled",
-                    "chaos": "Chaos"
-                }
-            },
-            "bosses": {
-                "title": "Boss Shuffle",
-                "options": {
-                    "off": "Off",
-                    "basic": "Simple",
-                    "normal": "Full",
-                    "chaos": "Chaos"
-                }
-            },
-            "palette_shuffle": "Palette Shuffle",
-            "pot_shuffle": "Pot Shuffle",
-            "enemy_shuffle": "Enemy Shuffle"
-        },
-        "entrance": {
-            "title": "Entrance Randomizer",
-            "switch": {
-                "item": "Switch to Item Randomizer"
-            },
-            "rom": {
-                "options": "ROM Options"
-            },
-            "difficulty": {
-                "title": "Difficulty",
-                "options": {
-                    "easy": "Easy",
-                    "normal": "Normal",
-                    "hard": "Hard",
-                    "expert": "Expert",
-                    "insane": "Insane"
-                }
-            },
-            "goal": {
-                "title": "Goal",
-                "options": {
-                    "ganon": "Defeat Ganon",
-                    "crystals": "Crystals",
-                    "dungeons": "All Dungeons",
-                    "pedestal": "Master Sword Pedestal",
-                    "triforcehunt": "Triforce Pieces"
-                }
-            },
-            "logic": {
-                "title": "Logic",
-                "options": {
-                    "NoGlitches": "No Glitches"
-                }
-            },
-            "mode": {
-                "title": "State",
-                "options": {
-                    "swordless": "Swordless",
-                    "open": "Open"
-                }
-            },
-            "shuffle": {
-                "title": "Shuffle",
-                "options": {
-                    "simple": "Simple",
-                    "restricted": "Restricted",
-                    "full": "Full",
-                    "crossed": "Crossed",
-                    "insanity": "Insanity"
-                }
-            },
-            "variation": {
-                "title": "Variation",
-                "options": {
-                    "none": "None",
-                    "timed-race": "Timed Race",
-                    "timed-ohko": "Timed OHKO",
-                    "ohko": "OHKO",
-                    "triforce-hunt": "Triforce Piece Hunt",
-                    "key-sanity": "Keysanity",
-                    "retro": "Retro"
-                }
-            },
-            "generate": {
-                "race": "Generate Race ROM",
-                "spoiler_race": "Spoiler Race ROM",
-                "casual": "Generate ROM"
-            },
-            "details": {
-                "title": "Game Details",
-                "save_spoiler": "Save Spoiler",
-                "save_rom": "Save Rom"
-            }
         },
         "customizer": {
             "settings": {
                 "timers": {
-                    "off": "Off",
-                    "stopwatch": "Stopwatch",
+                    "off": "Aus",
+                    "stopwatch": "Stoppuhr",
                     "countdown-ohko": "Countdown OHKO",
-                    "countdown-continue": "Countdown Continue",
-                    "countdown-stop": "Countdown Stop"
+                    "countdown-continue": "Countdown fortführen",
+                    "countdown-stop": "Countdown stopp"
                 },
                 "dungeon_count": {
-                    "off": "Off",
-                    "on": "Always On",
-                    "pickup": "On Compass Pickup"
+                    "off": "Aus",
+                    "on": "Immer an",
+                    "pickup": "Beim aufheben des Kompass"
                 }
             },
             "glitches": {
                 "canBombJump": {
                     "title": "Bomb Jump",
-                    "description": "One may be required to Bomb jump over gaps."
+                    "description": "Es kann vorausgesetz werden, dass man mit Bomben über Abgründe springt."
                 },
                 "canBootsClip": {
                     "title": "Boots Clip",
-                    "description": "When one has the Boots, they may be required to clip through walls in the overworld."
+                    "description": "Wenn man die Pegasusstiefel besitzt könnte es vorausgesetz werden, dass man mit ihnen durch Wände clippt in der Overworld."
                 },
                 "canBunnyRevive": {
                     "title": "Bunny Revive",
-                    "description": "One may be required to go somewhere in bunny form and abuse death/fairy revive to be Link."
+                    "description": "Es kann vorausgesetz werden, dass man die Wiederbelebungs/Feenmechanik ausnutzt um Link zu werden ohne Mondperle in der Overworld."
                 },
                 "canBunnySurf": {
                     "title": "Bunny Surf",
-                    "description": "One may be required to water walk in bunny state."
+                    "description": "Es kann vorausgesetz werden, dass man in der Hasenform auf dem Wassser läuft."
                 },
                 "canDungeonRevive": {
                     "title": "Dungeon Revive",
-                    "description": "One may be required to revive as a bunny in a dungeon to collect items as Link."
+                    "description": "Es kann vorausgesetz werden, dass man die Wiederbelebungsmechanik nutzt um Link zu werden in einem Palast um Gegenstände aufzusammeln."
                 },
                 "canFakeFlipper": {
                     "title": "Fake Flipper",
-                    "description": "One may be required to use the fake flipper glitch to collect items."
+                    "description": "Es kann vorausgesetz werden, dass man Fake Flipper nutzt um an gewissen Gegenstände zu kommen."
                 },
                 "canMirrorClip": {
                     "title": "Mirror Clip",
-                    "description": "One may be required to abuse Mirror Portal Placements to go out of bounds."
+                    "description": "Es kann vorausgesetz werden, dass man Mirror Bounce ausnutzt um außerhalb der Spielwelt zu gelangen."
                 },
                 "canMirrorWrap": {
                     "title": "Mirror Wrap",
-                    "description": "One may be required to use Mirror to auto scroll to a different location."
+                    "description": "Es kann vorausgesetz werden, dass man den Spiegel nutzt um den Spielbildschirm zu scrollen damit man an einen anderen Ort kommt."
                 },
                 "canOneFrameClipOW": {
                     "title": "One Frame Clip (overworld)",
-                    "description": "You don’t want this. Trust me."
+                    "description": "Du willst das hier nicht! Glaub mir."
                 },
                 "canOneFrameClipUW": {
                     "title": "One Frame Clip (underworld)",
@@ -1098,88 +666,32 @@ export default {
                 },
                 "canOWYBA": {
                     "title": "YBA (overworld)",
-                    "description": "May be required to use bottles in the overworld to teleport to different locations."
+                    "description": "Es kann vorausgesetz werden, dass man Flaschen in der Overworld nutzt um damit an einen Ort zu telepotieren."
                 },
                 "canSuperBunny": {
                     "title": "Super Bunny",
-                    "description": "One may be required to activate super bunny to access locations."
+                    "description": "Es kann vorausgesetz werden, dass man Super Bunny aktiviert um an gewisse Orte zu kommen."
                 },
                 "canSuperSpeed": {
-                    "title": "Super Speed Clip",
-                    "description": "One may be required to super speed clip through edges in the overworld."
+                    "title": "Super Speed",
+                    "description": "Es kann vorausgesetz werden, dass man Super Speed nutzt um durch die Ecken der Overworld durchzulaufen."
                 },
                 "canWaterFairyRevive": {
                     "title": "Water Fairy Revive",
-                    "description": "This setup is silly and requires a bunch of items."
+                    "description": "Die vorbereitung hierfür ist einfach nur dumm und brauch viel zu viele Gegenstände."
                 },
                 "canWaterWalk": {
                     "title": "Water walk",
-                    "description": "One may be required to use boots to walk on top of water."
+                    "description": "Es kann vorausgesetz werden, dass man auf Wasser läuft."
                 },
                 "noLogic": {
                     "title": "Disable all logic checks",
-                    "description": "When this is selected all bets are off, and nothing below matters."
-                },
-                "logicMode": {
-                    "title": "Glitches Required Rom \"Fixes\"",
-                    "description": "Set the type of rom fixes applied.  Does not change item placement logic."
+                    "description": "Wenn man diese Option aktiviert werden alle unteren Optionen ignoriert."
                 }
             }
-        },
-        "rom": {
-            "loader": {
-                "title": "Getting Started",
-                "file_select": "Select ROM File",
-                "content": "<ol><li>Select your rom file and load it into the browser (Please use a <strong>Zelda no Densetsu: Kamigami no Triforce v1.0</strong> ROM with an .smc or .sfc extension)</li><li>Select the <a href=\"/en/options\">Game Options</a> for how you would like your game randomized</li><li>Click Generate Normal ROM</li><li>Then Save your rom and get to playing</li></ol>"
-            },
-            "info": {
-                "spoilerwarning": "WARNING: The generator of this game viewed the spoiler log.",
-                "mystery": "This is a mystery game.  The settings must be discovered while you play!",
-                "logic": "Glitches Required",
-                "accessibility": "Accessibility",
-                "build": "ROM build",
-                "difficulty": "Difficulty",
-                "variation": "Variation",
-                "shuffle": "Entrance Shuffle",
-                "mode": "World State",
-                "weapons": "Swords",
-                "goal": "Goal",
-                "permalink": "Permalink",
-                "special": "Special",
-                "notes": "Notes",
-                "generated": "Created"
-            },
-            "settings": {
-                "heart_speed": "Heart Speed",
-                "heart_speeds": {
-                    "off": "Off",
-                    "double": "Double Speed",
-                    "normal": "Normal Speed",
-                    "half": "Half Speed",
-                    "quarter": "Quarter Speed"
-                },
-                "menu_speed": "Menu Speed",
-                "menu_speeds": {
-                    "instant": "Instant",
-                    "fast": "Fast",
-                    "normal": "Normal",
-                    "slow": "Slow"
-                },
-                "heart_color": "Heart Color",
-                "heart_colors": {
-                    "blue": "Blue",
-                    "green": "Green",
-                    "red": "Red",
-                    "yellow": "Yellow"
-                },
-                "play_as": "Play As",
-                "music": "Background Music",
-                "music_info": "(set to \"No\" for <a href=\"https://alttprlinks.page.link/SjiP\" target=\"_blank\" rel=\"noopener noreferrer\">MSU-1 support</a>)",
-                "quickswap": "Item Quickswap",
-                "palette_shuffle": "Palette Shuffle",
-                "race_warning": "Does not work in Race Roms"
-            }
-        },
+        }
+    },
+    "en": {
         "sprite": {
             "Raven": "Raven",
             "Vulture": "Vulture",
@@ -1426,9 +938,225 @@ export default {
             "SomariaPlatform3": "Cane of Somaria Platform (Unused)",
             "MedallionTablet": "Medallion Tablet"
         },
-        "multiworld": {
-            "title": "Multiworld Randomizer",
-            "generate": "Generate Multiworld Data File"
+        "randomizer": {
+            "title": "Randomizer",
+            "preset": {
+                "title": "Select Preset",
+                "customize": "Customize",
+                "options": {
+                    "default": "Default",
+                    "beginner": "Beginner",
+                    "veetorp": "OWG (Veetorp’s Favorite)",
+                    "crosskeys": "Crosskeys",
+                    "quick": "Super Quick",
+                    "nightmare": "Nightmare",
+                    "custom": "Custom"
+                }
+            },
+            "placement": {
+                "title": "Item Placement"
+            },
+            "item_placement": {
+                "title": "Item Placement",
+                "options": {
+                    "basic": "Basic",
+                    "advanced": "Advanced"
+                }
+            },
+            "dungeon_items": {
+                "title": "Dungeon Item Shuffle",
+                "options": {
+                    "standard": "Standard",
+                    "mc": "Maps/Compasses",
+                    "mcs": "Maps/Compasses/Small Keys",
+                    "full": "Keysanity"
+                }
+            },
+            "accessibility": {
+                "title": "Accessibility",
+                "options": {
+                    "items": "100% Inventory",
+                    "locations": "100% Locations",
+                    "none": "Beatable"
+                }
+            },
+            "glitches_required": {
+                "title": "Glitches Required",
+                "options": {
+                    "none": "None",
+                    "overworld_glitches": "Overworld Glitches",
+                    "major_glitches": "Major Glitches",
+                    "no_logic": "No Logic"
+                },
+                "glitch_warning": "These settings require knowledge of Major Glitches<sup>**</sup>"
+            },
+            "goal": {
+                "title": "Goal",
+                "options": {
+                    "ganon": "Defeat Ganon",
+                    "fast_ganon": "Fast Ganon",
+                    "dungeons": "All Dungeons",
+                    "pedestal": "Master Sword Pedestal",
+                    "triforce-hunt": "Triforce Pieces"
+                }
+            },
+            "tower_open": {
+                "title": "Open Tower",
+                "options": {
+                    "0": "0 Crystals",
+                    "1": "1 Crystal",
+                    "2": "2 Crystals",
+                    "3": "3 Crystals",
+                    "4": "4 Crystals",
+                    "5": "5 Crystals",
+                    "6": "6 Crystals",
+                    "7": "7 Crystals",
+                    "random": "Random"
+                }
+            },
+            "ganon_open": {
+                "title": "Ganon Vulnerable",
+                "options": {
+                    "0": "0 Crystals",
+                    "1": "1 Crystal",
+                    "2": "2 Crystals",
+                    "3": "3 Crystals",
+                    "4": "4 Crystals",
+                    "5": "5 Crystals",
+                    "6": "6 Crystals",
+                    "7": "7 Crystals",
+                    "random": "Random"
+                }
+            },
+            "gameplay": {
+                "title": "Gameplay"
+            },
+            "world_state": {
+                "title": "World State",
+                "options": {
+                    "standard": "Standard",
+                    "open": "Open",
+                    "inverted": "Inverted",
+                    "retro": "Retro"
+                }
+            },
+            "entrance_shuffle": {
+                "title": "Entrance Shuffle",
+                "options": {
+                    "none": "None",
+                    "simple": "Simple",
+                    "restricted": "Restricted",
+                    "full": "Full",
+                    "crossed": "Crossed",
+                    "insanity": "Insanity"
+                }
+            },
+            "boss_shuffle": {
+                "title": "Boss Shuffle",
+                "options": {
+                    "none": "None",
+                    "simple": "Simple",
+                    "full": "Full",
+                    "random": "Random"
+                }
+            },
+            "enemy_shuffle": {
+                "title": "Enemy Shuffle",
+                "options": {
+                    "none": "None",
+                    "shuffled": "Shuffled",
+                    "random": "Random"
+                }
+            },
+            "hints": {
+                "title": "Hints",
+                "options": {
+                    "on": "On",
+                    "off": "Off"
+                }
+            },
+            "weapons": {
+                "title": "Swords",
+                "options": {
+                    "randomized": "Randomized",
+                    "assured": "Assured",
+                    "vanilla": "Vanilla",
+                    "swordless": "Swordless"
+                }
+            },
+            "item_pool": {
+                "title": "Item Pool",
+                "options": {
+                    "easy": "Easy",
+                    "normal": "Normal",
+                    "hard": "Hard",
+                    "expert": "Expert",
+                    "crowd_control": "Crowd Control"
+                },
+                "crowd_control_warning": "<sup>*</sup> This setting is meant to be used with the Crowd Control Twitch extension. find out more: <a href=\"https://crowdcontrol.live/\" target=\"_blank\" rel=”noopener noreferrer”>https://crowdcontrol.live/</a>"
+            },
+            "item_functionality": {
+                "title": "Item Functionality",
+                "options": {
+                    "easy": "Easy",
+                    "normal": "Normal",
+                    "hard": "Hard",
+                    "expert": "Expert"
+                }
+            },
+            "enemy_damage": {
+                "title": "Enemy Damage",
+                "options": {
+                    "default": "Default",
+                    "shuffled": "Shuffled",
+                    "random": "Random"
+                }
+            },
+            "enemy_health": {
+                "title": "Enemy Health",
+                "options": {
+                    "default": "Default",
+                    "easy": "Easy",
+                    "hard": "Hard",
+                    "expert": "Expert"
+                }
+            },
+            "spoiler": {
+                "title": "Spoilers",
+                "options": {
+                    "off": "Disabled",
+                    "on": "Enabled",
+                    "generate": "Only on Generate"
+                }
+            },
+            "generate": {
+                "race": "Generate Race ROM",
+                "race_warning": "Spoilers will <span class=\"running-now\">never</span> be available for this option.",
+                "spoiler_race": "Generate Normal ROM",
+                "back": "Change Settings",
+                "regenerate": "Generate Again",
+                "regenerate_tooltip": "Generate new game with same settings",
+                "generating": "Generating..."
+            },
+            "details": {
+                "title": "Game Details",
+                "save_spoiler": "Save Spoiler",
+                "save_rom": "Save Rom"
+            },
+            "variation": {
+                "title": "Variation"
+            },
+            "difficulty": {
+                "title": "Difficulty",
+                "options": {
+                    "easy": "Easy",
+                    "normal": "Normal",
+                    "hard": "Hard",
+                    "expert": "Expert",
+                    "insane": "Insane",
+                    "crowdControl": "Crowd Control"
+                }
+            }
         },
         "error": {
             "title": "Error",
@@ -1436,6 +1164,194 @@ export default {
             "failed_generation": "Failed Creating Game :(",
             "bad_file": "File not recognized",
             "quota_exceeded_error": "Your local storage quota has been exceeded."
+        },
+        "enemizer": {
+            "title": "Enemizer",
+            "enable": "Enable Enemizer",
+            "disable": "Disable Enemizer",
+            "enemy_health": {
+                "title": "Enemy Health",
+                "options": [
+                    "Default",
+                    "Easy (1-4 hp)",
+                    "Normal (2-15 hp)",
+                    "Hard (2-30 hp)",
+                    "Brick Wall (4-50 hp)"
+                ]
+            },
+            "enemy_damage": {
+                "title": "Enemy Damage",
+                "options": {
+                    "off": "Default",
+                    "shuffle": "Shuffled",
+                    "chaos": "Chaos"
+                }
+            },
+            "bosses": {
+                "title": "Boss Shuffle",
+                "options": {
+                    "off": "Off",
+                    "basic": "Simple",
+                    "normal": "Full",
+                    "chaos": "Chaos"
+                }
+            },
+            "palette_shuffle": "Palette Shuffle",
+            "pot_shuffle": "Pot Shuffle",
+            "enemy_shuffle": "Enemy Shuffle"
+        },
+        "rom": {
+            "loader": {
+                "title": "Getting Started",
+                "file_select": "Select ROM File",
+                "content": "<ol><li>Select your rom file and load it into the browser (Please use a <strong>Zelda no Densetsu: Kamigami no Triforce v1.0</strong> ROM with an .smc or .sfc extension)</li><li>Select the <a href=\"/en/options\">Game Options</a> for how you would like your game randomized</li><li>Click Generate Normal ROM</li><li>Then Save your rom and get to playing</li></ol>"
+            },
+            "info": {
+                "spoilerwarning": "WARNING: The generator of this game viewed the spoiler log.",
+                "mystery": "This is a mystery game.  The settings must be discovered while you play!",
+                "logic": "Glitches Required",
+                "accessibility": "Accessibility",
+                "build": "ROM build",
+                "difficulty": "Difficulty",
+                "variation": "Variation",
+                "shuffle": "Entrance Shuffle",
+                "mode": "World State",
+                "weapons": "Swords",
+                "goal": "Goal",
+                "permalink": "Permalink",
+                "special": "Special",
+                "notes": "Notes",
+                "generated": "Created"
+            },
+            "settings": {
+                "heart_speed": "Heart Speed",
+                "heart_speeds": {
+                    "off": "Off",
+                    "double": "Double Speed",
+                    "normal": "Normal Speed",
+                    "half": "Half Speed",
+                    "quarter": "Quarter Speed"
+                },
+                "menu_speed": "Menu Speed",
+                "menu_speeds": {
+                    "instant": "Instant",
+                    "fast": "Fast",
+                    "normal": "Normal",
+                    "slow": "Slow"
+                },
+                "heart_color": "Heart Color",
+                "heart_colors": {
+                    "blue": "Blue",
+                    "green": "Green",
+                    "red": "Red",
+                    "yellow": "Yellow"
+                },
+                "play_as": "Play As",
+                "sprite_file_select": "Select .zspr File",
+                "music": "Background Music",
+                "music_info": "(set to \"No\" for <a href=\"https://alttprlinks.page.link/SjiP\" target=\"_blank\" rel=\"noopener noreferrer\">MSU-1 support</a>)",
+                "quickswap": "Item Quickswap",
+                "palette_shuffle": "Palette Shuffle",
+                "race_warning": "Does not work in Race Roms"
+            }
+        },
+        "multiworld": {
+            "title": "Multiworld Randomizer",
+            "generate": "Generate Multiworld Data File"
+        },
+        "region": {
+            "all": "All Regions",
+            "Light World": "Light World",
+            "Hyrule Castle": "Hyrule Castle",
+            "Eastern Palace": "Eastern Palace",
+            "Desert Palace": "Desert Palace",
+            "Death Mountain": "Death Mountain",
+            "Tower Of Hera": "Tower Of Hera",
+            "Castle Tower": "Castle Tower",
+            "Dark World": "Dark World",
+            "Dark Palace": "Dark Palace",
+            "Swamp Palace": "Swamp Palace",
+            "Skull Woods": "Skull Woods",
+            "Thieves Town": "Thieves Town",
+            "Ice Palace": "Ice Palace",
+            "Misery Mire": "Misery Mire",
+            "Turtle Rock": "Turtle Rock",
+            "Ganons Tower": "Ganons Tower",
+            "Special": "Special"
+        },
+        "entrance": {
+            "title": "Entrance Randomizer",
+            "switch": {
+                "item": "Switch to Item Randomizer"
+            },
+            "rom": {
+                "options": "ROM Options"
+            },
+            "difficulty": {
+                "title": "Difficulty",
+                "options": {
+                    "easy": "Easy",
+                    "normal": "Normal",
+                    "hard": "Hard",
+                    "expert": "Expert",
+                    "insane": "Insane"
+                }
+            },
+            "goal": {
+                "title": "Goal",
+                "options": {
+                    "ganon": "Defeat Ganon",
+                    "crystals": "Crystals",
+                    "dungeons": "All Dungeons",
+                    "pedestal": "Master Sword Pedestal",
+                    "triforcehunt": "Triforce Pieces"
+                }
+            },
+            "logic": {
+                "title": "Logic",
+                "options": {
+                    "NoGlitches": "No Glitches"
+                }
+            },
+            "mode": {
+                "title": "State",
+                "options": {
+                    "swordless": "Swordless",
+                    "open": "Open"
+                }
+            },
+            "shuffle": {
+                "title": "Shuffle",
+                "options": {
+                    "simple": "Simple",
+                    "restricted": "Restricted",
+                    "full": "Full",
+                    "crossed": "Crossed",
+                    "insanity": "Insanity"
+                }
+            },
+            "variation": {
+                "title": "Variation",
+                "options": {
+                    "none": "None",
+                    "timed-race": "Timed Race",
+                    "timed-ohko": "Timed OHKO",
+                    "ohko": "OHKO",
+                    "triforce-hunt": "Triforce Piece Hunt",
+                    "key-sanity": "Keysanity",
+                    "retro": "Retro"
+                }
+            },
+            "generate": {
+                "race": "Generate Race ROM",
+                "spoiler_race": "Spoiler Race ROM",
+                "casual": "Generate ROM"
+            },
+            "details": {
+                "title": "Game Details",
+                "save_spoiler": "Save Spoiler",
+                "save_rom": "Save Rom"
+            }
         },
         "item": {
             "Random": "Random",
@@ -1653,6 +1569,92 @@ export default {
             "Agahnim 2": "Agahnim 2",
             "Ganon": "Ganon",
             "Test": "Testing Item"
+        },
+        "customizer": {
+            "settings": {
+                "timers": {
+                    "off": "Off",
+                    "stopwatch": "Stopwatch",
+                    "countdown-ohko": "Countdown OHKO",
+                    "countdown-continue": "Countdown Continue",
+                    "countdown-stop": "Countdown Stop"
+                },
+                "dungeon_count": {
+                    "off": "Off",
+                    "on": "Always On",
+                    "pickup": "On Compass Pickup"
+                }
+            },
+            "glitches": {
+                "canBombJump": {
+                    "title": "Bomb Jump",
+                    "description": "One may be required to Bomb jump over gaps."
+                },
+                "canBootsClip": {
+                    "title": "Boots Clip",
+                    "description": "When one has the Boots, they may be required to clip through walls in the overworld."
+                },
+                "canBunnyRevive": {
+                    "title": "Bunny Revive",
+                    "description": "One may be required to go somewhere in bunny form and abuse death/fairy revive to be Link."
+                },
+                "canBunnySurf": {
+                    "title": "Bunny Surf",
+                    "description": "One may be required to water walk in bunny state."
+                },
+                "canDungeonRevive": {
+                    "title": "Dungeon Revive",
+                    "description": "One may be required to revive as a bunny in a dungeon to collect items as Link."
+                },
+                "canFakeFlipper": {
+                    "title": "Fake Flipper",
+                    "description": "One may be required to use the fake flipper glitch to collect items."
+                },
+                "canMirrorClip": {
+                    "title": "Mirror Clip",
+                    "description": "One may be required to abuse Mirror Portal Placements to go out of bounds."
+                },
+                "canMirrorWrap": {
+                    "title": "Mirror Wrap",
+                    "description": "One may be required to use Mirror to auto scroll to a different location."
+                },
+                "canOneFrameClipOW": {
+                    "title": "One Frame Clip (overworld)",
+                    "description": "You don’t want this. Trust me."
+                },
+                "canOneFrameClipUW": {
+                    "title": "One Frame Clip (underworld)",
+                    "description": "Use 1 Frame Movement to clip between rooms of the underworld."
+                },
+                "canOWYBA": {
+                    "title": "YBA (overworld)",
+                    "description": "May be required to use bottles in the overworld to teleport to different locations."
+                },
+                "canSuperBunny": {
+                    "title": "Super Bunny",
+                    "description": "One may be required to activate super bunny to access locations."
+                },
+                "canSuperSpeed": {
+                    "title": "Super Speed Clip",
+                    "description": "One may be required to super speed clip through edges in the overworld."
+                },
+                "canWaterFairyRevive": {
+                    "title": "Water Fairy Revive",
+                    "description": "This setup is silly and requires a bunch of items."
+                },
+                "canWaterWalk": {
+                    "title": "Water walk",
+                    "description": "One may be required to use boots to walk on top of water."
+                },
+                "noLogic": {
+                    "title": "Disable all logic checks",
+                    "description": "When this is selected all bets are off, and nothing below matters."
+                },
+                "logicMode": {
+                    "title": "Glitches Required Rom \"Fixes\"",
+                    "description": "Set the type of rom fixes applied.  Does not change item placement logic."
+                }
+            }
         }
     },
     "es": {
@@ -1876,6 +1878,13 @@ export default {
                 }
             }
         },
+        "error": {
+            "title": "Error",
+            "429": "Aunque apreciamos que quieras generar un montón de partidas, otras personas quieren hacerlo también. Por favor, vuelve más tarde si quieres generar más.",
+            "failed_generation": "Error creando la semilla :(",
+            "bad_file": "Archivo no reconocido",
+            "quota_exceeded_error": "Has sobrepasado tu cuota de almacenamiento local."
+        },
         "enemizer": {
             "title": "Randomizer de enemigos (Enemizer)",
             "enable": "Activar Enemizer",
@@ -1910,6 +1919,61 @@ export default {
             "palette_shuffle": "Paleta aleatoria",
             "pot_shuffle": "Vasijas aleatorias",
             "enemy_shuffle": "Enemigos aleatorios"
+        },
+        "rom": {
+            "loader": {
+                "title": "Empezar a Jugar",
+                "file_select": "Selecciona archivo ROM",
+                "content": "<ol><li>Selecciona tu archivo ROM y cárgalo en tu navegador (Por favor, usa una ROM <strong>Zelda no Densetsu: Kamigami no Triforce v1.0</strong> con extensión .smc o .sfc)</li><li>Selecciona las <a href=\"/en/options\">Opciones de Juego</a> para cómo quieres que tu juego sea randomizado</li><li>Haz click en Generar ROM para carreras</li><li>Guarda tu ROM y ponte a jugar</li></ol>"
+            },
+            "info": {
+                "spoilerwarning": "ADVERTENCIA: El generador de este juego ha visto el registro de spoiler.",
+                "mystery": "Este es un juego de misterios. Debes descubrir las configuraciones mientras lo juegas!",
+                "logic": "Glitches Requeridos",
+                "accessibility": "Accesibilidad",
+                "build": "Build de la ROM",
+                "difficulty": "Dificultad",
+                "variation": "Variación",
+                "shuffle": "Randomizer de entradas",
+                "mode": "Estado del mundo",
+                "weapons": "Espadas",
+                "goal": "Objetivo",
+                "permalink": "Enlace permanente",
+                "special": "Especial",
+                "notes": "Notas",
+                "generated": "Creada"
+            },
+            "settings": {
+                "heart_speed": "Velocidad de Corazones",
+                "heart_speeds": {
+                    "off": "Desactivado",
+                    "double": "Velocidad Doble",
+                    "normal": "Velocidad Normal",
+                    "half": "Media Velocidad",
+                    "quarter": "Cuarto de Velocidad"
+                },
+                "menu_speed": "Velocidad de Menú",
+                "menu_speeds": {
+                    "instant": "Instantáneo",
+                    "fast": "Rápido",
+                    "normal": "Normal",
+                    "slow": "Lento"
+                },
+                "heart_color": "Color de Corazones",
+                "heart_colors": {
+                    "blue": "Azul",
+                    "green": "Verde",
+                    "red": "Rojo",
+                    "yellow": "Amarillo"
+                },
+                "play_as": "Jugar Como",
+                "sprite_file_select": "Selecciona archivo .zspr",
+                "music": "Música de fondo",
+                "music_info": "(poner en \"No\" para <a href=\"https://alttprlinks.page.link/SjiP\" target=\"_blank\" rel=\"noopener noreferrer\">soporte con MSU-1</a>)",
+                "quickswap": "Cambio Rápido de Objetos",
+                "palette_shuffle": "Paletas aleatorias",
+                "race_warning": "No funciona en ROMs para carreras"
+            }
         },
         "entrance": {
             "title": "Randomizer de Entradas",
@@ -1984,149 +2048,6 @@ export default {
                 "save_spoiler": "Guardar spoiler",
                 "save_rom": "Guardar ROM"
             }
-        },
-        "customizer": {
-            "settings": {
-                "timers": {
-                    "off": "Sin temporizador",
-                    "stopwatch": "Cronómetro",
-                    "countdown-ohko": "Cuenta atrás (muerte súbita)",
-                    "countdown-continue": "Cuenta atrás (continua)",
-                    "countdown-stop": "Cuenta atrás (para)"
-                },
-                "dungeon_count": {
-                    "off": "Desactivado",
-                    "on": "Siempre visible",
-                    "pickup": "Visible con brújula"
-                }
-            },
-            "glitches": {
-                "canBombJump": {
-                    "title": "Salto Bomba",
-                    "description": "Podría ser necesario tener que hacer Saltos Bomba para atravesar agujeros."
-                },
-                "canBootsClip": {
-                    "title": "Clips de Botas",
-                    "description": "Cuando se tengan las botas, podría ser necesario hacer <i>clips</i> a través de paredes de la superfície."
-                },
-                "canBunnyRevive": {
-                    "title": "Reanimación como Conejo",
-                    "description": "Podría ser necesario ir a algún sitio como conejo y abusar de morir o revivir con hadas para ser Link."
-                },
-                "canBunnySurf": {
-                    "title": "Surf como Conejo",
-                    "description": "Podría ser necesario andar sobre el agua en estado de conejo."
-                },
-                "canDungeonRevive": {
-                    "title": "Reanimación en Mazmorras",
-                    "description": "Podría ser necesario revivir como conejo en una mazmorra para conseguir objetos como Link."
-                },
-                "canFakeFlipper": {
-                    "title": "Aletas Falsas",
-                    "description": "Podría ser necesario usar el glitch de las Aletas Falsas para conseguir objetos."
-                },
-                "canMirrorClip": {
-                    "title": "Clips de Espejo",
-                    "description": "Podría ser necesario abusar la animación del espejo para salir del mapa."
-                },
-                "canMirrorWrap": {
-                    "title": "Mirror Wrap",
-                    "description": "Podría ser necesario usar el Espejo para hacer <i>scroll</i> automático a otro sitio."
-                },
-                "canOneFrameClipOW": {
-                    "title": "Clip de un frame (superfície)",
-                    "description": "Créeme, no quieres hacer esto."
-                },
-                "canOneFrameClipUW": {
-                    "title": "One Frame Clip (underworld)",
-                    "description": "Use 1 Frame Movement to clip between rooms of the underworld."
-                },
-                "canOWYBA": {
-                    "title": "YBA (superfície)",
-                    "description": "Podría ser necesario usar botellas en la superfície para teletransportarse a otras localizaciones."
-                },
-                "canSuperBunny": {
-                    "title": "Súper Conejo",
-                    "description": "Podría ser necesario activar el estado de súper conejo para acceder algunas localizaciones."
-                },
-                "canSuperSpeed": {
-                    "title": "Súper Velocidad",
-                    "description": "Podría ser necesario hacer <i>clips</i> con súper velocidad a través de esquinas de la superfície."
-                },
-                "canWaterFairyRevive": {
-                    "title": "Reanimación en el Agua con Hadas",
-                    "description": "Este <i>setup</i> es estúpido y requiere un montón de objetos."
-                },
-                "canWaterWalk": {
-                    "title": "Andar por el Agua",
-                    "description": "Podría ser necesario utilizar las Botas para andar sobre el agua."
-                },
-                "noLogic": {
-                    "title": "Desactivar todas las comprobaciones de lógica",
-                    "description": "Cuando esto está activado, todas las garantías desaparecen, y nada de lo que hay aquí importa."
-                }
-            }
-        },
-        "rom": {
-            "loader": {
-                "title": "Empezar a Jugar",
-                "file_select": "Selecciona archivo ROM",
-                "content": "<ol><li>Selecciona tu archivo ROM y cárgalo en tu navegador (Por favor, usa una ROM <strong>Zelda no Densetsu: Kamigami no Triforce v1.0</strong> con extensión .smc o .sfc)</li><li>Selecciona las <a href=\"/en/options\">Opciones de Juego</a> para cómo quieres que tu juego sea randomizado</li><li>Haz click en Generar ROM para carreras</li><li>Guarda tu ROM y ponte a jugar</li></ol>"
-            },
-            "info": {
-                "spoilerwarning": "ADVERTENCIA: El generador de este juego ha visto el registro de spoiler.",
-                "mystery": "Este es un juego de misterios. Debes descubrir las configuraciones mientras lo juegas!",
-                "logic": "Glitches Requeridos",
-                "accessibility": "Accesibilidad",
-                "build": "Build de la ROM",
-                "difficulty": "Dificultad",
-                "variation": "Variación",
-                "shuffle": "Randomizer de entradas",
-                "mode": "Estado del mundo",
-                "weapons": "Espadas",
-                "goal": "Objetivo",
-                "permalink": "Enlace permanente",
-                "special": "Especial",
-                "notes": "Notas",
-                "generated": "Creada"
-            },
-            "settings": {
-                "heart_speed": "Velocidad de Corazones",
-                "heart_speeds": {
-                    "off": "Desactivado",
-                    "double": "Velocidad Doble",
-                    "normal": "Velocidad Normal",
-                    "half": "Media Velocidad",
-                    "quarter": "Cuarto de Velocidad"
-                },
-                "menu_speed": "Velocidad de Menú",
-                "menu_speeds": {
-                    "instant": "Instantáneo",
-                    "fast": "Rápido",
-                    "normal": "Normal",
-                    "slow": "Lento"
-                },
-                "heart_color": "Color de Corazones",
-                "heart_colors": {
-                    "blue": "Azul",
-                    "green": "Verde",
-                    "red": "Rojo",
-                    "yellow": "Amarillo"
-                },
-                "play_as": "Jugar Como",
-                "music": "Música de fondo",
-                "music_info": "(poner en \"No\" para <a href=\"https://alttprlinks.page.link/SjiP\" target=\"_blank\" rel=\"noopener noreferrer\">soporte con MSU-1</a>)",
-                "quickswap": "Cambio Rápido de Objetos",
-                "palette_shuffle": "Paletas aleatorias",
-                "race_warning": "No funciona en ROMs para carreras"
-            }
-        },
-        "error": {
-            "title": "Error",
-            "429": "Aunque apreciamos que quieras generar un montón de partidas, otras personas quieren hacerlo también. Por favor, vuelve más tarde si quieres generar más.",
-            "failed_generation": "Error creando la semilla :(",
-            "bad_file": "Archivo no reconocido",
-            "quota_exceeded_error": "Has sobrepasado tu cuota de almacenamiento local."
         },
         "item": {
             "Random": "Aleatorio",
@@ -2343,6 +2264,88 @@ export default {
             "Agahnim": "Agahnim",
             "Agahnim 2": "Agahnim 2",
             "Ganon": "Ganon"
+        },
+        "customizer": {
+            "settings": {
+                "timers": {
+                    "off": "Sin temporizador",
+                    "stopwatch": "Cronómetro",
+                    "countdown-ohko": "Cuenta atrás (muerte súbita)",
+                    "countdown-continue": "Cuenta atrás (continua)",
+                    "countdown-stop": "Cuenta atrás (para)"
+                },
+                "dungeon_count": {
+                    "off": "Desactivado",
+                    "on": "Siempre visible",
+                    "pickup": "Visible con brújula"
+                }
+            },
+            "glitches": {
+                "canBombJump": {
+                    "title": "Salto Bomba",
+                    "description": "Podría ser necesario tener que hacer Saltos Bomba para atravesar agujeros."
+                },
+                "canBootsClip": {
+                    "title": "Clips de Botas",
+                    "description": "Cuando se tengan las botas, podría ser necesario hacer <i>clips</i> a través de paredes de la superfície."
+                },
+                "canBunnyRevive": {
+                    "title": "Reanimación como Conejo",
+                    "description": "Podría ser necesario ir a algún sitio como conejo y abusar de morir o revivir con hadas para ser Link."
+                },
+                "canBunnySurf": {
+                    "title": "Surf como Conejo",
+                    "description": "Podría ser necesario andar sobre el agua en estado de conejo."
+                },
+                "canDungeonRevive": {
+                    "title": "Reanimación en Mazmorras",
+                    "description": "Podría ser necesario revivir como conejo en una mazmorra para conseguir objetos como Link."
+                },
+                "canFakeFlipper": {
+                    "title": "Aletas Falsas",
+                    "description": "Podría ser necesario usar el glitch de las Aletas Falsas para conseguir objetos."
+                },
+                "canMirrorClip": {
+                    "title": "Clips de Espejo",
+                    "description": "Podría ser necesario abusar la animación del espejo para salir del mapa."
+                },
+                "canMirrorWrap": {
+                    "title": "Mirror Wrap",
+                    "description": "Podría ser necesario usar el Espejo para hacer <i>scroll</i> automático a otro sitio."
+                },
+                "canOneFrameClipOW": {
+                    "title": "Clip de un frame (superfície)",
+                    "description": "Créeme, no quieres hacer esto."
+                },
+                "canOneFrameClipUW": {
+                    "title": "One Frame Clip (underworld)",
+                    "description": "Use 1 Frame Movement to clip between rooms of the underworld."
+                },
+                "canOWYBA": {
+                    "title": "YBA (superfície)",
+                    "description": "Podría ser necesario usar botellas en la superfície para teletransportarse a otras localizaciones."
+                },
+                "canSuperBunny": {
+                    "title": "Súper Conejo",
+                    "description": "Podría ser necesario activar el estado de súper conejo para acceder algunas localizaciones."
+                },
+                "canSuperSpeed": {
+                    "title": "Súper Velocidad",
+                    "description": "Podría ser necesario hacer <i>clips</i> con súper velocidad a través de esquinas de la superfície."
+                },
+                "canWaterFairyRevive": {
+                    "title": "Reanimación en el Agua con Hadas",
+                    "description": "Este <i>setup</i> es estúpido y requiere un montón de objetos."
+                },
+                "canWaterWalk": {
+                    "title": "Andar por el Agua",
+                    "description": "Podría ser necesario utilizar las Botas para andar sobre el agua."
+                },
+                "noLogic": {
+                    "title": "Desactivar todas las comprobaciones de lógica",
+                    "description": "Cuando esto está activado, todas las garantías desaparecen, y nada de lo que hay aquí importa."
+                }
+            }
         }
     },
     "fr": {
@@ -2566,6 +2569,13 @@ export default {
                 }
             }
         },
+        "error": {
+            "title": "Erreur",
+            "429": "Bien que nous appréciions que vous souhaitiez générer beaucoup de jeux, d’autres personnes aimeraient également le faire. Veuillez revenir plus tard si vous souhaitez continuer à générer.",
+            "failed_generation": "Échec de la création de jeu :(",
+            "bad_file": "Fichier non reconnu",
+            "quota_exceeded_error": "Vous avez atteint la limite de stockage local."
+        },
         "enemizer": {
             "title": "Enemizer",
             "enable": "Activer l’Ennemiseur",
@@ -2600,6 +2610,61 @@ export default {
             "palette_shuffle": "Mélange les Palettes",
             "pot_shuffle": "Mélange les Pots",
             "enemy_shuffle": "Mélanger les Ennemis"
+        },
+        "rom": {
+            "loader": {
+                "title": "Pour commencer",
+                "file_select": "Sélectionnez le fichier ROM",
+                "content": "<ol><li>Sélectionnez votre fichier ROM et chargez-le dans le navigateur (utilisez une ROM <strong>Zelda no Densetsu: Kamigami no Triforce v1.0</strong> avec une extension .smc ou .sfc)</li><li>Sélectionnez les <a href=\"/fr/options\">Options de Jeu</a> pour déterminer de quelle façon le jeu sera randomisé</li><li>Cliquez sur Générer une ROM de Course</li><li>Ensuite, sauvegardez votre rom et commencez à jouer</li></ol>"
+            },
+            "info": {
+                "spoilerwarning": "AVERTISSEMENT : La personne qui a généré cette partie a regardé le spoiler log.",
+                "mystery": "Ceci est une partie mystère. Les paramètres seront à découvrir pendant que vous jouez!",
+                "logic": "Glitchs requis",
+                "accessibility": "Accessibilité",
+                "build": "Création de ROM",
+                "difficulty": "Difficulté",
+                "variation": "Variation",
+                "shuffle": "Mélangeur d'Entrées",
+                "mode": "État du Monde",
+                "weapons": "Épées",
+                "goal": "Objectif",
+                "permalink": "Lien permanent",
+                "special": "Spécial",
+                "notes": "Remarques",
+                "generated": "Créé"
+            },
+            "settings": {
+                "heart_speed": "Bip de vie faible",
+                "heart_speeds": {
+                    "off": "Éteint",
+                    "double": "Vitesse Double",
+                    "normal": "Vitesse Normale",
+                    "half": "Moitié de Vitesse",
+                    "quarter": "Quart de Vitesse"
+                },
+                "menu_speed": "Vitesse du menu",
+                "menu_speeds": {
+                    "instant": "Immédiat",
+                    "fast": "Rapide",
+                    "normal": "Normal",
+                    "slow": "Lent"
+                },
+                "heart_color": "Couleur des coeurs",
+                "heart_colors": {
+                    "blue": "Bleu",
+                    "green": "Vert",
+                    "red": "Rouge",
+                    "yellow": "Jaune"
+                },
+                "play_as": "Jouer en tant que",
+                "sprite_file_select": "Sélectionnez le fichier .zspr",
+                "music": "Musique de fond",
+                "music_info": "(définie sur \"Non\" pour <a href=\"https://alttprlinks.page.link/SjiP\" target=\"_blank\" rel=\"noopener noreferrer\">le support MSU-1</a>)",
+                "quickswap": "Changement rapide d’objets",
+                "palette_shuffle": "Mélange des Couleurs de Palettes",
+                "race_warning": "Ne fonctionne pas dans les ROMs de course"
+            }
         },
         "entrance": {
             "title": "Randomizer de portes",
@@ -2674,149 +2739,6 @@ export default {
                 "save_spoiler": "Enregistrer le spoiler",
                 "save_rom": "Sauvegarder la ROM"
             }
-        },
-        "customizer": {
-            "settings": {
-                "timers": {
-                    "off": "Désactivé",
-                    "stopwatch": "Contre-la-montre",
-                    "countdown-ohko": "Compte à rebours OHKO",
-                    "countdown-continue": "Compte à rebours",
-                    "countdown-stop": "Compte à rebours Fin du jeu"
-                },
-                "dungeon_count": {
-                    "off": "Désactivé",
-                    "on": "Toujours activé",
-                    "pickup": "Avec Boussole"
-                }
-            },
-            "glitches": {
-                "canBombJump": {
-                    "title": "Saut à la Bombe",
-                    "description": "Il peut être requis de sauter par dessus un gouffre avec une bombe."
-                },
-                "canBootsClip": {
-                    "title": "Clip aux Bottes",
-                    "description": "Avec les bottes, il peut être requis de passer à travers de murs, dans le monde extérieur."
-                },
-                "canBunnyRevive": {
-                    "title": "Résurrection du Lapin",
-                    "description": "Il peut être requis de se rendre quelque part en forme de Lapin, et de mourir/user une fée pour redevenir Link."
-                },
-                "canBunnySurf": {
-                    "title": "Lapin Surfeur",
-                    "description": "Il peut être requis de marcher sur l'eau en tant que Lapin."
-                },
-                "canDungeonRevive": {
-                    "title": "Résurrection en Donjon",
-                    "description": "Il peut être requis d'entrer dans un donjon en Lapin, et de mourir, afin de redevenir Link pour collecter des objets."
-                },
-                "canFakeFlipper": {
-                    "title": "Fausses Palmes",
-                    "description": "Il peut être requis de faire la technique des Fausses Palmes afin de récupérer des objets."
-                },
-                "canMirrorClip": {
-                    "title": "Clip au Miroir",
-                    "description": "Il peut être requis d'utiliser des rebonds avec le Miroir pour se transporter hors des limites du jeu."
-                },
-                "canMirrorWrap": {
-                    "title": "Wrap au Miroir",
-                    "description": "Il peut être requis d\\utiliser le Miroir afin de défiler l'écran à un endroit normalement inaccessible."
-                },
-                "canOneFrameClipOW": {
-                    "title": "Clip d\\Une Image (Monde extérieur)",
-                    "description": "Vous ne voulez pas faire ça. Croyez-moi.."
-                },
-                "canOneFrameClipUW": {
-                    "title": "One Frame Clip (underworld)",
-                    "description": "Use 1 Frame Movement to clip between rooms of the underworld."
-                },
-                "canOWYBA": {
-                    "title": "YBA (Monde extérieur)",
-                    "description": "Il peut être requis d'utiliser des Bocaux dans le monde extérieur afin de se rendre à un endroit normalement inaccessible."
-                },
-                "canSuperBunny": {
-                    "title": "Super Lapin",
-                    "description": "Il peut être requis d'activer la technique du Super Lapin pour accéder à certains endroits et objets."
-                },
-                "canSuperSpeed": {
-                    "title": "Super Vitesse",
-                    "description": "Il peut être requis d'utiliser la Super Vitesse afin de passer à travers une barrière dans le monde extérieur."
-                },
-                "canWaterFairyRevive": {
-                    "title": "Résurrection par une Fée dans l'Eau",
-                    "description": "Cette technique est ridicule et requiert un grand nombre d'objets."
-                },
-                "canWaterWalk": {
-                    "title": "Marche sur l'Eau",
-                    "description": "Il peut être requis d'utiliser les Bottes pour marcher sur l\\eau."
-                },
-                "noLogic": {
-                    "title": "Désactiver la Logique",
-                    "description": "Quand ceci est activé, les dés en sont jetés, et rien d'autre n'importe.."
-                }
-            }
-        },
-        "rom": {
-            "loader": {
-                "title": "Pour commencer",
-                "file_select": "Sélectionnez le fichier ROM",
-                "content": "<ol><li>Sélectionnez votre fichier ROM et chargez-le dans le navigateur (utilisez une ROM <strong>Zelda no Densetsu: Kamigami no Triforce v1.0</strong> avec une extension .smc ou .sfc)</li><li>Sélectionnez les <a href=\"/fr/options\">Options de Jeu</a> pour déterminer de quelle façon le jeu sera randomisé</li><li>Cliquez sur Générer une ROM de Course</li><li>Ensuite, sauvegardez votre rom et commencez à jouer</li></ol>"
-            },
-            "info": {
-                "spoilerwarning": "AVERTISSEMENT : La personne qui a généré cette partie a regardé le spoiler log.",
-                "mystery": "Ceci est une partie mystère. Les paramètres seront à découvrir pendant que vous jouez!",
-                "logic": "Glitchs requis",
-                "accessibility": "Accessibilité",
-                "build": "Création de ROM",
-                "difficulty": "Difficulté",
-                "variation": "Variation",
-                "shuffle": "Mélangeur d'Entrées",
-                "mode": "État du Monde",
-                "weapons": "Épées",
-                "goal": "Objectif",
-                "permalink": "Lien permanent",
-                "special": "Spécial",
-                "notes": "Remarques",
-                "generated": "Créé"
-            },
-            "settings": {
-                "heart_speed": "Bip de vie faible",
-                "heart_speeds": {
-                    "off": "Éteint",
-                    "double": "Vitesse Double",
-                    "normal": "Vitesse Normale",
-                    "half": "Moitié de Vitesse",
-                    "quarter": "Quart de Vitesse"
-                },
-                "menu_speed": "Vitesse du menu",
-                "menu_speeds": {
-                    "instant": "Immédiat",
-                    "fast": "Rapide",
-                    "normal": "Normal",
-                    "slow": "Lent"
-                },
-                "heart_color": "Couleur des coeurs",
-                "heart_colors": {
-                    "blue": "Bleu",
-                    "green": "Vert",
-                    "red": "Rouge",
-                    "yellow": "Jaune"
-                },
-                "play_as": "Jouer en tant que",
-                "music": "Musique de fond",
-                "music_info": "(définie sur \"Non\" pour <a href=\"https://alttprlinks.page.link/SjiP\" target=\"_blank\" rel=\"noopener noreferrer\">le support MSU-1</a>)",
-                "quickswap": "Changement rapide d’objets",
-                "palette_shuffle": "Mélange des Couleurs de Palettes",
-                "race_warning": "Ne fonctionne pas dans les ROMs de course"
-            }
-        },
-        "error": {
-            "title": "Erreur",
-            "429": "Bien que nous appréciions que vous souhaitiez générer beaucoup de jeux, d’autres personnes aimeraient également le faire. Veuillez revenir plus tard si vous souhaitez continuer à générer.",
-            "failed_generation": "Échec de la création de jeu :(",
-            "bad_file": "Fichier non reconnu",
-            "quota_exceeded_error": "Vous avez atteint la limite de stockage local."
         },
         "item": {
             "Random": "Random",
@@ -3034,6 +2956,88 @@ export default {
             "Agahnim 2": "Agahnim 2",
             "Ganon": "Ganon",
             "Test": "Testing Item"
+        },
+        "customizer": {
+            "settings": {
+                "timers": {
+                    "off": "Désactivé",
+                    "stopwatch": "Contre-la-montre",
+                    "countdown-ohko": "Compte à rebours OHKO",
+                    "countdown-continue": "Compte à rebours",
+                    "countdown-stop": "Compte à rebours Fin du jeu"
+                },
+                "dungeon_count": {
+                    "off": "Désactivé",
+                    "on": "Toujours activé",
+                    "pickup": "Avec Boussole"
+                }
+            },
+            "glitches": {
+                "canBombJump": {
+                    "title": "Saut à la Bombe",
+                    "description": "Il peut être requis de sauter par dessus un gouffre avec une bombe."
+                },
+                "canBootsClip": {
+                    "title": "Clip aux Bottes",
+                    "description": "Avec les bottes, il peut être requis de passer à travers de murs, dans le monde extérieur."
+                },
+                "canBunnyRevive": {
+                    "title": "Résurrection du Lapin",
+                    "description": "Il peut être requis de se rendre quelque part en forme de Lapin, et de mourir/user une fée pour redevenir Link."
+                },
+                "canBunnySurf": {
+                    "title": "Lapin Surfeur",
+                    "description": "Il peut être requis de marcher sur l'eau en tant que Lapin."
+                },
+                "canDungeonRevive": {
+                    "title": "Résurrection en Donjon",
+                    "description": "Il peut être requis d'entrer dans un donjon en Lapin, et de mourir, afin de redevenir Link pour collecter des objets."
+                },
+                "canFakeFlipper": {
+                    "title": "Fausses Palmes",
+                    "description": "Il peut être requis de faire la technique des Fausses Palmes afin de récupérer des objets."
+                },
+                "canMirrorClip": {
+                    "title": "Clip au Miroir",
+                    "description": "Il peut être requis d'utiliser des rebonds avec le Miroir pour se transporter hors des limites du jeu."
+                },
+                "canMirrorWrap": {
+                    "title": "Wrap au Miroir",
+                    "description": "Il peut être requis d\\utiliser le Miroir afin de défiler l'écran à un endroit normalement inaccessible."
+                },
+                "canOneFrameClipOW": {
+                    "title": "Clip d\\Une Image (Monde extérieur)",
+                    "description": "Vous ne voulez pas faire ça. Croyez-moi.."
+                },
+                "canOneFrameClipUW": {
+                    "title": "One Frame Clip (underworld)",
+                    "description": "Use 1 Frame Movement to clip between rooms of the underworld."
+                },
+                "canOWYBA": {
+                    "title": "YBA (Monde extérieur)",
+                    "description": "Il peut être requis d'utiliser des Bocaux dans le monde extérieur afin de se rendre à un endroit normalement inaccessible."
+                },
+                "canSuperBunny": {
+                    "title": "Super Lapin",
+                    "description": "Il peut être requis d'activer la technique du Super Lapin pour accéder à certains endroits et objets."
+                },
+                "canSuperSpeed": {
+                    "title": "Super Vitesse",
+                    "description": "Il peut être requis d'utiliser la Super Vitesse afin de passer à travers une barrière dans le monde extérieur."
+                },
+                "canWaterFairyRevive": {
+                    "title": "Résurrection par une Fée dans l'Eau",
+                    "description": "Cette technique est ridicule et requiert un grand nombre d'objets."
+                },
+                "canWaterWalk": {
+                    "title": "Marche sur l'Eau",
+                    "description": "Il peut être requis d'utiliser les Bottes pour marcher sur l\\eau."
+                },
+                "noLogic": {
+                    "title": "Désactiver la Logique",
+                    "description": "Quand ceci est activé, les dés en sont jetés, et rien d'autre n'importe.."
+                }
+            }
         }
     }
 }

--- a/resources/lang/de/rom.php
+++ b/resources/lang/de/rom.php
@@ -51,6 +51,7 @@ return [
             'yellow' => 'Gelb',
         ],
         'play_as' => 'Spiele als',
+        'sprite_file_select' => '.zspr Datei auswählen',
         'music' => 'Hintergrundmusik',
         'music_info' => '(setze zu "Keine" für <a href="https://alttprlinks.page.link/SjiP" target="_blank" rel="noopener noreferrer">MSU-1 Support</a>)',
         'quickswap' => 'Gegenstand Schnellwechsel',

--- a/resources/lang/en/rom.php
+++ b/resources/lang/en/rom.php
@@ -51,6 +51,7 @@ return [
             'yellow' => 'Yellow',
         ],
         'play_as' => 'Play As',
+        'sprite_file_select' => 'Select .zspr File',
         'music' => 'Background Music',
         'music_info' => '(set to "No" for <a href="https://alttprlinks.page.link/SjiP" target="_blank" rel="noopener noreferrer">MSU-1 support</a>)',
         'quickswap' => 'Item Quickswap',

--- a/resources/lang/es/rom.php
+++ b/resources/lang/es/rom.php
@@ -51,6 +51,7 @@ return [
             'yellow' => 'Amarillo',
         ],
         'play_as' => 'Jugar Como',
+        'sprite_file_select' => 'Selecciona archivo .zspr',
         'music' => 'Música de fondo',
         'music_info' => '(poner en "No" para <a href="https://alttprlinks.page.link/SjiP" target="_blank" rel="noopener noreferrer">soporte con MSU-1</a>)',
         'quickswap' => 'Cambio Rápido de Objetos',

--- a/resources/lang/fr/rom.php
+++ b/resources/lang/fr/rom.php
@@ -51,6 +51,7 @@ return [
             'yellow' => 'Jaune',
         ],
         'play_as' => 'Jouer en tant que',
+        'sprite_file_select' => 'Sélectionnez le fichier .zspr',
         'music' => 'Musique de fond',
         'music_info' => '(définie sur "Non" pour <a href="https://alttprlinks.page.link/SjiP" target="_blank" rel="noopener noreferrer">le support MSU-1</a>)',
         'quickswap' => 'Changement rapide d’objets',


### PR DESCRIPTION
TODO:
- Localization of error messages
- Remembering user preference? (EDIT: Done)
- Add icon-custom gfx (currently shares icon-custom-Random)
- Improve button/text alignment in VTSpriteLoader.vue

Testing performed:
- Verified loading several valid .zspr files works, and correctly
  patches the ROM
- Verified select interface only appears when Load Custom Sprite
  is selected, and otherwise does not change the normal GUI
- Verified loading a bogus .zspr file displays an error message