### PR TITLE
Get the last commit from the ROM repo and use that

### DIFF
--- a/app/Console/Commands/UpdateBuildRecord.php
+++ b/app/Console/Commands/UpdateBuildRecord.php
@@ -77,9 +77,13 @@ class UpdateBuildRecord extends Command
 
         $build_date = $this->argument('build');
 
-        if (!$this->argument('build')) {
-            $git_log = new Process(['git', 'log', '-1','--format=%cd', '--date=short'], base_path("vendor/z3/randomizer"));
+        if (!$build_date) {
+            $git_log = new Process(
+                ['git', 'log', '-1','--format=%cd', '--date=short'],
+                base_path("vendor/z3/randomizer"));
+
             $git_log->run();
+
             if (!$git_log->isSuccessful()) {
                 $this->error($proc->getErrorOutput());
 

--- a/app/Console/Commands/UpdateBuildRecord.php
+++ b/app/Console/Commands/UpdateBuildRecord.php
@@ -9,7 +9,6 @@ use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 use Symfony\Component\Process\Process;
-use Symfony\Component\Process\Exception\ProcessFailedException;
 
 class UpdateBuildRecord extends Command
 {

--- a/app/Rom.php
+++ b/app/Rom.php
@@ -12,7 +12,7 @@ use Log;
  */
 class Rom
 {
-    const BUILD = '2020-09-26';
+    const BUILD = '2020-09-25';
     const HASH = '251976ea7cdaadf16742c4f86c571732';
     const SIZE = 2097152;
 


### PR DESCRIPTION
This patch instead uses the `git log` command to get the date of the latest commit, and use that instead of just using the current date.  This will result in a more consistent experience when using `php artisan alttp:updatebuildrecord`.