### PR TITLE
V31.0.7 - Sprite and patch notes updates, also intro mystery masking

### DIFF
--- a/app/Rom.php
+++ b/app/Rom.php
@@ -2670,6 +2670,8 @@ class Rom
      * spoilers is set to "mystery".  This text is currently what is used by
      * the entrance randomizer.
      *
+     * @param bool $enable switch on or off
+     *
      * @return $this
      */
     public function setMysteryMasking(bool $enable = true): self

--- a/app/Rom.php
+++ b/app/Rom.php
@@ -2665,6 +2665,29 @@ class Rom
     }
 
     /**
+     * Sets intro text and, in the future, other game elements to mask settings
+     * visible to the player prior to the start of a run.  This is used when
+     * spoilers is set to "mystery".  This text is currently what is used by
+     * the entrance randomizer.
+     *
+     * @return $this
+     */
+    public function setMysteryMasking(bool $enable = true): self
+    {
+        if ($enable) {
+            $this->text->setString('intro_main', "{INTRO}\n Episode  III\n{PAUSE3}\n A Link to\n   the Past\n"
+            . "{PAUSE3}\n  Randomizer\n{PAUSE3}\nAfter mostly disregarding what happened in the first two games.\n"
+            . "{PAUSE3}\nLink awakens to his uncle leaving the house.\n{PAUSE3}\nHe just runs out the door,\n"
+            . "{PAUSE3}\ninto the rainy night.\n{PAUSE3}\n{CHANGEPIC}\nGanon has moved around all the items in Hyrule.\n"
+            . "{PAUSE7}\nYou will have to find all the items necessary to beat Ganon.\n"
+            . "{PAUSE7}\nThis is your chance to be a hero.\n{PAUSE3}\n{CHANGEPIC}\n"
+            . "You must get the 7 crystals to beat Ganon.\n{PAUSE9}\n{CHANGEPIC}", false);
+        }
+
+        return $this;
+    }
+
+    /**
      * Enable/Disable ability to Save and Quit from Boss room after item collection.
      *
      * @param bool $enable switch on or off

--- a/app/World.php
+++ b/app/World.php
@@ -1151,6 +1151,8 @@ abstract class World
             $rom->setGameType('item');
         }
 
+        $rom->setMysteryMasking($this->config('spoilers', 'on') === 'mystery');
+
         $rom->writeCredits();
         $rom->writeText();
 

--- a/config/sprites.php
+++ b/config/sprites.php
@@ -268,6 +268,16 @@ return [
             3 => 'ALTTP NPC',
         ],
     ],
+    'blazer.1.zspr' => [
+        'name' => 'Blazer',
+        'author' => 'Herowho',
+        'file' => 'blazer.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Male',
+        ],
+    ],
     'blossom.1.zspr' => [
         'name' => 'Blossom',
         'author' => 'Artheau',
@@ -336,6 +346,17 @@ return [
             0 => 'Legend of Zelda',
         ],
     ],
+    'botw-link.1.zspr' => [
+        'name' => 'BotW Link',
+        'author' => 'Pasta La Vista',
+        'file' => 'botw-link.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Legend of Zelda',
+            1 => 'Male',
+        ],
+    ],
     'botw-zelda.1.zspr' => [
         'name' => 'BotW Zelda',
         'author' => 'Roo',
@@ -344,6 +365,7 @@ return [
         'vtversion' => '31.0.5',
         'tags' => [
             0 => 'Legend of Zelda',
+            1 => 'Female',
         ],
     ],
     'bowser.1.zspr' => [
@@ -355,6 +377,30 @@ return [
         'tags' => [
             0 => 'Male',
             1 => 'Mario',
+            2 => 'Villain',
+        ],
+    ],
+    'bowsette-red.1.zspr' => [
+        'name' => 'Bowsette (Red)',
+        'author' => 'Sarah Shinespark',
+        'file' => 'bowsette-red.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Mario',
+            1 => 'Female',
+            2 => 'Villain',
+        ],
+    ],
+    'bowsette.1.zspr' => [
+        'name' => 'Bowsette',
+        'author' => 'Sarah Shinespark',
+        'file' => 'bowsette.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Mario',
+            1 => 'Female',
             2 => 'Villain',
         ],
     ],
@@ -583,6 +629,17 @@ return [
         'vtversion' => '31',
         'tags' => [
             0 => 'Personality',
+        ],
+    ],
+    'chrizzz.1.zspr' => [
+        'name' => 'Chrizzz',
+        'author' => 'Chrizzz',
+        'file' => 'chrizzz.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Link',
+            1 => 'Personality',
         ],
     ],
     'cirno.1.zspr' => [
@@ -1326,6 +1383,16 @@ return [
             1 => 'Legend of Zelda',
         ],
     ],
+    'hollow-knight.1.zspr' => [
+        'name' => 'Hollow Knight',
+        'author' => 'Chew_Terr',
+        'file' => 'hollow-knight.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Hollow Knight',
+        ],
+    ],
     'homer.1.zspr' => [
         'name' => 'Homer Simpson',
         'author' => 'Fwiller',
@@ -1335,6 +1402,17 @@ return [
         'tags' => [
             0 => 'Simpsons',
             1 => 'Male',
+        ],
+    ],
+    'hotdog.1.zspr' => [
+        'name' => 'Hotdog',
+        'author' => 'Xag & Tylo',
+        'file' => 'hotdog.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Link',
+            1 => 'Food',
         ],
     ],
     'hyruleknight.1.zspr' => [
@@ -1548,6 +1626,18 @@ return [
             0 => 'Personality',
         ],
     ],
+    'korok.1.zspr' => [
+        'name' => 'Korok',
+        'author' => 'atth3h3art0fwinter',
+        'file' => 'korok.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'The Legend of Zelda',
+            1 => 'Wind Waker',
+            2 => 'NPC',
+        ],
+    ],
     'lakitu.1.zspr' => [
         'name' => 'Lakitu',
         'author' => 'SirCzah',
@@ -1661,6 +1751,17 @@ return [
             2 => 'Animal',
         ],
     ],
+    'locke.1.zspr' => [
+        'name' => 'Locke',
+        'author' => 'Rose',
+        'file' => 'locke.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Male',
+            1 => 'Final Fantasy',
+        ],
+    ],
     'locke_merchant.1.zspr' => [
         'name' => 'Figaro Merchant',
         'author' => 'Artheau',
@@ -1704,6 +1805,17 @@ return [
             0 => 'Male',
             1 => 'Mario',
             2 => 'Superhero',
+        ],
+    ],
+    'luna-maindo.1.zspr' => [
+        'name' => 'Luna Maindo',
+        'author' => 'IkkyLights',
+        'file' => 'luna-maindo.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Female',
+            1 => 'Elsword',
         ],
     ],
     'madeline.1.zspr' => [
@@ -2462,6 +2574,27 @@ return [
             2 => 'Legend of Zelda',
         ],
     ],
+    'rat.1.zspr' => [
+        'name' => 'Rat',
+        'author' => 'atth3h3art0fwinter',
+        'file' => 'rat.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'ALTTP NPC',
+            1 => 'Legend of Zelda',
+        ],
+    ],
+    'red-mage.1.zspr' => [
+        'name' => 'Red Mage',
+        'author' => 'TheRedMage',
+        'file' => 'red-mage.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Final Fantasy',
+        ],
+    ],
     'remeer.1.zspr' => [
         'name' => 'Remeer',
         'author' => 'Herowho',
@@ -2750,6 +2883,16 @@ return [
         'vtversion' => '31',
         'tags' => [
             0 => 'Personality',
+        ],
+    ],
+    'slime.1.zspr' => [
+        'name' => 'Slime',
+        'author' => 'KamenRideDecade',
+        'file' => 'slime.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Dragon Quest',
         ],
     ],
     'slowpoke.1.zspr' => [

--- a/config/sprites.php
+++ b/config/sprites.php
@@ -89,11 +89,22 @@ return [
             0 => 'Personality',
         ],
     ],
-    'ark.2.zspr' => [
-        'name' => 'Ark',
+    'ark-dorana.1.zspr' => [
+        'name' => 'Ark (No Cape)',
+        'author' => 'Dorana',
+        'file' => 'ark-dorana.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.5',
+        'tags' => [
+            0 => 'Terranigma',
+            1 => 'Male',
+        ],
+    ],
+    'ark.1.zspr' => [
+        'name' => 'Ark (Cape)',
         'author' => 'wzl',
-        'file' => 'ark.2.zspr',
-        'version' => 2,
+        'file' => 'ark.1.zspr',
+        'version' => 1,
         'vtversion' => '31.0.5',
         'tags' => [
             0 => 'Terranigma',
@@ -121,6 +132,17 @@ return [
         'vtversion' => '31.0.5',
         'tags' => [
             0 => 'IRL',
+        ],
+    ],
+    'asuna.1.zspr' => [
+        'name' => 'Asuna',
+        'author' => 'Natsuru Kiyohoshi',
+        'file' => 'asuna.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Female',
+            1 => 'Sword Art Online',
         ],
     ],
     'badeline.1.zspr' => [
@@ -269,6 +291,17 @@ return [
             0 => 'Randomizer',
             1 => 'ALTTP NPC',
             2 => 'Legend of Zelda',
+        ],
+    ],
+    'bobross.1.zspr' => [
+        'name' => 'Bob Ross',
+        'author' => 'CaptainApathy',
+        'file' => 'bobross.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Male',
+            1 => 'Personality',
         ],
     ],
     'boo-two.1.zspr' => [
@@ -619,6 +652,16 @@ return [
             1 => 'Male',
         ],
     ],
+    'crewmate.1.zspr' => [
+        'name' => 'Crewmate',
+        'author' => 'Fish_waffle64',
+        'file' => 'crewmate.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Among Us',
+        ],
+    ],
     'cucco.1.zspr' => [
         'name' => 'Cucco',
         'author' => 'MikeTrethewey',
@@ -641,11 +684,11 @@ return [
             0 => 'Personality',
         ],
     ],
-    'd_owls.1.zspr' => [
+    'd_owls.2.zspr' => [
         'name' => 'D.Owls',
         'author' => 'D.Owls',
-        'file' => 'd_owls.1.zspr',
-        'version' => 1,
+        'file' => 'd_owls.2.zspr',
+        'version' => 2,
         'vtversion' => '31',
         'tags' => [
             0 => 'Personality',
@@ -790,6 +833,17 @@ return [
             1 => 'Bird',
         ],
     ],
+    'dekar.1.zspr' => [
+        'name' => 'Dekar',
+        'author' => 'The3X',
+        'file' => 'dekar.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Male',
+            1 => 'Lufia',
+        ],
+    ],
     'demonlink.1.zspr' => [
         'name' => 'Demon Link',
         'author' => 'Krelbel',
@@ -855,11 +909,11 @@ return [
             1 => 'Male',
         ],
     ],
-    'fierce-deity-link.1.zspr' => [
+    'fierce-deity-link.2.zspr' => [
         'name' => 'Fierce Deity Link',
         'author' => 'Jeffreygriggs2',
-        'file' => 'fierce-deity-link.1.zspr',
-        'version' => 1,
+        'file' => 'fierce-deity-link.2.zspr',
+        'version' => 2,
         'vtversion' => '31.0.5',
         'tags' => [
             0 => 'Link',
@@ -1070,6 +1124,18 @@ return [
             1 => 'Male',
         ],
     ],
+    'gliitchwiitch.1.zspr' => [
+        'name' => 'GliitchWiitch',
+        'author' => 'Ivy-IV',
+        'file' => 'gliitchwiitch.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Female',
+            1 => 'Personality',
+            2 => 'Streamer',
+        ],
+    ],
     'gobli.1.zspr' => [
         'name' => 'Gobli',
         'author' => 'Lantis',
@@ -1114,6 +1180,18 @@ return [
             3 => 'Male',
         ],
     ],
+    'gretis.1.zspr' => [
+        'name' => 'Gretis',
+        'author' => 'SnakeGrunger',
+        'file' => 'gretis.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Male',
+            1 => 'Personality',
+            2 => 'Streamer',
+        ],
+    ],
     'grunclestan.1.zspr' => [
         'name' => 'Gruncle Stan',
         'author' => 'SirCzah',
@@ -1135,6 +1213,17 @@ return [
             0 => 'Personality',
             1 => 'Streamer',
             2 => 'Male',
+        ],
+    ],
+    'hanna.1.zspr' => [
+        'name' => 'Hanna',
+        'author' => 'Maya-Neko',
+        'file' => 'hanna.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Female',
+            1 => 'Personality',
         ],
     ],
     'hardhat_beetle.1.zspr' => [
@@ -1202,18 +1291,6 @@ return [
         'vtversion' => '30.5',
         'tags' => [
             0 => 'ALTTP NPC',
-        ],
-    ],
-    'hitsuyan.1.zspr' => [
-        'name' => 'Hitsuyan1337',
-        'author' => 'BOtheMighty',
-        'file' => 'hitsuyan.1.zspr',
-        'version' => 1,
-        'vtversion' => '31.0.5',
-        'tags' => [
-            0 => 'Personality',
-            1 => 'Streamer',
-            2 => 'Male',
         ],
     ],
     'hoarder-bush.1.zspr' => [
@@ -1524,6 +1601,18 @@ return [
             2 => 'Legend of Zelda',
         ],
     ],
+    'link-redrawn.1.zspr' => [
+        'name' => 'Link Redrawn',
+        'author' => 'Spiffy',
+        'file' => 'link-redrawn.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Link',
+            1 => 'ALTTP',
+            2 => 'Male',
+        ],
+    ],
     'linkhatcolor.1.zspr' => [
         'name' => 'Hat Color Link',
         'author' => 'Damon',
@@ -1546,6 +1635,18 @@ return [
             0 => 'Link',
             1 => 'Male',
             2 => 'Legend of Zelda',
+        ],
+    ],
+    'little-hylian.1.zspr' => [
+        'name' => 'Little Hylian',
+        'author' => 'MM102',
+        'file' => 'little-hylian.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Male',
+            1 => 'Personality',
+            2 => 'Pokemon',
         ],
     ],
     'littlepony.1.zspr' => [
@@ -1579,6 +1680,18 @@ return [
         'vtversion' => '30.5',
         'tags' => [
             0 => 'Pokemon',
+        ],
+    ],
+    'luffy.1.zspr' => [
+        'name' => 'Luffy',
+        'author' => 'BOtheMighty',
+        'file' => 'luffy.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.5',
+        'tags' => [
+            0 => 'Personality',
+            1 => 'Streamer',
+            2 => 'Male',
         ],
     ],
     'luigi.1.zspr' => [
@@ -1842,6 +1955,17 @@ return [
             0 => 'Pokemon',
         ],
     ],
+    'moblin.1.zspr' => [
+        'name' => 'Moblin',
+        'author' => 'Noctai_',
+        'file' => 'moblin.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Legend of Zelda',
+            1 => 'ALTTP',
+        ],
+    ],
     'modernlink.1.zspr' => [
         'name' => 'Modern Link',
         'author' => 'RyuTech',
@@ -1942,11 +2066,11 @@ return [
             1 => 'Legend of Zelda',
         ],
     ],
-    'navirou.1.zspr' => [
+    'navirou.2.zspr' => [
         'name' => 'Navirou',
         'author' => 'Lori',
-        'file' => 'navirou.1.zspr',
-        'version' => 1,
+        'file' => 'navirou.2.zspr',
+        'version' => 2,
         'vtversion' => '31.0.6',
         'tags' => [
             0 => 'Monster Hunter',
@@ -2019,6 +2143,17 @@ return [
         'tags' => [
             0 => 'Xenoblade',
             1 => 'Female',
+        ],
+    ],
+    'niddraig.1.zspr' => [
+        'name' => 'Niddraig',
+        'author' => 'Jakebob',
+        'file' => 'niddraig.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Final Fantasy',
+            1 => 'Personality',
         ],
     ],
     'niko.1.zspr' => [
@@ -2382,6 +2517,18 @@ return [
             0 => 'Cartoon',
         ],
     ],
+    'rover.1.zspr' => [
+        'name' => 'Rover',
+        'author' => 'NO Body the Dragon',
+        'file' => 'rover.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Male',
+            1 => 'Animal Crossing',
+            2 => 'Cat',
+        ],
+    ],
     'roykoopa.1.zspr' => [
         'name' => 'Roy Koopa',
         'author' => 'Achy',
@@ -2605,6 +2752,16 @@ return [
             0 => 'Personality',
         ],
     ],
+    'slowpoke.1.zspr' => [
+        'name' => 'Slowpoke',
+        'author' => 'Joey_Rat',
+        'file' => 'slowpoke.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Pokemon',
+        ],
+    ],
     'snes-controller.1.zspr' => [
         'name' => 'SNES Controller',
         'author' => 'Cbass601',
@@ -2682,6 +2839,17 @@ return [
             1 => 'Kingdom Hearts',
         ],
     ],
+    'spongebob.1.zspr' => [
+        'name' => 'Spongebob Squarepants',
+        'author' => 'JJ0033LL',
+        'file' => 'spongebob.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Male',
+            1 => 'Spongebob Squarepants',
+        ],
+    ],
     'squall.1.zspr' => [
         'name' => 'Squall',
         'author' => 'Maessan',
@@ -2750,6 +2918,17 @@ return [
             3 => 'Randomizer',
         ],
     ],
+    'steamedhams.1.zspr' => [
+        'name' => 'Steamed Hams',
+        'author' => 'AFewGoodTaters',
+        'file' => 'steamedhams.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Link',
+            1 => 'Cartoon',
+        ],
+    ],
     'stick_man.1.zspr' => [
         'name' => 'Stick Man',
         'author' => 'skovacs1',
@@ -2792,6 +2971,18 @@ return [
         'tags' => [
             0 => 'Male',
             1 => 'Meat Boy',
+        ],
+    ],
+    'susie.1.zspr' => [
+        'name' => 'Susie',
+        'author' => 'Zandra',
+        'file' => 'susie.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Female',
+            1 => 'Undertale',
+            2 => 'Deltarune',
         ],
     ],
     'swatchy.1.zspr' => [

--- a/config/sprites.php
+++ b/config/sprites.php
@@ -314,6 +314,17 @@ return [
             1 => 'Personality',
         ],
     ],
+    'boco.1.zspr' => [
+        'name' => 'Boco the Chocobo',
+        'author' => 'Tar Thoron',
+        'file' => 'boco.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.7',
+        'tags' => [
+            0 => 'Final Fantasy',
+            1 => 'Animal',
+        ],
+    ],
     'boo-two.1.zspr' => [
         'name' => 'Boo 2',
         'author' => 'Achy',

--- a/resources/sass/_sprites.scss
+++ b/resources/sass/_sprites.scss
@@ -10,962 +10,965 @@
   background-position: 0 0;
 }
 .icon-custom-Link {
-  background-position: percentage((1 - 321)/ 320) 0;
+  background-position: percentage((1 - 322)/ 321) 0;
 }
 .icon-custom-FourSwordsLink {
-  background-position: percentage((2 - 321)/ 320) 0;
+  background-position: percentage((2 - 322)/ 321) 0;
 }
 .icon-custom-Abigail {
-  background-position: percentage((3 - 321)/ 320) 0;
+  background-position: percentage((3 - 322)/ 321) 0;
 }
 .icon-custom-Adol {
-  background-position: percentage((4 - 321)/ 320) 0;
+  background-position: percentage((4 - 322)/ 321) 0;
 }
 .icon-custom-Aggretsuko {
-  background-position: percentage((5 - 321)/ 320) 0;
+  background-position: percentage((5 - 322)/ 321) 0;
 }
 .icon-custom-Alice {
-  background-position: percentage((6 - 321)/ 320) 0;
+  background-position: percentage((6 - 322)/ 321) 0;
 }
 .icon-custom-AngryVideoGameNerd {
-  background-position: percentage((7 - 321)/ 320) 0;
+  background-position: percentage((7 - 322)/ 321) 0;
 }
 .icon-custom-Arcane {
-  background-position: percentage((8 - 321)/ 320) 0;
+  background-position: percentage((8 - 322)/ 321) 0;
 }
 .icon-custom-ArkNoCape {
-  background-position: percentage((9 - 321)/ 320) 0;
+  background-position: percentage((9 - 322)/ 321) 0;
 }
 .icon-custom-ArkCape {
-  background-position: percentage((10 - 321)/ 320) 0;
+  background-position: percentage((10 - 322)/ 321) 0;
 }
 .icon-custom-Arrghus {
-  background-position: percentage((11 - 321)/ 320) 0;
+  background-position: percentage((11 - 322)/ 321) 0;
 }
 .icon-custom-Astronaut {
-  background-position: percentage((12 - 321)/ 320) 0;
+  background-position: percentage((12 - 322)/ 321) 0;
 }
 .icon-custom-Asuna {
-  background-position: percentage((13 - 321)/ 320) 0;
+  background-position: percentage((13 - 322)/ 321) 0;
 }
 .icon-custom-Badeline {
-  background-position: percentage((14 - 321)/ 320) 0;
+  background-position: percentage((14 - 322)/ 321) 0;
 }
 .icon-custom-BananasInPyjamas {
-  background-position: percentage((15 - 321)/ 320) 0;
+  background-position: percentage((15 - 322)/ 321) 0;
 }
 .icon-custom-Bandit {
-  background-position: percentage((16 - 321)/ 320) 0;
+  background-position: percentage((16 - 322)/ 321) 0;
 }
 .icon-custom-Batman {
-  background-position: percentage((17 - 321)/ 320) 0;
+  background-position: percentage((17 - 322)/ 321) 0;
 }
 .icon-custom-Beau {
-  background-position: percentage((18 - 321)/ 320) 0;
+  background-position: percentage((18 - 322)/ 321) 0;
 }
 .icon-custom-Bewp {
-  background-position: percentage((19 - 321)/ 320) 0;
+  background-position: percentage((19 - 322)/ 321) 0;
 }
 .icon-custom-BigKey {
-  background-position: percentage((20 - 321)/ 320) 0;
+  background-position: percentage((20 - 322)/ 321) 0;
 }
 .icon-custom-Birb {
-  background-position: percentage((21 - 321)/ 320) 0;
+  background-position: percentage((21 - 322)/ 321) 0;
 }
 .icon-custom-Birdo {
-  background-position: percentage((22 - 321)/ 320) 0;
+  background-position: percentage((22 - 322)/ 321) 0;
 }
 .icon-custom-BlackMage {
-  background-position: percentage((23 - 321)/ 320) 0;
+  background-position: percentage((23 - 322)/ 321) 0;
 }
 .icon-custom-BlacksmithLink {
-  background-position: percentage((24 - 321)/ 320) 0;
+  background-position: percentage((24 - 322)/ 321) 0;
 }
 .icon-custom-Blazer {
-  background-position: percentage((25 - 321)/ 320) 0;
+  background-position: percentage((25 - 322)/ 321) 0;
 }
 .icon-custom-Blossom {
-  background-position: percentage((26 - 321)/ 320) 0;
+  background-position: percentage((26 - 322)/ 321) 0;
 }
 .icon-custom-Bob {
-  background-position: percentage((27 - 321)/ 320) 0;
+  background-position: percentage((27 - 322)/ 321) 0;
 }
 .icon-custom-BobRoss {
-  background-position: percentage((28 - 321)/ 320) 0;
+  background-position: percentage((28 - 322)/ 321) 0;
+}
+.icon-custom-BocotheChocobo {
+  background-position: percentage((29 - 322)/ 321) 0;
 }
 .icon-custom-Boo2 {
-  background-position: percentage((29 - 321)/ 320) 0;
+  background-position: percentage((30 - 322)/ 321) 0;
 }
 .icon-custom-Boo {
-  background-position: percentage((30 - 321)/ 320) 0;
+  background-position: percentage((31 - 322)/ 321) 0;
 }
 .icon-custom-BottleoGoo {
-  background-position: percentage((31 - 321)/ 320) 0;
+  background-position: percentage((32 - 322)/ 321) 0;
 }
 .icon-custom-BotWLink {
-  background-position: percentage((32 - 321)/ 320) 0;
+  background-position: percentage((33 - 322)/ 321) 0;
 }
 .icon-custom-BotWZelda {
-  background-position: percentage((33 - 321)/ 320) 0;
+  background-position: percentage((34 - 322)/ 321) 0;
 }
 .icon-custom-Bowser {
-  background-position: percentage((34 - 321)/ 320) 0;
+  background-position: percentage((35 - 322)/ 321) 0;
 }
 .icon-custom-BowsetteRed {
-  background-position: percentage((35 - 321)/ 320) 0;
+  background-position: percentage((36 - 322)/ 321) 0;
 }
 .icon-custom-Bowsette {
-  background-position: percentage((36 - 321)/ 320) 0;
+  background-position: percentage((37 - 322)/ 321) 0;
 }
 .icon-custom-Branch {
-  background-position: percentage((37 - 321)/ 320) 0;
+  background-position: percentage((38 - 322)/ 321) 0;
 }
 .icon-custom-Brian {
-  background-position: percentage((38 - 321)/ 320) 0;
+  background-position: percentage((39 - 322)/ 321) 0;
 }
 .icon-custom-Broccoli {
-  background-position: percentage((39 - 321)/ 320) 0;
+  background-position: percentage((40 - 322)/ 321) 0;
 }
 .icon-custom-Bronzor {
-  background-position: percentage((40 - 321)/ 320) 0;
+  background-position: percentage((41 - 322)/ 321) 0;
 }
 .icon-custom-BSBoy {
-  background-position: percentage((41 - 321)/ 320) 0;
+  background-position: percentage((42 - 322)/ 321) 0;
 }
 .icon-custom-BSGirl {
-  background-position: percentage((42 - 321)/ 320) 0;
+  background-position: percentage((43 - 322)/ 321) 0;
 }
 .icon-custom-Bubbles {
-  background-position: percentage((43 - 321)/ 320) 0;
+  background-position: percentage((44 - 322)/ 321) 0;
 }
 .icon-custom-BulletBill {
-  background-position: percentage((44 - 321)/ 320) 0;
+  background-position: percentage((45 - 322)/ 321) 0;
 }
 .icon-custom-Buttercup {
-  background-position: percentage((45 - 321)/ 320) 0;
+  background-position: percentage((46 - 322)/ 321) 0;
 }
 .icon-custom-Cactuar {
-  background-position: percentage((46 - 321)/ 320) 0;
+  background-position: percentage((47 - 322)/ 321) 0;
 }
 .icon-custom-Cadence {
-  background-position: percentage((47 - 321)/ 320) 0;
+  background-position: percentage((48 - 322)/ 321) 0;
 }
 .icon-custom-CarlSagan42 {
-  background-position: percentage((48 - 321)/ 320) 0;
+  background-position: percentage((49 - 322)/ 321) 0;
 }
 .icon-custom-CasualZelda {
-  background-position: percentage((49 - 321)/ 320) 0;
+  background-position: percentage((50 - 322)/ 321) 0;
 }
 .icon-custom-MarvintheCat {
-  background-position: percentage((50 - 321)/ 320) 0;
+  background-position: percentage((51 - 322)/ 321) 0;
 }
 .icon-custom-CatBoo {
-  background-position: percentage((51 - 321)/ 320) 0;
+  background-position: percentage((52 - 322)/ 321) 0;
 }
 .icon-custom-CD-iLink {
-  background-position: percentage((52 - 321)/ 320) 0;
+  background-position: percentage((53 - 322)/ 321) 0;
 }
 .icon-custom-Celes {
-  background-position: percentage((53 - 321)/ 320) 0;
+  background-position: percentage((54 - 322)/ 321) 0;
 }
 .icon-custom-Charizard {
-  background-position: percentage((54 - 321)/ 320) 0;
+  background-position: percentage((55 - 322)/ 321) 0;
 }
 .icon-custom-CheepCheep {
-  background-position: percentage((55 - 321)/ 320) 0;
+  background-position: percentage((56 - 322)/ 321) 0;
 }
 .icon-custom-Chibity {
-  background-position: percentage((56 - 321)/ 320) 0;
+  background-position: percentage((57 - 322)/ 321) 0;
 }
 .icon-custom-Chrizzz {
-  background-position: percentage((57 - 321)/ 320) 0;
+  background-position: percentage((58 - 322)/ 321) 0;
 }
 .icon-custom-Cirno {
-  background-position: percentage((58 - 321)/ 320) 0;
+  background-position: percentage((59 - 322)/ 321) 0;
 }
 .icon-custom-Clifford {
-  background-position: percentage((59 - 321)/ 320) 0;
+  background-position: percentage((60 - 322)/ 321) 0;
 }
 .icon-custom-Clyde {
-  background-position: percentage((60 - 321)/ 320) 0;
+  background-position: percentage((61 - 322)/ 321) 0;
 }
 .icon-custom-Conker {
-  background-position: percentage((61 - 321)/ 320) 0;
+  background-position: percentage((62 - 322)/ 321) 0;
 }
 .icon-custom-Cornelius {
-  background-position: percentage((62 - 321)/ 320) 0;
+  background-position: percentage((63 - 322)/ 321) 0;
 }
 .icon-custom-Corona {
-  background-position: percentage((63 - 321)/ 320) 0;
+  background-position: percentage((64 - 322)/ 321) 0;
 }
 .icon-custom-Crewmate {
-  background-position: percentage((64 - 321)/ 320) 0;
+  background-position: percentage((65 - 322)/ 321) 0;
 }
 .icon-custom-Cucco {
-  background-position: percentage((65 - 321)/ 320) 0;
+  background-position: percentage((66 - 322)/ 321) 0;
 }
 .icon-custom-Cursor {
-  background-position: percentage((66 - 321)/ 320) 0;
+  background-position: percentage((67 - 322)/ 321) 0;
 }
 .icon-custom-DOwls {
-  background-position: percentage((67 - 321)/ 320) 0;
+  background-position: percentage((68 - 322)/ 321) 0;
 }
 .icon-custom-DarkPanda {
-  background-position: percentage((68 - 321)/ 320) 0;
+  background-position: percentage((69 - 322)/ 321) 0;
 }
 .icon-custom-DarkBoy {
-  background-position: percentage((69 - 321)/ 320) 0;
+  background-position: percentage((70 - 322)/ 321) 0;
 }
 .icon-custom-DarkGirl {
-  background-position: percentage((70 - 321)/ 320) 0;
+  background-position: percentage((71 - 322)/ 321) 0;
 }
 .icon-custom-DarkLinkTunic {
-  background-position: percentage((71 - 321)/ 320) 0;
+  background-position: percentage((72 - 322)/ 321) 0;
 }
 .icon-custom-DarkLink {
-  background-position: percentage((72 - 321)/ 320) 0;
+  background-position: percentage((73 - 322)/ 321) 0;
 }
 .icon-custom-DarkSwatchy {
-  background-position: percentage((73 - 321)/ 320) 0;
+  background-position: percentage((74 - 322)/ 321) 0;
 }
 .icon-custom-DarkZelda {
-  background-position: percentage((74 - 321)/ 320) 0;
+  background-position: percentage((75 - 322)/ 321) 0;
 }
 .icon-custom-DarkZora {
-  background-position: percentage((75 - 321)/ 320) 0;
+  background-position: percentage((76 - 322)/ 321) 0;
 }
 .icon-custom-DeadpoolMythic {
-  background-position: percentage((76 - 321)/ 320) 0;
+  background-position: percentage((77 - 322)/ 321) 0;
 }
 .icon-custom-DeadpoolSirCzah {
-  background-position: percentage((77 - 321)/ 320) 0;
+  background-position: percentage((78 - 322)/ 321) 0;
 }
 .icon-custom-Deadrock {
-  background-position: percentage((78 - 321)/ 320) 0;
+  background-position: percentage((79 - 322)/ 321) 0;
 }
 .icon-custom-Decidueye {
-  background-position: percentage((79 - 321)/ 320) 0;
+  background-position: percentage((80 - 322)/ 321) 0;
 }
 .icon-custom-Dekar {
-  background-position: percentage((80 - 321)/ 320) 0;
+  background-position: percentage((81 - 322)/ 321) 0;
 }
 .icon-custom-DemonLink {
-  background-position: percentage((81 - 321)/ 320) 0;
+  background-position: percentage((82 - 322)/ 321) 0;
 }
 .icon-custom-Dragonite {
-  background-position: percentage((82 - 321)/ 320) 0;
+  background-position: percentage((83 - 322)/ 321) 0;
 }
 .icon-custom-DrakeTheDragon {
-  background-position: percentage((83 - 321)/ 320) 0;
+  background-position: percentage((84 - 322)/ 321) 0;
 }
 .icon-custom-Eggplant {
-  background-position: percentage((84 - 321)/ 320) 0;
+  background-position: percentage((85 - 322)/ 321) 0;
 }
 .icon-custom-EmoSaru {
-  background-position: percentage((85 - 321)/ 320) 0;
+  background-position: percentage((86 - 322)/ 321) 0;
 }
 .icon-custom-Ezlo {
-  background-position: percentage((86 - 321)/ 320) 0;
+  background-position: percentage((87 - 322)/ 321) 0;
 }
 .icon-custom-FierceDeityLink {
-  background-position: percentage((87 - 321)/ 320) 0;
+  background-position: percentage((88 - 322)/ 321) 0;
 }
 .icon-custom-FinnMerten {
-  background-position: percentage((88 - 321)/ 320) 0;
+  background-position: percentage((89 - 322)/ 321) 0;
 }
 .icon-custom-FinnyBear {
-  background-position: percentage((89 - 321)/ 320) 0;
+  background-position: percentage((90 - 322)/ 321) 0;
 }
 .icon-custom-FloodgateFish {
-  background-position: percentage((90 - 321)/ 320) 0;
+  background-position: percentage((91 - 322)/ 321) 0;
 }
 .icon-custom-FlavorGuy {
-  background-position: percentage((91 - 321)/ 320) 0;
+  background-position: percentage((92 - 322)/ 321) 0;
 }
 .icon-custom-FoxLink {
-  background-position: percentage((92 - 321)/ 320) 0;
+  background-position: percentage((93 - 322)/ 321) 0;
 }
 .icon-custom-FreyaCrescent {
-  background-position: percentage((93 - 321)/ 320) 0;
+  background-position: percentage((94 - 322)/ 321) 0;
 }
 .icon-custom-Frisk {
-  background-position: percentage((94 - 321)/ 320) 0;
+  background-position: percentage((95 - 322)/ 321) 0;
 }
 .icon-custom-FrogLink {
-  background-position: percentage((95 - 321)/ 320) 0;
+  background-position: percentage((96 - 322)/ 321) 0;
 }
 .icon-custom-Fujin {
-  background-position: percentage((96 - 321)/ 320) 0;
+  background-position: percentage((97 - 322)/ 321) 0;
 }
 .icon-custom-FutureTrunks {
-  background-position: percentage((97 - 321)/ 320) 0;
+  background-position: percentage((98 - 322)/ 321) 0;
 }
 .icon-custom-Gamer {
-  background-position: percentage((98 - 321)/ 320) 0;
+  background-position: percentage((99 - 322)/ 321) 0;
 }
 .icon-custom-MiniGanon {
-  background-position: percentage((99 - 321)/ 320) 0;
+  background-position: percentage((100 - 322)/ 321) 0;
 }
 .icon-custom-Ganondorf {
-  background-position: percentage((100 - 321)/ 320) 0;
+  background-position: percentage((101 - 322)/ 321) 0;
 }
 .icon-custom-Garfield {
-  background-position: percentage((101 - 321)/ 320) 0;
+  background-position: percentage((102 - 322)/ 321) 0;
 }
 .icon-custom-Garnet {
-  background-position: percentage((102 - 321)/ 320) 0;
+  background-position: percentage((103 - 322)/ 321) 0;
 }
 .icon-custom-GaroMaster {
-  background-position: percentage((103 - 321)/ 320) 0;
+  background-position: percentage((104 - 322)/ 321) 0;
 }
 .icon-custom-GBCLink {
-  background-position: percentage((104 - 321)/ 320) 0;
+  background-position: percentage((105 - 322)/ 321) 0;
 }
 .icon-custom-Geno {
-  background-position: percentage((105 - 321)/ 320) 0;
+  background-position: percentage((106 - 322)/ 321) 0;
 }
 .icon-custom-GliitchWiitch {
-  background-position: percentage((106 - 321)/ 320) 0;
+  background-position: percentage((107 - 322)/ 321) 0;
 }
 .icon-custom-Gobli {
-  background-position: percentage((107 - 321)/ 320) 0;
+  background-position: percentage((108 - 322)/ 321) 0;
 }
 .icon-custom-Goomba {
-  background-position: percentage((108 - 321)/ 320) 0;
+  background-position: percentage((109 - 322)/ 321) 0;
 }
 .icon-custom-Goose {
-  background-position: percentage((109 - 321)/ 320) 0;
+  background-position: percentage((110 - 322)/ 321) 0;
 }
 .icon-custom-GrandPOOBear {
-  background-position: percentage((110 - 321)/ 320) 0;
+  background-position: percentage((111 - 322)/ 321) 0;
 }
 .icon-custom-Gretis {
-  background-position: percentage((111 - 321)/ 320) 0;
+  background-position: percentage((112 - 322)/ 321) 0;
 }
 .icon-custom-GruncleStan {
-  background-position: percentage((112 - 321)/ 320) 0;
+  background-position: percentage((113 - 322)/ 321) 0;
 }
 .icon-custom-Guiz {
-  background-position: percentage((113 - 321)/ 320) 0;
+  background-position: percentage((114 - 322)/ 321) 0;
 }
 .icon-custom-Hanna {
-  background-position: percentage((114 - 321)/ 320) 0;
+  background-position: percentage((115 - 322)/ 321) 0;
 }
 .icon-custom-HardhatBeetle {
-  background-position: percentage((115 - 321)/ 320) 0;
+  background-position: percentage((116 - 322)/ 321) 0;
 }
 .icon-custom-HatKid {
-  background-position: percentage((116 - 321)/ 320) 0;
+  background-position: percentage((117 - 322)/ 321) 0;
 }
 .icon-custom-HeadlessLink {
-  background-position: percentage((117 - 321)/ 320) 0;
+  background-position: percentage((118 - 322)/ 321) 0;
 }
 .icon-custom-HelloKitty {
-  background-position: percentage((118 - 321)/ 320) 0;
+  background-position: percentage((119 - 322)/ 321) 0;
 }
 .icon-custom-Hidari {
-  background-position: percentage((119 - 321)/ 320) 0;
+  background-position: percentage((120 - 322)/ 321) 0;
 }
 .icon-custom-HintTile {
-  background-position: percentage((120 - 321)/ 320) 0;
+  background-position: percentage((121 - 322)/ 321) 0;
 }
 .icon-custom-HoarderBush {
-  background-position: percentage((121 - 321)/ 320) 0;
+  background-position: percentage((122 - 322)/ 321) 0;
 }
 .icon-custom-HoarderPot {
-  background-position: percentage((122 - 321)/ 320) 0;
+  background-position: percentage((123 - 322)/ 321) 0;
 }
 .icon-custom-HoarderRock {
-  background-position: percentage((123 - 321)/ 320) 0;
+  background-position: percentage((124 - 322)/ 321) 0;
 }
 .icon-custom-HollowKnight {
-  background-position: percentage((124 - 321)/ 320) 0;
+  background-position: percentage((125 - 322)/ 321) 0;
 }
 .icon-custom-HomerSimpson {
-  background-position: percentage((125 - 321)/ 320) 0;
+  background-position: percentage((126 - 322)/ 321) 0;
 }
 .icon-custom-Hotdog {
-  background-position: percentage((126 - 321)/ 320) 0;
+  background-position: percentage((127 - 322)/ 321) 0;
 }
 .icon-custom-HyruleKnight {
-  background-position: percentage((127 - 321)/ 320) 0;
+  background-position: percentage((128 - 322)/ 321) 0;
 }
 .icon-custom-iBazly {
-  background-position: percentage((128 - 321)/ 320) 0;
+  background-position: percentage((129 - 322)/ 321) 0;
 }
 .icon-custom-Ignignokt {
-  background-position: percentage((129 - 321)/ 320) 0;
+  background-position: percentage((130 - 322)/ 321) 0;
 }
 .icon-custom-InformantWoman {
-  background-position: percentage((130 - 321)/ 320) 0;
+  background-position: percentage((131 - 322)/ 321) 0;
 }
 .icon-custom-Inkling {
-  background-position: percentage((131 - 321)/ 320) 0;
+  background-position: percentage((132 - 322)/ 321) 0;
 }
 .icon-custom-InvisibleLink {
-  background-position: percentage((132 - 321)/ 320) 0;
+  background-position: percentage((133 - 322)/ 321) 0;
 }
 .icon-custom-JackFrost {
-  background-position: percentage((133 - 321)/ 320) 0;
+  background-position: percentage((134 - 322)/ 321) 0;
 }
 .icon-custom-JasonFrudnick {
-  background-position: percentage((134 - 321)/ 320) 0;
+  background-position: percentage((135 - 322)/ 321) 0;
 }
 .icon-custom-Jasp {
-  background-position: percentage((135 - 321)/ 320) 0;
+  background-position: percentage((136 - 322)/ 321) 0;
 }
 .icon-custom-Jogurt {
-  background-position: percentage((136 - 321)/ 320) 0;
+  background-position: percentage((137 - 322)/ 321) 0;
 }
 .icon-custom-Katsura {
-  background-position: percentage((137 - 321)/ 320) 0;
+  background-position: percentage((138 - 322)/ 321) 0;
 }
 .icon-custom-Kecleon {
-  background-position: percentage((138 - 321)/ 320) 0;
+  background-position: percentage((139 - 322)/ 321) 0;
 }
 .icon-custom-KennyMcCormick {
-  background-position: percentage((139 - 321)/ 320) 0;
+  background-position: percentage((140 - 322)/ 321) 0;
 }
 .icon-custom-Ketchup {
-  background-position: percentage((140 - 321)/ 320) 0;
+  background-position: percentage((141 - 322)/ 321) 0;
 }
 .icon-custom-Kholdstare {
-  background-position: percentage((141 - 321)/ 320) 0;
+  background-position: percentage((142 - 322)/ 321) 0;
 }
 .icon-custom-KingGothalion {
-  background-position: percentage((142 - 321)/ 320) 0;
+  background-position: percentage((143 - 322)/ 321) 0;
 }
 .icon-custom-KingGraham {
-  background-position: percentage((143 - 321)/ 320) 0;
+  background-position: percentage((144 - 322)/ 321) 0;
 }
 .icon-custom-Kirby {
-  background-position: percentage((144 - 321)/ 320) 0;
+  background-position: percentage((145 - 322)/ 321) 0;
 }
 .icon-custom-Kore8 {
-  background-position: percentage((145 - 321)/ 320) 0;
+  background-position: percentage((146 - 322)/ 321) 0;
 }
 .icon-custom-Korok {
-  background-position: percentage((146 - 321)/ 320) 0;
+  background-position: percentage((147 - 322)/ 321) 0;
 }
 .icon-custom-Lakitu {
-  background-position: percentage((147 - 321)/ 320) 0;
+  background-position: percentage((148 - 322)/ 321) 0;
 }
 .icon-custom-Lapras {
-  background-position: percentage((148 - 321)/ 320) 0;
+  background-position: percentage((149 - 322)/ 321) 0;
 }
 .icon-custom-Lest {
-  background-position: percentage((149 - 321)/ 320) 0;
+  background-position: percentage((150 - 322)/ 321) 0;
 }
 .icon-custom-Lily {
-  background-position: percentage((150 - 321)/ 320) 0;
+  background-position: percentage((151 - 322)/ 321) 0;
 }
 .icon-custom-Linja {
-  background-position: percentage((151 - 321)/ 320) 0;
+  background-position: percentage((152 - 322)/ 321) 0;
 }
 .icon-custom-LinkRedrawn {
-  background-position: percentage((152 - 321)/ 320) 0;
+  background-position: percentage((153 - 322)/ 321) 0;
 }
 .icon-custom-HatColorLink {
-  background-position: percentage((153 - 321)/ 320) 0;
+  background-position: percentage((154 - 322)/ 321) 0;
 }
 .icon-custom-TunicColorLink {
-  background-position: percentage((154 - 321)/ 320) 0;
+  background-position: percentage((155 - 322)/ 321) 0;
 }
 .icon-custom-LittleHylian {
-  background-position: percentage((155 - 321)/ 320) 0;
+  background-position: percentage((156 - 322)/ 321) 0;
 }
 .icon-custom-Pony {
-  background-position: percentage((156 - 321)/ 320) 0;
+  background-position: percentage((157 - 322)/ 321) 0;
 }
 .icon-custom-Locke {
-  background-position: percentage((157 - 321)/ 320) 0;
+  background-position: percentage((158 - 322)/ 321) 0;
 }
 .icon-custom-FigaroMerchant {
-  background-position: percentage((158 - 321)/ 320) 0;
+  background-position: percentage((159 - 322)/ 321) 0;
 }
 .icon-custom-Lucario {
-  background-position: percentage((159 - 321)/ 320) 0;
+  background-position: percentage((160 - 322)/ 321) 0;
 }
 .icon-custom-Luffy {
-  background-position: percentage((160 - 321)/ 320) 0;
+  background-position: percentage((161 - 322)/ 321) 0;
 }
 .icon-custom-Luigi {
-  background-position: percentage((161 - 321)/ 320) 0;
+  background-position: percentage((162 - 322)/ 321) 0;
 }
 .icon-custom-LunaMaindo {
-  background-position: percentage((162 - 321)/ 320) 0;
+  background-position: percentage((163 - 322)/ 321) 0;
 }
 .icon-custom-Madeline {
-  background-position: percentage((163 - 321)/ 320) 0;
+  background-position: percentage((164 - 322)/ 321) 0;
 }
 .icon-custom-Magus {
-  background-position: percentage((164 - 321)/ 320) 0;
+  background-position: percentage((165 - 322)/ 321) 0;
 }
 .icon-custom-Maiden {
-  background-position: percentage((165 - 321)/ 320) 0;
+  background-position: percentage((166 - 322)/ 321) 0;
 }
 .icon-custom-MallowCat {
-  background-position: percentage((166 - 321)/ 320) 0;
+  background-position: percentage((167 - 322)/ 321) 0;
 }
 .icon-custom-MangaLink {
-  background-position: percentage((167 - 321)/ 320) 0;
+  background-position: percentage((168 - 322)/ 321) 0;
 }
 .icon-custom-MapleQueen {
-  background-position: percentage((168 - 321)/ 320) 0;
+  background-position: percentage((169 - 322)/ 321) 0;
 }
 .icon-custom-Marin {
-  background-position: percentage((169 - 321)/ 320) 0;
+  background-position: percentage((170 - 322)/ 321) 0;
 }
 .icon-custom-MarioClassic {
-  background-position: percentage((170 - 321)/ 320) 0;
+  background-position: percentage((171 - 322)/ 321) 0;
 }
 .icon-custom-TanookiMario {
-  background-position: percentage((171 - 321)/ 320) 0;
+  background-position: percentage((172 - 322)/ 321) 0;
 }
 .icon-custom-MarioandCappy {
-  background-position: percentage((172 - 321)/ 320) 0;
+  background-position: percentage((173 - 322)/ 321) 0;
 }
 .icon-custom-MarisaKirisame {
-  background-position: percentage((173 - 321)/ 320) 0;
+  background-position: percentage((174 - 322)/ 321) 0;
 }
 .icon-custom-Matthias {
-  background-position: percentage((174 - 321)/ 320) 0;
+  background-position: percentage((175 - 322)/ 321) 0;
 }
 .icon-custom-Meatwad {
-  background-position: percentage((175 - 321)/ 320) 0;
+  background-position: percentage((176 - 322)/ 321) 0;
 }
 .icon-custom-Medallions {
-  background-position: percentage((176 - 321)/ 320) 0;
+  background-position: percentage((177 - 322)/ 321) 0;
 }
 .icon-custom-Medli {
-  background-position: percentage((177 - 321)/ 320) 0;
+  background-position: percentage((178 - 322)/ 321) 0;
 }
 .icon-custom-MegamanX {
-  background-position: percentage((178 - 321)/ 320) 0;
+  background-position: percentage((179 - 322)/ 321) 0;
 }
 .icon-custom-BabyMetroid {
-  background-position: percentage((179 - 321)/ 320) 0;
+  background-position: percentage((180 - 322)/ 321) 0;
 }
 .icon-custom-MewLp {
-  background-position: percentage((180 - 321)/ 320) 0;
+  background-position: percentage((181 - 322)/ 321) 0;
 }
 .icon-custom-MikeJones {
-  background-position: percentage((181 - 321)/ 320) 0;
+  background-position: percentage((182 - 322)/ 321) 0;
 }
 .icon-custom-MinishLink {
-  background-position: percentage((182 - 321)/ 320) 0;
+  background-position: percentage((183 - 322)/ 321) 0;
 }
 .icon-custom-MinishCapLink {
-  background-position: percentage((183 - 321)/ 320) 0;
+  background-position: percentage((184 - 322)/ 321) 0;
 }
 .icon-custom-missingno {
-  background-position: percentage((184 - 321)/ 320) 0;
+  background-position: percentage((185 - 322)/ 321) 0;
 }
 .icon-custom-Moblin {
-  background-position: percentage((185 - 321)/ 320) 0;
+  background-position: percentage((186 - 322)/ 321) 0;
 }
 .icon-custom-ModernLink {
-  background-position: percentage((186 - 321)/ 320) 0;
+  background-position: percentage((187 - 322)/ 321) 0;
 }
 .icon-custom-Mog {
-  background-position: percentage((187 - 321)/ 320) 0;
+  background-position: percentage((188 - 322)/ 321) 0;
 }
 .icon-custom-MomijiInubashiri {
-  background-position: percentage((188 - 321)/ 320) 0;
+  background-position: percentage((189 - 322)/ 321) 0;
 }
 .icon-custom-Moosh {
-  background-position: percentage((189 - 321)/ 320) 0;
+  background-position: percentage((190 - 322)/ 321) 0;
 }
 .icon-custom-Mouse {
-  background-position: percentage((190 - 321)/ 320) 0;
+  background-position: percentage((191 - 322)/ 321) 0;
 }
 .icon-custom-MsPaintDog {
-  background-position: percentage((191 - 321)/ 320) 0;
+  background-position: percentage((192 - 322)/ 321) 0;
 }
 .icon-custom-PowerUpwithPrideMushroom {
-  background-position: percentage((192 - 321)/ 320) 0;
+  background-position: percentage((193 - 322)/ 321) 0;
 }
 .icon-custom-NatureLink {
-  background-position: percentage((193 - 321)/ 320) 0;
+  background-position: percentage((194 - 322)/ 321) 0;
 }
 .icon-custom-Navi {
-  background-position: percentage((194 - 321)/ 320) 0;
+  background-position: percentage((195 - 322)/ 321) 0;
 }
 .icon-custom-Navirou {
-  background-position: percentage((195 - 321)/ 320) 0;
+  background-position: percentage((196 - 322)/ 321) 0;
 }
 .icon-custom-NedFlanders {
-  background-position: percentage((196 - 321)/ 320) 0;
+  background-position: percentage((197 - 322)/ 321) 0;
 }
 .icon-custom-NegativeLink {
-  background-position: percentage((197 - 321)/ 320) 0;
+  background-position: percentage((198 - 322)/ 321) 0;
 }
 .icon-custom-Neosad {
-  background-position: percentage((198 - 321)/ 320) 0;
+  background-position: percentage((199 - 322)/ 321) 0;
 }
 .icon-custom-NESLink {
-  background-position: percentage((199 - 321)/ 320) 0;
+  background-position: percentage((200 - 322)/ 321) 0;
 }
 .icon-custom-Ness {
-  background-position: percentage((200 - 321)/ 320) 0;
+  background-position: percentage((201 - 322)/ 321) 0;
 }
 .icon-custom-Nia {
-  background-position: percentage((201 - 321)/ 320) 0;
+  background-position: percentage((202 - 322)/ 321) 0;
 }
 .icon-custom-Niddraig {
-  background-position: percentage((202 - 321)/ 320) 0;
+  background-position: percentage((203 - 322)/ 321) 0;
 }
 .icon-custom-Niko {
-  background-position: percentage((203 - 321)/ 320) 0;
+  background-position: percentage((204 - 322)/ 321) 0;
 }
 .icon-custom-OldMan {
-  background-position: percentage((204 - 321)/ 320) 0;
+  background-position: percentage((205 - 322)/ 321) 0;
 }
 .icon-custom-Ori {
-  background-position: percentage((205 - 321)/ 320) 0;
+  background-position: percentage((206 - 322)/ 321) 0;
 }
 .icon-custom-OutlineLink {
-  background-position: percentage((206 - 321)/ 320) 0;
+  background-position: percentage((207 - 322)/ 321) 0;
 }
 .icon-custom-ParallelWorldsLink {
-  background-position: percentage((207 - 321)/ 320) 0;
+  background-position: percentage((208 - 322)/ 321) 0;
 }
 .icon-custom-Paula {
-  background-position: percentage((208 - 321)/ 320) 0;
+  background-position: percentage((209 - 322)/ 321) 0;
 }
 .icon-custom-PrincessPeach {
-  background-position: percentage((209 - 321)/ 320) 0;
+  background-position: percentage((210 - 322)/ 321) 0;
 }
 .icon-custom-PenguinLink {
-  background-position: percentage((210 - 321)/ 320) 0;
+  background-position: percentage((211 - 322)/ 321) 0;
 }
 .icon-custom-Pete {
-  background-position: percentage((211 - 321)/ 320) 0;
+  background-position: percentage((212 - 322)/ 321) 0;
 }
 .icon-custom-PhoenixWright {
-  background-position: percentage((212 - 321)/ 320) 0;
+  background-position: percentage((213 - 322)/ 321) 0;
 }
 .icon-custom-Pikachu {
-  background-position: percentage((213 - 321)/ 320) 0;
+  background-position: percentage((214 - 322)/ 321) 0;
 }
 .icon-custom-PinkRibbonLink {
-  background-position: percentage((214 - 321)/ 320) 0;
+  background-position: percentage((215 - 322)/ 321) 0;
 }
 .icon-custom-PiranhaPlant {
-  background-position: percentage((215 - 321)/ 320) 0;
+  background-position: percentage((216 - 322)/ 321) 0;
 }
 .icon-custom-PlagueKnight {
-  background-position: percentage((216 - 321)/ 320) 0;
+  background-position: percentage((217 - 322)/ 321) 0;
 }
 .icon-custom-Pokey {
-  background-position: percentage((217 - 321)/ 320) 0;
+  background-position: percentage((218 - 322)/ 321) 0;
 }
 .icon-custom-Popoi {
-  background-position: percentage((218 - 321)/ 320) 0;
+  background-position: percentage((219 - 322)/ 321) 0;
 }
 .icon-custom-Poppy {
-  background-position: percentage((219 - 321)/ 320) 0;
+  background-position: percentage((220 - 322)/ 321) 0;
 }
 .icon-custom-PorgKnight {
-  background-position: percentage((220 - 321)/ 320) 0;
+  background-position: percentage((221 - 322)/ 321) 0;
 }
 .icon-custom-PowerpuffGirl {
-  background-position: percentage((221 - 321)/ 320) 0;
+  background-position: percentage((222 - 322)/ 321) 0;
 }
 .icon-custom-PrideLink {
-  background-position: percentage((222 - 321)/ 320) 0;
+  background-position: percentage((223 - 322)/ 321) 0;
 }
 .icon-custom-Primm {
-  background-position: percentage((223 - 321)/ 320) 0;
+  background-position: percentage((224 - 322)/ 321) 0;
 }
 .icon-custom-PrincessBubblegum {
-  background-position: percentage((224 - 321)/ 320) 0;
+  background-position: percentage((225 - 322)/ 321) 0;
 }
 .icon-custom-Psyduck {
-  background-position: percentage((225 - 321)/ 320) 0;
+  background-position: percentage((226 - 322)/ 321) 0;
 }
 .icon-custom-ThePug {
-  background-position: percentage((226 - 321)/ 320) 0;
+  background-position: percentage((227 - 322)/ 321) 0;
 }
 .icon-custom-PurpleChest {
-  background-position: percentage((227 - 321)/ 320) 0;
+  background-position: percentage((228 - 322)/ 321) 0;
 }
 .icon-custom-Pyro {
-  background-position: percentage((228 - 321)/ 320) 0;
+  background-position: percentage((229 - 322)/ 321) 0;
 }
 .icon-custom-RainbowLink {
-  background-position: percentage((229 - 321)/ 320) 0;
+  background-position: percentage((230 - 322)/ 321) 0;
 }
 .icon-custom-Rat {
-  background-position: percentage((230 - 321)/ 320) 0;
+  background-position: percentage((231 - 322)/ 321) 0;
 }
 .icon-custom-RedMage {
-  background-position: percentage((231 - 321)/ 320) 0;
+  background-position: percentage((232 - 322)/ 321) 0;
 }
 .icon-custom-Remeer {
-  background-position: percentage((232 - 321)/ 320) 0;
+  background-position: percentage((233 - 322)/ 321) 0;
 }
 .icon-custom-Rick {
-  background-position: percentage((233 - 321)/ 320) 0;
+  background-position: percentage((234 - 322)/ 321) 0;
 }
 .icon-custom-Robo-Link9000 {
-  background-position: percentage((234 - 321)/ 320) 0;
+  background-position: percentage((235 - 322)/ 321) 0;
 }
 .icon-custom-Rocko {
-  background-position: percentage((235 - 321)/ 320) 0;
+  background-position: percentage((236 - 322)/ 321) 0;
 }
 .icon-custom-Rottytops {
-  background-position: percentage((236 - 321)/ 320) 0;
+  background-position: percentage((237 - 322)/ 321) 0;
 }
 .icon-custom-Rover {
-  background-position: percentage((237 - 321)/ 320) 0;
+  background-position: percentage((238 - 322)/ 321) 0;
 }
 .icon-custom-RoyKoopa {
-  background-position: percentage((238 - 321)/ 320) 0;
+  background-position: percentage((239 - 322)/ 321) 0;
 }
 .icon-custom-Rumia {
-  background-position: percentage((239 - 321)/ 320) 0;
+  background-position: percentage((240 - 322)/ 321) 0;
 }
 .icon-custom-Rydia {
-  background-position: percentage((240 - 321)/ 320) 0;
+  background-position: percentage((241 - 322)/ 321) 0;
 }
 .icon-custom-Ryu {
-  background-position: percentage((241 - 321)/ 320) 0;
+  background-position: percentage((242 - 322)/ 321) 0;
 }
 .icon-custom-SailorMoon {
-  background-position: percentage((242 - 321)/ 320) 0;
+  background-position: percentage((243 - 322)/ 321) 0;
 }
 .icon-custom-Saitama {
-  background-position: percentage((243 - 321)/ 320) 0;
+  background-position: percentage((244 - 322)/ 321) 0;
 }
 .icon-custom-SamusSuperMetroid {
-  background-position: percentage((244 - 321)/ 320) 0;
+  background-position: percentage((245 - 322)/ 321) 0;
 }
 .icon-custom-Samus {
-  background-position: percentage((245 - 321)/ 320) 0;
+  background-position: percentage((246 - 322)/ 321) 0;
 }
 .icon-custom-SamusClassic {
-  background-position: percentage((246 - 321)/ 320) 0;
+  background-position: percentage((247 - 322)/ 321) 0;
 }
 .icon-custom-SantaLink {
-  background-position: percentage((247 - 321)/ 320) 0;
+  background-position: percentage((248 - 322)/ 321) 0;
 }
 .icon-custom-Scholar {
-  background-position: percentage((248 - 321)/ 320) 0;
+  background-position: percentage((249 - 322)/ 321) 0;
 }
 .icon-custom-Selan {
-  background-position: percentage((249 - 321)/ 320) 0;
+  background-position: percentage((250 - 322)/ 321) 0;
 }
 .icon-custom-SevenS1ns {
-  background-position: percentage((250 - 321)/ 320) 0;
+  background-position: percentage((251 - 322)/ 321) 0;
 }
 .icon-custom-Shadow {
-  background-position: percentage((251 - 321)/ 320) 0;
+  background-position: percentage((252 - 322)/ 321) 0;
 }
 .icon-custom-ShadowSakura {
-  background-position: percentage((252 - 321)/ 320) 0;
+  background-position: percentage((253 - 322)/ 321) 0;
 }
 .icon-custom-Shantae {
-  background-position: percentage((253 - 321)/ 320) 0;
+  background-position: percentage((254 - 322)/ 321) 0;
 }
 .icon-custom-Shuppet {
-  background-position: percentage((254 - 321)/ 320) 0;
+  background-position: percentage((255 - 322)/ 321) 0;
 }
 .icon-custom-ShyGal {
-  background-position: percentage((255 - 321)/ 320) 0;
+  background-position: percentage((256 - 322)/ 321) 0;
 }
 .icon-custom-ShyGuy {
-  background-position: percentage((256 - 321)/ 320) 0;
+  background-position: percentage((257 - 322)/ 321) 0;
 }
 .icon-custom-SighnWaive {
-  background-position: percentage((257 - 321)/ 320) 0;
+  background-position: percentage((258 - 322)/ 321) 0;
 }
 .icon-custom-Slime {
-  background-position: percentage((258 - 321)/ 320) 0;
+  background-position: percentage((259 - 322)/ 321) 0;
 }
 .icon-custom-Slowpoke {
-  background-position: percentage((259 - 321)/ 320) 0;
+  background-position: percentage((260 - 322)/ 321) 0;
 }
 .icon-custom-SNESController {
-  background-position: percentage((260 - 321)/ 320) 0;
+  background-position: percentage((261 - 322)/ 321) 0;
 }
 .icon-custom-SodaCan {
-  background-position: percentage((261 - 321)/ 320) 0;
+  background-position: percentage((262 - 322)/ 321) 0;
 }
 .icon-custom-SolaireofAstora {
-  background-position: percentage((262 - 321)/ 320) 0;
+  background-position: percentage((263 - 322)/ 321) 0;
 }
 .icon-custom-HyruleSoldier {
-  background-position: percentage((263 - 321)/ 320) 0;
+  background-position: percentage((264 - 322)/ 321) 0;
 }
 .icon-custom-SonictheHedgehog {
-  background-position: percentage((264 - 321)/ 320) 0;
+  background-position: percentage((265 - 322)/ 321) 0;
 }
 .icon-custom-Sora {
-  background-position: percentage((265 - 321)/ 320) 0;
+  background-position: percentage((266 - 322)/ 321) 0;
 }
 .icon-custom-SoraKH1 {
-  background-position: percentage((266 - 321)/ 320) 0;
+  background-position: percentage((267 - 322)/ 321) 0;
 }
 .icon-custom-SpongebobSquarepants {
-  background-position: percentage((267 - 321)/ 320) 0;
+  background-position: percentage((268 - 322)/ 321) 0;
 }
 .icon-custom-Squall {
-  background-position: percentage((268 - 321)/ 320) 0;
+  background-position: percentage((269 - 322)/ 321) 0;
 }
 .icon-custom-Squirrel {
-  background-position: percentage((269 - 321)/ 320) 0;
+  background-position: percentage((270 - 322)/ 321) 0;
 }
 .icon-custom-Squirtle {
-  background-position: percentage((270 - 321)/ 320) 0;
+  background-position: percentage((271 - 322)/ 321) 0;
 }
 .icon-custom-Stalfos {
-  background-position: percentage((271 - 321)/ 320) 0;
+  background-position: percentage((272 - 322)/ 321) 0;
 }
 .icon-custom-Stan {
-  background-position: percentage((272 - 321)/ 320) 0;
+  background-position: percentage((273 - 322)/ 321) 0;
 }
 .icon-custom-StaticLink {
-  background-position: percentage((273 - 321)/ 320) 0;
+  background-position: percentage((274 - 322)/ 321) 0;
 }
 .icon-custom-SteamedHams {
-  background-position: percentage((274 - 321)/ 320) 0;
+  background-position: percentage((275 - 322)/ 321) 0;
 }
 .icon-custom-StickMan {
-  background-position: percentage((275 - 321)/ 320) 0;
+  background-position: percentage((276 - 322)/ 321) 0;
 }
 .icon-custom-SuperBomb {
-  background-position: percentage((276 - 321)/ 320) 0;
+  background-position: percentage((277 - 322)/ 321) 0;
 }
 .icon-custom-SuperBunny {
-  background-position: percentage((277 - 321)/ 320) 0;
+  background-position: percentage((278 - 322)/ 321) 0;
 }
 .icon-custom-SuperMeatBoy {
-  background-position: percentage((278 - 321)/ 320) 0;
+  background-position: percentage((279 - 322)/ 321) 0;
 }
 .icon-custom-Susie {
-  background-position: percentage((279 - 321)/ 320) 0;
+  background-position: percentage((280 - 322)/ 321) 0;
 }
 .icon-custom-Swatchy {
-  background-position: percentage((280 - 321)/ 320) 0;
+  background-position: percentage((281 - 322)/ 321) 0;
 }
 .icon-custom-TASBot {
-  background-position: percentage((281 - 321)/ 320) 0;
+  background-position: percentage((282 - 322)/ 321) 0;
 }
 .icon-custom-TeaTime {
-  background-position: percentage((282 - 321)/ 320) 0;
+  background-position: percentage((283 - 322)/ 321) 0;
 }
 .icon-custom-TerraEsper {
-  background-position: percentage((283 - 321)/ 320) 0;
+  background-position: percentage((284 - 322)/ 321) 0;
 }
 .icon-custom-Tetra {
-  background-position: percentage((284 - 321)/ 320) 0;
+  background-position: percentage((285 - 322)/ 321) 0;
 }
 .icon-custom-TGH {
-  background-position: percentage((285 - 321)/ 320) 0;
+  background-position: percentage((286 - 322)/ 321) 0;
 }
 .icon-custom-Thief {
-  background-position: percentage((286 - 321)/ 320) 0;
+  background-position: percentage((287 - 322)/ 321) 0;
 }
 .icon-custom-Thomcrow {
-  background-position: percentage((287 - 321)/ 320) 0;
+  background-position: percentage((288 - 322)/ 321) 0;
 }
 .icon-custom-Tile {
-  background-position: percentage((288 - 321)/ 320) 0;
+  background-position: percentage((289 - 322)/ 321) 0;
 }
 .icon-custom-Tingle {
-  background-position: percentage((289 - 321)/ 320) 0;
+  background-position: percentage((290 - 322)/ 321) 0;
 }
 .icon-custom-TMNT {
-  background-position: percentage((290 - 321)/ 320) 0;
+  background-position: percentage((291 - 322)/ 321) 0;
 }
 .icon-custom-Toad {
-  background-position: percentage((291 - 321)/ 320) 0;
+  background-position: percentage((292 - 322)/ 321) 0;
 }
 .icon-custom-Toadette {
-  background-position: percentage((292 - 321)/ 320) 0;
+  background-position: percentage((293 - 322)/ 321) 0;
 }
 .icon-custom-CaptainToadette {
-  background-position: percentage((293 - 321)/ 320) 0;
+  background-position: percentage((294 - 322)/ 321) 0;
 }
 .icon-custom-TotemLinks {
-  background-position: percentage((294 - 321)/ 320) 0;
+  background-position: percentage((295 - 322)/ 321) 0;
 }
 .icon-custom-TrogdortheBurninator {
-  background-position: percentage((295 - 321)/ 320) 0;
+  background-position: percentage((296 - 322)/ 321) 0;
 }
 .icon-custom-TPZelda {
-  background-position: percentage((296 - 321)/ 320) 0;
+  background-position: percentage((297 - 322)/ 321) 0;
 }
 .icon-custom-TwoFaced {
-  background-position: percentage((297 - 321)/ 320) 0;
+  background-position: percentage((298 - 322)/ 321) 0;
 }
 .icon-custom-TytheTasmanianTiger {
-  background-position: percentage((298 - 321)/ 320) 0;
+  background-position: percentage((299 - 322)/ 321) 0;
 }
 .icon-custom-Ultros {
-  background-position: percentage((299 - 321)/ 320) 0;
+  background-position: percentage((300 - 322)/ 321) 0;
 }
 .icon-custom-Valeera {
-  background-position: percentage((300 - 321)/ 320) 0;
+  background-position: percentage((301 - 322)/ 321) 0;
 }
 .icon-custom-VanillaLink {
-  background-position: percentage((301 - 321)/ 320) 0;
+  background-position: percentage((302 - 322)/ 321) 0;
 }
 .icon-custom-Vaporeon {
-  background-position: percentage((302 - 321)/ 320) 0;
+  background-position: percentage((303 - 322)/ 321) 0;
 }
 .icon-custom-Vegeta {
-  background-position: percentage((303 - 321)/ 320) 0;
+  background-position: percentage((304 - 322)/ 321) 0;
 }
 .icon-custom-Vera {
-  background-position: percentage((304 - 321)/ 320) 0;
+  background-position: percentage((305 - 322)/ 321) 0;
 }
 .icon-custom-Vitreous {
-  background-position: percentage((305 - 321)/ 320) 0;
+  background-position: percentage((306 - 322)/ 321) 0;
 }
 .icon-custom-Vivi {
-  background-position: percentage((306 - 321)/ 320) 0;
+  background-position: percentage((307 - 322)/ 321) 0;
 }
 .icon-custom-Vivian {
-  background-position: percentage((307 - 321)/ 320) 0;
+  background-position: percentage((308 - 322)/ 321) 0;
 }
 .icon-custom-Wario {
-  background-position: percentage((308 - 321)/ 320) 0;
+  background-position: percentage((309 - 322)/ 321) 0;
 }
 .icon-custom-Will {
-  background-position: percentage((309 - 321)/ 320) 0;
+  background-position: percentage((310 - 322)/ 321) 0;
 }
 .icon-custom-Wizzrobe {
-  background-position: percentage((310 - 321)/ 320) 0;
+  background-position: percentage((311 - 322)/ 321) 0;
 }
 .icon-custom-WolfLinkFestive {
-  background-position: percentage((311 - 321)/ 320) 0;
+  background-position: percentage((312 - 322)/ 321) 0;
 }
 .icon-custom-WolfLinkTP {
-  background-position: percentage((312 - 321)/ 320) 0;
+  background-position: percentage((313 - 322)/ 321) 0;
 }
 .icon-custom-Yoshi {
-  background-position: percentage((313 - 321)/ 320) 0;
+  background-position: percentage((314 - 322)/ 321) 0;
 }
 .icon-custom-YunicaTovah {
-  background-position: percentage((314 - 321)/ 320) 0;
+  background-position: percentage((315 - 322)/ 321) 0;
 }
 .icon-custom-Zandra {
-  background-position: percentage((315 - 321)/ 320) 0;
+  background-position: percentage((316 - 322)/ 321) 0;
 }
 .icon-custom-ZebraUnicorn {
-  background-position: percentage((316 - 321)/ 320) 0;
+  background-position: percentage((317 - 322)/ 321) 0;
 }
 .icon-custom-Zeckemyro {
-  background-position: percentage((317 - 321)/ 320) 0;
+  background-position: percentage((318 - 322)/ 321) 0;
 }
 .icon-custom-Zelda {
-  background-position: percentage((318 - 321)/ 320) 0;
+  background-position: percentage((319 - 322)/ 321) 0;
 }
 .icon-custom-ZeroSuitSamus {
-  background-position: percentage((319 - 321)/ 320) 0;
+  background-position: percentage((320 - 322)/ 321) 0;
 }
 .icon-custom-Zora {
-  background-position: percentage((320 - 321)/ 320) 0;
+  background-position: percentage((321 - 322)/ 321) 0;
 }

--- a/resources/sass/_sprites.scss
+++ b/resources/sass/_sprites.scss
@@ -10,923 +10,962 @@
   background-position: 0 0;
 }
 .icon-custom-Link {
-  background-position: percentage((1 - 308)/ 307) 0;
+  background-position: percentage((1 - 321)/ 320) 0;
 }
 .icon-custom-FourSwordsLink {
-  background-position: percentage((2 - 308)/ 307) 0;
+  background-position: percentage((2 - 321)/ 320) 0;
 }
 .icon-custom-Abigail {
-  background-position: percentage((3 - 308)/ 307) 0;
+  background-position: percentage((3 - 321)/ 320) 0;
 }
 .icon-custom-Adol {
-  background-position: percentage((4 - 308)/ 307) 0;
+  background-position: percentage((4 - 321)/ 320) 0;
 }
 .icon-custom-Aggretsuko {
-  background-position: percentage((5 - 308)/ 307) 0;
+  background-position: percentage((5 - 321)/ 320) 0;
 }
 .icon-custom-Alice {
-  background-position: percentage((6 - 308)/ 307) 0;
+  background-position: percentage((6 - 321)/ 320) 0;
 }
 .icon-custom-AngryVideoGameNerd {
-  background-position: percentage((7 - 308)/ 307) 0;
+  background-position: percentage((7 - 321)/ 320) 0;
 }
 .icon-custom-Arcane {
-  background-position: percentage((8 - 308)/ 307) 0;
+  background-position: percentage((8 - 321)/ 320) 0;
 }
 .icon-custom-ArkNoCape {
-  background-position: percentage((9 - 308)/ 307) 0;
+  background-position: percentage((9 - 321)/ 320) 0;
 }
 .icon-custom-ArkCape {
-  background-position: percentage((10 - 308)/ 307) 0;
+  background-position: percentage((10 - 321)/ 320) 0;
 }
 .icon-custom-Arrghus {
-  background-position: percentage((11 - 308)/ 307) 0;
+  background-position: percentage((11 - 321)/ 320) 0;
 }
 .icon-custom-Astronaut {
-  background-position: percentage((12 - 308)/ 307) 0;
+  background-position: percentage((12 - 321)/ 320) 0;
 }
 .icon-custom-Asuna {
-  background-position: percentage((13 - 308)/ 307) 0;
+  background-position: percentage((13 - 321)/ 320) 0;
 }
 .icon-custom-Badeline {
-  background-position: percentage((14 - 308)/ 307) 0;
+  background-position: percentage((14 - 321)/ 320) 0;
 }
 .icon-custom-BananasInPyjamas {
-  background-position: percentage((15 - 308)/ 307) 0;
+  background-position: percentage((15 - 321)/ 320) 0;
 }
 .icon-custom-Bandit {
-  background-position: percentage((16 - 308)/ 307) 0;
+  background-position: percentage((16 - 321)/ 320) 0;
 }
 .icon-custom-Batman {
-  background-position: percentage((17 - 308)/ 307) 0;
+  background-position: percentage((17 - 321)/ 320) 0;
 }
 .icon-custom-Beau {
-  background-position: percentage((18 - 308)/ 307) 0;
+  background-position: percentage((18 - 321)/ 320) 0;
 }
 .icon-custom-Bewp {
-  background-position: percentage((19 - 308)/ 307) 0;
+  background-position: percentage((19 - 321)/ 320) 0;
 }
 .icon-custom-BigKey {
-  background-position: percentage((20 - 308)/ 307) 0;
+  background-position: percentage((20 - 321)/ 320) 0;
 }
 .icon-custom-Birb {
-  background-position: percentage((21 - 308)/ 307) 0;
+  background-position: percentage((21 - 321)/ 320) 0;
 }
 .icon-custom-Birdo {
-  background-position: percentage((22 - 308)/ 307) 0;
+  background-position: percentage((22 - 321)/ 320) 0;
 }
 .icon-custom-BlackMage {
-  background-position: percentage((23 - 308)/ 307) 0;
+  background-position: percentage((23 - 321)/ 320) 0;
 }
 .icon-custom-BlacksmithLink {
-  background-position: percentage((24 - 308)/ 307) 0;
+  background-position: percentage((24 - 321)/ 320) 0;
+}
+.icon-custom-Blazer {
+  background-position: percentage((25 - 321)/ 320) 0;
 }
 .icon-custom-Blossom {
-  background-position: percentage((25 - 308)/ 307) 0;
+  background-position: percentage((26 - 321)/ 320) 0;
 }
 .icon-custom-Bob {
-  background-position: percentage((26 - 308)/ 307) 0;
+  background-position: percentage((27 - 321)/ 320) 0;
 }
 .icon-custom-BobRoss {
-  background-position: percentage((27 - 308)/ 307) 0;
+  background-position: percentage((28 - 321)/ 320) 0;
 }
 .icon-custom-Boo2 {
-  background-position: percentage((28 - 308)/ 307) 0;
+  background-position: percentage((29 - 321)/ 320) 0;
 }
 .icon-custom-Boo {
-  background-position: percentage((29 - 308)/ 307) 0;
+  background-position: percentage((30 - 321)/ 320) 0;
 }
 .icon-custom-BottleoGoo {
-  background-position: percentage((30 - 308)/ 307) 0;
+  background-position: percentage((31 - 321)/ 320) 0;
+}
+.icon-custom-BotWLink {
+  background-position: percentage((32 - 321)/ 320) 0;
 }
 .icon-custom-BotWZelda {
-  background-position: percentage((31 - 308)/ 307) 0;
+  background-position: percentage((33 - 321)/ 320) 0;
 }
 .icon-custom-Bowser {
-  background-position: percentage((32 - 308)/ 307) 0;
+  background-position: percentage((34 - 321)/ 320) 0;
+}
+.icon-custom-BowsetteRed {
+  background-position: percentage((35 - 321)/ 320) 0;
+}
+.icon-custom-Bowsette {
+  background-position: percentage((36 - 321)/ 320) 0;
 }
 .icon-custom-Branch {
-  background-position: percentage((33 - 308)/ 307) 0;
+  background-position: percentage((37 - 321)/ 320) 0;
 }
 .icon-custom-Brian {
-  background-position: percentage((34 - 308)/ 307) 0;
+  background-position: percentage((38 - 321)/ 320) 0;
 }
 .icon-custom-Broccoli {
-  background-position: percentage((35 - 308)/ 307) 0;
+  background-position: percentage((39 - 321)/ 320) 0;
 }
 .icon-custom-Bronzor {
-  background-position: percentage((36 - 308)/ 307) 0;
+  background-position: percentage((40 - 321)/ 320) 0;
 }
 .icon-custom-BSBoy {
-  background-position: percentage((37 - 308)/ 307) 0;
+  background-position: percentage((41 - 321)/ 320) 0;
 }
 .icon-custom-BSGirl {
-  background-position: percentage((38 - 308)/ 307) 0;
+  background-position: percentage((42 - 321)/ 320) 0;
 }
 .icon-custom-Bubbles {
-  background-position: percentage((39 - 308)/ 307) 0;
+  background-position: percentage((43 - 321)/ 320) 0;
 }
 .icon-custom-BulletBill {
-  background-position: percentage((40 - 308)/ 307) 0;
+  background-position: percentage((44 - 321)/ 320) 0;
 }
 .icon-custom-Buttercup {
-  background-position: percentage((41 - 308)/ 307) 0;
+  background-position: percentage((45 - 321)/ 320) 0;
 }
 .icon-custom-Cactuar {
-  background-position: percentage((42 - 308)/ 307) 0;
+  background-position: percentage((46 - 321)/ 320) 0;
 }
 .icon-custom-Cadence {
-  background-position: percentage((43 - 308)/ 307) 0;
+  background-position: percentage((47 - 321)/ 320) 0;
 }
 .icon-custom-CarlSagan42 {
-  background-position: percentage((44 - 308)/ 307) 0;
+  background-position: percentage((48 - 321)/ 320) 0;
 }
 .icon-custom-CasualZelda {
-  background-position: percentage((45 - 308)/ 307) 0;
+  background-position: percentage((49 - 321)/ 320) 0;
 }
 .icon-custom-MarvintheCat {
-  background-position: percentage((46 - 308)/ 307) 0;
+  background-position: percentage((50 - 321)/ 320) 0;
 }
 .icon-custom-CatBoo {
-  background-position: percentage((47 - 308)/ 307) 0;
+  background-position: percentage((51 - 321)/ 320) 0;
 }
 .icon-custom-CD-iLink {
-  background-position: percentage((48 - 308)/ 307) 0;
+  background-position: percentage((52 - 321)/ 320) 0;
 }
 .icon-custom-Celes {
-  background-position: percentage((49 - 308)/ 307) 0;
+  background-position: percentage((53 - 321)/ 320) 0;
 }
 .icon-custom-Charizard {
-  background-position: percentage((50 - 308)/ 307) 0;
+  background-position: percentage((54 - 321)/ 320) 0;
 }
 .icon-custom-CheepCheep {
-  background-position: percentage((51 - 308)/ 307) 0;
+  background-position: percentage((55 - 321)/ 320) 0;
 }
 .icon-custom-Chibity {
-  background-position: percentage((52 - 308)/ 307) 0;
+  background-position: percentage((56 - 321)/ 320) 0;
+}
+.icon-custom-Chrizzz {
+  background-position: percentage((57 - 321)/ 320) 0;
 }
 .icon-custom-Cirno {
-  background-position: percentage((53 - 308)/ 307) 0;
+  background-position: percentage((58 - 321)/ 320) 0;
 }
 .icon-custom-Clifford {
-  background-position: percentage((54 - 308)/ 307) 0;
+  background-position: percentage((59 - 321)/ 320) 0;
 }
 .icon-custom-Clyde {
-  background-position: percentage((55 - 308)/ 307) 0;
+  background-position: percentage((60 - 321)/ 320) 0;
 }
 .icon-custom-Conker {
-  background-position: percentage((56 - 308)/ 307) 0;
+  background-position: percentage((61 - 321)/ 320) 0;
 }
 .icon-custom-Cornelius {
-  background-position: percentage((57 - 308)/ 307) 0;
+  background-position: percentage((62 - 321)/ 320) 0;
 }
 .icon-custom-Corona {
-  background-position: percentage((58 - 308)/ 307) 0;
+  background-position: percentage((63 - 321)/ 320) 0;
 }
 .icon-custom-Crewmate {
-  background-position: percentage((59 - 308)/ 307) 0;
+  background-position: percentage((64 - 321)/ 320) 0;
 }
 .icon-custom-Cucco {
-  background-position: percentage((60 - 308)/ 307) 0;
+  background-position: percentage((65 - 321)/ 320) 0;
 }
 .icon-custom-Cursor {
-  background-position: percentage((61 - 308)/ 307) 0;
+  background-position: percentage((66 - 321)/ 320) 0;
 }
 .icon-custom-DOwls {
-  background-position: percentage((62 - 308)/ 307) 0;
+  background-position: percentage((67 - 321)/ 320) 0;
 }
 .icon-custom-DarkPanda {
-  background-position: percentage((63 - 308)/ 307) 0;
+  background-position: percentage((68 - 321)/ 320) 0;
 }
 .icon-custom-DarkBoy {
-  background-position: percentage((64 - 308)/ 307) 0;
+  background-position: percentage((69 - 321)/ 320) 0;
 }
 .icon-custom-DarkGirl {
-  background-position: percentage((65 - 308)/ 307) 0;
+  background-position: percentage((70 - 321)/ 320) 0;
 }
 .icon-custom-DarkLinkTunic {
-  background-position: percentage((66 - 308)/ 307) 0;
+  background-position: percentage((71 - 321)/ 320) 0;
 }
 .icon-custom-DarkLink {
-  background-position: percentage((67 - 308)/ 307) 0;
+  background-position: percentage((72 - 321)/ 320) 0;
 }
 .icon-custom-DarkSwatchy {
-  background-position: percentage((68 - 308)/ 307) 0;
+  background-position: percentage((73 - 321)/ 320) 0;
 }
 .icon-custom-DarkZelda {
-  background-position: percentage((69 - 308)/ 307) 0;
+  background-position: percentage((74 - 321)/ 320) 0;
 }
 .icon-custom-DarkZora {
-  background-position: percentage((70 - 308)/ 307) 0;
+  background-position: percentage((75 - 321)/ 320) 0;
 }
 .icon-custom-DeadpoolMythic {
-  background-position: percentage((71 - 308)/ 307) 0;
+  background-position: percentage((76 - 321)/ 320) 0;
 }
 .icon-custom-DeadpoolSirCzah {
-  background-position: percentage((72 - 308)/ 307) 0;
+  background-position: percentage((77 - 321)/ 320) 0;
 }
 .icon-custom-Deadrock {
-  background-position: percentage((73 - 308)/ 307) 0;
+  background-position: percentage((78 - 321)/ 320) 0;
 }
 .icon-custom-Decidueye {
-  background-position: percentage((74 - 308)/ 307) 0;
+  background-position: percentage((79 - 321)/ 320) 0;
 }
 .icon-custom-Dekar {
-  background-position: percentage((75 - 308)/ 307) 0;
+  background-position: percentage((80 - 321)/ 320) 0;
 }
 .icon-custom-DemonLink {
-  background-position: percentage((76 - 308)/ 307) 0;
+  background-position: percentage((81 - 321)/ 320) 0;
 }
 .icon-custom-Dragonite {
-  background-position: percentage((77 - 308)/ 307) 0;
+  background-position: percentage((82 - 321)/ 320) 0;
 }
 .icon-custom-DrakeTheDragon {
-  background-position: percentage((78 - 308)/ 307) 0;
+  background-position: percentage((83 - 321)/ 320) 0;
 }
 .icon-custom-Eggplant {
-  background-position: percentage((79 - 308)/ 307) 0;
+  background-position: percentage((84 - 321)/ 320) 0;
 }
 .icon-custom-EmoSaru {
-  background-position: percentage((80 - 308)/ 307) 0;
+  background-position: percentage((85 - 321)/ 320) 0;
 }
 .icon-custom-Ezlo {
-  background-position: percentage((81 - 308)/ 307) 0;
+  background-position: percentage((86 - 321)/ 320) 0;
 }
 .icon-custom-FierceDeityLink {
-  background-position: percentage((82 - 308)/ 307) 0;
+  background-position: percentage((87 - 321)/ 320) 0;
 }
 .icon-custom-FinnMerten {
-  background-position: percentage((83 - 308)/ 307) 0;
+  background-position: percentage((88 - 321)/ 320) 0;
 }
 .icon-custom-FinnyBear {
-  background-position: percentage((84 - 308)/ 307) 0;
+  background-position: percentage((89 - 321)/ 320) 0;
 }
 .icon-custom-FloodgateFish {
-  background-position: percentage((85 - 308)/ 307) 0;
+  background-position: percentage((90 - 321)/ 320) 0;
 }
 .icon-custom-FlavorGuy {
-  background-position: percentage((86 - 308)/ 307) 0;
+  background-position: percentage((91 - 321)/ 320) 0;
 }
 .icon-custom-FoxLink {
-  background-position: percentage((87 - 308)/ 307) 0;
+  background-position: percentage((92 - 321)/ 320) 0;
 }
 .icon-custom-FreyaCrescent {
-  background-position: percentage((88 - 308)/ 307) 0;
+  background-position: percentage((93 - 321)/ 320) 0;
 }
 .icon-custom-Frisk {
-  background-position: percentage((89 - 308)/ 307) 0;
+  background-position: percentage((94 - 321)/ 320) 0;
 }
 .icon-custom-FrogLink {
-  background-position: percentage((90 - 308)/ 307) 0;
+  background-position: percentage((95 - 321)/ 320) 0;
 }
 .icon-custom-Fujin {
-  background-position: percentage((91 - 308)/ 307) 0;
+  background-position: percentage((96 - 321)/ 320) 0;
 }
 .icon-custom-FutureTrunks {
-  background-position: percentage((92 - 308)/ 307) 0;
+  background-position: percentage((97 - 321)/ 320) 0;
 }
 .icon-custom-Gamer {
-  background-position: percentage((93 - 308)/ 307) 0;
+  background-position: percentage((98 - 321)/ 320) 0;
 }
 .icon-custom-MiniGanon {
-  background-position: percentage((94 - 308)/ 307) 0;
+  background-position: percentage((99 - 321)/ 320) 0;
 }
 .icon-custom-Ganondorf {
-  background-position: percentage((95 - 308)/ 307) 0;
+  background-position: percentage((100 - 321)/ 320) 0;
 }
 .icon-custom-Garfield {
-  background-position: percentage((96 - 308)/ 307) 0;
+  background-position: percentage((101 - 321)/ 320) 0;
 }
 .icon-custom-Garnet {
-  background-position: percentage((97 - 308)/ 307) 0;
+  background-position: percentage((102 - 321)/ 320) 0;
 }
 .icon-custom-GaroMaster {
-  background-position: percentage((98 - 308)/ 307) 0;
+  background-position: percentage((103 - 321)/ 320) 0;
 }
 .icon-custom-GBCLink {
-  background-position: percentage((99 - 308)/ 307) 0;
+  background-position: percentage((104 - 321)/ 320) 0;
 }
 .icon-custom-Geno {
-  background-position: percentage((100 - 308)/ 307) 0;
+  background-position: percentage((105 - 321)/ 320) 0;
 }
 .icon-custom-GliitchWiitch {
-  background-position: percentage((101 - 308)/ 307) 0;
+  background-position: percentage((106 - 321)/ 320) 0;
 }
 .icon-custom-Gobli {
-  background-position: percentage((102 - 308)/ 307) 0;
+  background-position: percentage((107 - 321)/ 320) 0;
 }
 .icon-custom-Goomba {
-  background-position: percentage((103 - 308)/ 307) 0;
+  background-position: percentage((108 - 321)/ 320) 0;
 }
 .icon-custom-Goose {
-  background-position: percentage((104 - 308)/ 307) 0;
+  background-position: percentage((109 - 321)/ 320) 0;
 }
 .icon-custom-GrandPOOBear {
-  background-position: percentage((105 - 308)/ 307) 0;
+  background-position: percentage((110 - 321)/ 320) 0;
 }
 .icon-custom-Gretis {
-  background-position: percentage((106 - 308)/ 307) 0;
+  background-position: percentage((111 - 321)/ 320) 0;
 }
 .icon-custom-GruncleStan {
-  background-position: percentage((107 - 308)/ 307) 0;
+  background-position: percentage((112 - 321)/ 320) 0;
 }
 .icon-custom-Guiz {
-  background-position: percentage((108 - 308)/ 307) 0;
+  background-position: percentage((113 - 321)/ 320) 0;
 }
 .icon-custom-Hanna {
-  background-position: percentage((109 - 308)/ 307) 0;
+  background-position: percentage((114 - 321)/ 320) 0;
 }
 .icon-custom-HardhatBeetle {
-  background-position: percentage((110 - 308)/ 307) 0;
+  background-position: percentage((115 - 321)/ 320) 0;
 }
 .icon-custom-HatKid {
-  background-position: percentage((111 - 308)/ 307) 0;
+  background-position: percentage((116 - 321)/ 320) 0;
 }
 .icon-custom-HeadlessLink {
-  background-position: percentage((112 - 308)/ 307) 0;
+  background-position: percentage((117 - 321)/ 320) 0;
 }
 .icon-custom-HelloKitty {
-  background-position: percentage((113 - 308)/ 307) 0;
+  background-position: percentage((118 - 321)/ 320) 0;
 }
 .icon-custom-Hidari {
-  background-position: percentage((114 - 308)/ 307) 0;
+  background-position: percentage((119 - 321)/ 320) 0;
 }
 .icon-custom-HintTile {
-  background-position: percentage((115 - 308)/ 307) 0;
+  background-position: percentage((120 - 321)/ 320) 0;
 }
 .icon-custom-HoarderBush {
-  background-position: percentage((116 - 308)/ 307) 0;
+  background-position: percentage((121 - 321)/ 320) 0;
 }
 .icon-custom-HoarderPot {
-  background-position: percentage((117 - 308)/ 307) 0;
+  background-position: percentage((122 - 321)/ 320) 0;
 }
 .icon-custom-HoarderRock {
-  background-position: percentage((118 - 308)/ 307) 0;
+  background-position: percentage((123 - 321)/ 320) 0;
+}
+.icon-custom-HollowKnight {
+  background-position: percentage((124 - 321)/ 320) 0;
 }
 .icon-custom-HomerSimpson {
-  background-position: percentage((119 - 308)/ 307) 0;
+  background-position: percentage((125 - 321)/ 320) 0;
+}
+.icon-custom-Hotdog {
+  background-position: percentage((126 - 321)/ 320) 0;
 }
 .icon-custom-HyruleKnight {
-  background-position: percentage((120 - 308)/ 307) 0;
+  background-position: percentage((127 - 321)/ 320) 0;
 }
 .icon-custom-iBazly {
-  background-position: percentage((121 - 308)/ 307) 0;
+  background-position: percentage((128 - 321)/ 320) 0;
 }
 .icon-custom-Ignignokt {
-  background-position: percentage((122 - 308)/ 307) 0;
+  background-position: percentage((129 - 321)/ 320) 0;
 }
 .icon-custom-InformantWoman {
-  background-position: percentage((123 - 308)/ 307) 0;
+  background-position: percentage((130 - 321)/ 320) 0;
 }
 .icon-custom-Inkling {
-  background-position: percentage((124 - 308)/ 307) 0;
+  background-position: percentage((131 - 321)/ 320) 0;
 }
 .icon-custom-InvisibleLink {
-  background-position: percentage((125 - 308)/ 307) 0;
+  background-position: percentage((132 - 321)/ 320) 0;
 }
 .icon-custom-JackFrost {
-  background-position: percentage((126 - 308)/ 307) 0;
+  background-position: percentage((133 - 321)/ 320) 0;
 }
 .icon-custom-JasonFrudnick {
-  background-position: percentage((127 - 308)/ 307) 0;
+  background-position: percentage((134 - 321)/ 320) 0;
 }
 .icon-custom-Jasp {
-  background-position: percentage((128 - 308)/ 307) 0;
+  background-position: percentage((135 - 321)/ 320) 0;
 }
 .icon-custom-Jogurt {
-  background-position: percentage((129 - 308)/ 307) 0;
+  background-position: percentage((136 - 321)/ 320) 0;
 }
 .icon-custom-Katsura {
-  background-position: percentage((130 - 308)/ 307) 0;
+  background-position: percentage((137 - 321)/ 320) 0;
 }
 .icon-custom-Kecleon {
-  background-position: percentage((131 - 308)/ 307) 0;
+  background-position: percentage((138 - 321)/ 320) 0;
 }
 .icon-custom-KennyMcCormick {
-  background-position: percentage((132 - 308)/ 307) 0;
+  background-position: percentage((139 - 321)/ 320) 0;
 }
 .icon-custom-Ketchup {
-  background-position: percentage((133 - 308)/ 307) 0;
+  background-position: percentage((140 - 321)/ 320) 0;
 }
 .icon-custom-Kholdstare {
-  background-position: percentage((134 - 308)/ 307) 0;
+  background-position: percentage((141 - 321)/ 320) 0;
 }
 .icon-custom-KingGothalion {
-  background-position: percentage((135 - 308)/ 307) 0;
+  background-position: percentage((142 - 321)/ 320) 0;
 }
 .icon-custom-KingGraham {
-  background-position: percentage((136 - 308)/ 307) 0;
+  background-position: percentage((143 - 321)/ 320) 0;
 }
 .icon-custom-Kirby {
-  background-position: percentage((137 - 308)/ 307) 0;
+  background-position: percentage((144 - 321)/ 320) 0;
 }
 .icon-custom-Kore8 {
-  background-position: percentage((138 - 308)/ 307) 0;
+  background-position: percentage((145 - 321)/ 320) 0;
+}
+.icon-custom-Korok {
+  background-position: percentage((146 - 321)/ 320) 0;
 }
 .icon-custom-Lakitu {
-  background-position: percentage((139 - 308)/ 307) 0;
+  background-position: percentage((147 - 321)/ 320) 0;
 }
 .icon-custom-Lapras {
-  background-position: percentage((140 - 308)/ 307) 0;
+  background-position: percentage((148 - 321)/ 320) 0;
 }
 .icon-custom-Lest {
-  background-position: percentage((141 - 308)/ 307) 0;
+  background-position: percentage((149 - 321)/ 320) 0;
 }
 .icon-custom-Lily {
-  background-position: percentage((142 - 308)/ 307) 0;
+  background-position: percentage((150 - 321)/ 320) 0;
 }
 .icon-custom-Linja {
-  background-position: percentage((143 - 308)/ 307) 0;
+  background-position: percentage((151 - 321)/ 320) 0;
 }
 .icon-custom-LinkRedrawn {
-  background-position: percentage((144 - 308)/ 307) 0;
+  background-position: percentage((152 - 321)/ 320) 0;
 }
 .icon-custom-HatColorLink {
-  background-position: percentage((145 - 308)/ 307) 0;
+  background-position: percentage((153 - 321)/ 320) 0;
 }
 .icon-custom-TunicColorLink {
-  background-position: percentage((146 - 308)/ 307) 0;
+  background-position: percentage((154 - 321)/ 320) 0;
 }
 .icon-custom-LittleHylian {
-  background-position: percentage((147 - 308)/ 307) 0;
+  background-position: percentage((155 - 321)/ 320) 0;
 }
 .icon-custom-Pony {
-  background-position: percentage((148 - 308)/ 307) 0;
+  background-position: percentage((156 - 321)/ 320) 0;
+}
+.icon-custom-Locke {
+  background-position: percentage((157 - 321)/ 320) 0;
 }
 .icon-custom-FigaroMerchant {
-  background-position: percentage((149 - 308)/ 307) 0;
+  background-position: percentage((158 - 321)/ 320) 0;
 }
 .icon-custom-Lucario {
-  background-position: percentage((150 - 308)/ 307) 0;
+  background-position: percentage((159 - 321)/ 320) 0;
 }
 .icon-custom-Luffy {
-  background-position: percentage((151 - 308)/ 307) 0;
+  background-position: percentage((160 - 321)/ 320) 0;
 }
 .icon-custom-Luigi {
-  background-position: percentage((152 - 308)/ 307) 0;
+  background-position: percentage((161 - 321)/ 320) 0;
+}
+.icon-custom-LunaMaindo {
+  background-position: percentage((162 - 321)/ 320) 0;
 }
 .icon-custom-Madeline {
-  background-position: percentage((153 - 308)/ 307) 0;
+  background-position: percentage((163 - 321)/ 320) 0;
 }
 .icon-custom-Magus {
-  background-position: percentage((154 - 308)/ 307) 0;
+  background-position: percentage((164 - 321)/ 320) 0;
 }
 .icon-custom-Maiden {
-  background-position: percentage((155 - 308)/ 307) 0;
+  background-position: percentage((165 - 321)/ 320) 0;
 }
 .icon-custom-MallowCat {
-  background-position: percentage((156 - 308)/ 307) 0;
+  background-position: percentage((166 - 321)/ 320) 0;
 }
 .icon-custom-MangaLink {
-  background-position: percentage((157 - 308)/ 307) 0;
+  background-position: percentage((167 - 321)/ 320) 0;
 }
 .icon-custom-MapleQueen {
-  background-position: percentage((158 - 308)/ 307) 0;
+  background-position: percentage((168 - 321)/ 320) 0;
 }
 .icon-custom-Marin {
-  background-position: percentage((159 - 308)/ 307) 0;
+  background-position: percentage((169 - 321)/ 320) 0;
 }
 .icon-custom-MarioClassic {
-  background-position: percentage((160 - 308)/ 307) 0;
+  background-position: percentage((170 - 321)/ 320) 0;
 }
 .icon-custom-TanookiMario {
-  background-position: percentage((161 - 308)/ 307) 0;
+  background-position: percentage((171 - 321)/ 320) 0;
 }
 .icon-custom-MarioandCappy {
-  background-position: percentage((162 - 308)/ 307) 0;
+  background-position: percentage((172 - 321)/ 320) 0;
 }
 .icon-custom-MarisaKirisame {
-  background-position: percentage((163 - 308)/ 307) 0;
+  background-position: percentage((173 - 321)/ 320) 0;
 }
 .icon-custom-Matthias {
-  background-position: percentage((164 - 308)/ 307) 0;
+  background-position: percentage((174 - 321)/ 320) 0;
 }
 .icon-custom-Meatwad {
-  background-position: percentage((165 - 308)/ 307) 0;
+  background-position: percentage((175 - 321)/ 320) 0;
 }
 .icon-custom-Medallions {
-  background-position: percentage((166 - 308)/ 307) 0;
+  background-position: percentage((176 - 321)/ 320) 0;
 }
 .icon-custom-Medli {
-  background-position: percentage((167 - 308)/ 307) 0;
+  background-position: percentage((177 - 321)/ 320) 0;
 }
 .icon-custom-MegamanX {
-  background-position: percentage((168 - 308)/ 307) 0;
+  background-position: percentage((178 - 321)/ 320) 0;
 }
 .icon-custom-BabyMetroid {
-  background-position: percentage((169 - 308)/ 307) 0;
+  background-position: percentage((179 - 321)/ 320) 0;
 }
 .icon-custom-MewLp {
-  background-position: percentage((170 - 308)/ 307) 0;
+  background-position: percentage((180 - 321)/ 320) 0;
 }
 .icon-custom-MikeJones {
-  background-position: percentage((171 - 308)/ 307) 0;
+  background-position: percentage((181 - 321)/ 320) 0;
 }
 .icon-custom-MinishLink {
-  background-position: percentage((172 - 308)/ 307) 0;
+  background-position: percentage((182 - 321)/ 320) 0;
 }
 .icon-custom-MinishCapLink {
-  background-position: percentage((173 - 308)/ 307) 0;
+  background-position: percentage((183 - 321)/ 320) 0;
 }
 .icon-custom-missingno {
-  background-position: percentage((174 - 308)/ 307) 0;
+  background-position: percentage((184 - 321)/ 320) 0;
 }
 .icon-custom-Moblin {
-  background-position: percentage((175 - 308)/ 307) 0;
+  background-position: percentage((185 - 321)/ 320) 0;
 }
 .icon-custom-ModernLink {
-  background-position: percentage((176 - 308)/ 307) 0;
+  background-position: percentage((186 - 321)/ 320) 0;
 }
 .icon-custom-Mog {
-  background-position: percentage((177 - 308)/ 307) 0;
+  background-position: percentage((187 - 321)/ 320) 0;
 }
 .icon-custom-MomijiInubashiri {
-  background-position: percentage((178 - 308)/ 307) 0;
+  background-position: percentage((188 - 321)/ 320) 0;
 }
 .icon-custom-Moosh {
-  background-position: percentage((179 - 308)/ 307) 0;
+  background-position: percentage((189 - 321)/ 320) 0;
 }
 .icon-custom-Mouse {
-  background-position: percentage((180 - 308)/ 307) 0;
+  background-position: percentage((190 - 321)/ 320) 0;
 }
 .icon-custom-MsPaintDog {
-  background-position: percentage((181 - 308)/ 307) 0;
+  background-position: percentage((191 - 321)/ 320) 0;
 }
 .icon-custom-PowerUpwithPrideMushroom {
-  background-position: percentage((182 - 308)/ 307) 0;
+  background-position: percentage((192 - 321)/ 320) 0;
 }
 .icon-custom-NatureLink {
-  background-position: percentage((183 - 308)/ 307) 0;
+  background-position: percentage((193 - 321)/ 320) 0;
 }
 .icon-custom-Navi {
-  background-position: percentage((184 - 308)/ 307) 0;
+  background-position: percentage((194 - 321)/ 320) 0;
 }
 .icon-custom-Navirou {
-  background-position: percentage((185 - 308)/ 307) 0;
+  background-position: percentage((195 - 321)/ 320) 0;
 }
 .icon-custom-NedFlanders {
-  background-position: percentage((186 - 308)/ 307) 0;
+  background-position: percentage((196 - 321)/ 320) 0;
 }
 .icon-custom-NegativeLink {
-  background-position: percentage((187 - 308)/ 307) 0;
+  background-position: percentage((197 - 321)/ 320) 0;
 }
 .icon-custom-Neosad {
-  background-position: percentage((188 - 308)/ 307) 0;
+  background-position: percentage((198 - 321)/ 320) 0;
 }
 .icon-custom-NESLink {
-  background-position: percentage((189 - 308)/ 307) 0;
+  background-position: percentage((199 - 321)/ 320) 0;
 }
 .icon-custom-Ness {
-  background-position: percentage((190 - 308)/ 307) 0;
+  background-position: percentage((200 - 321)/ 320) 0;
 }
 .icon-custom-Nia {
-  background-position: percentage((191 - 308)/ 307) 0;
+  background-position: percentage((201 - 321)/ 320) 0;
 }
 .icon-custom-Niddraig {
-  background-position: percentage((192 - 308)/ 307) 0;
+  background-position: percentage((202 - 321)/ 320) 0;
 }
 .icon-custom-Niko {
-  background-position: percentage((193 - 308)/ 307) 0;
+  background-position: percentage((203 - 321)/ 320) 0;
 }
 .icon-custom-OldMan {
-  background-position: percentage((194 - 308)/ 307) 0;
+  background-position: percentage((204 - 321)/ 320) 0;
 }
 .icon-custom-Ori {
-  background-position: percentage((195 - 308)/ 307) 0;
+  background-position: percentage((205 - 321)/ 320) 0;
 }
 .icon-custom-OutlineLink {
-  background-position: percentage((196 - 308)/ 307) 0;
+  background-position: percentage((206 - 321)/ 320) 0;
 }
 .icon-custom-ParallelWorldsLink {
-  background-position: percentage((197 - 308)/ 307) 0;
+  background-position: percentage((207 - 321)/ 320) 0;
 }
 .icon-custom-Paula {
-  background-position: percentage((198 - 308)/ 307) 0;
+  background-position: percentage((208 - 321)/ 320) 0;
 }
 .icon-custom-PrincessPeach {
-  background-position: percentage((199 - 308)/ 307) 0;
+  background-position: percentage((209 - 321)/ 320) 0;
 }
 .icon-custom-PenguinLink {
-  background-position: percentage((200 - 308)/ 307) 0;
+  background-position: percentage((210 - 321)/ 320) 0;
 }
 .icon-custom-Pete {
-  background-position: percentage((201 - 308)/ 307) 0;
+  background-position: percentage((211 - 321)/ 320) 0;
 }
 .icon-custom-PhoenixWright {
-  background-position: percentage((202 - 308)/ 307) 0;
+  background-position: percentage((212 - 321)/ 320) 0;
 }
 .icon-custom-Pikachu {
-  background-position: percentage((203 - 308)/ 307) 0;
+  background-position: percentage((213 - 321)/ 320) 0;
 }
 .icon-custom-PinkRibbonLink {
-  background-position: percentage((204 - 308)/ 307) 0;
+  background-position: percentage((214 - 321)/ 320) 0;
 }
 .icon-custom-PiranhaPlant {
-  background-position: percentage((205 - 308)/ 307) 0;
+  background-position: percentage((215 - 321)/ 320) 0;
 }
 .icon-custom-PlagueKnight {
-  background-position: percentage((206 - 308)/ 307) 0;
+  background-position: percentage((216 - 321)/ 320) 0;
 }
 .icon-custom-Pokey {
-  background-position: percentage((207 - 308)/ 307) 0;
+  background-position: percentage((217 - 321)/ 320) 0;
 }
 .icon-custom-Popoi {
-  background-position: percentage((208 - 308)/ 307) 0;
+  background-position: percentage((218 - 321)/ 320) 0;
 }
 .icon-custom-Poppy {
-  background-position: percentage((209 - 308)/ 307) 0;
+  background-position: percentage((219 - 321)/ 320) 0;
 }
 .icon-custom-PorgKnight {
-  background-position: percentage((210 - 308)/ 307) 0;
+  background-position: percentage((220 - 321)/ 320) 0;
 }
 .icon-custom-PowerpuffGirl {
-  background-position: percentage((211 - 308)/ 307) 0;
+  background-position: percentage((221 - 321)/ 320) 0;
 }
 .icon-custom-PrideLink {
-  background-position: percentage((212 - 308)/ 307) 0;
+  background-position: percentage((222 - 321)/ 320) 0;
 }
 .icon-custom-Primm {
-  background-position: percentage((213 - 308)/ 307) 0;
+  background-position: percentage((223 - 321)/ 320) 0;
 }
 .icon-custom-PrincessBubblegum {
-  background-position: percentage((214 - 308)/ 307) 0;
+  background-position: percentage((224 - 321)/ 320) 0;
 }
 .icon-custom-Psyduck {
-  background-position: percentage((215 - 308)/ 307) 0;
+  background-position: percentage((225 - 321)/ 320) 0;
 }
 .icon-custom-ThePug {
-  background-position: percentage((216 - 308)/ 307) 0;
+  background-position: percentage((226 - 321)/ 320) 0;
 }
 .icon-custom-PurpleChest {
-  background-position: percentage((217 - 308)/ 307) 0;
+  background-position: percentage((227 - 321)/ 320) 0;
 }
 .icon-custom-Pyro {
-  background-position: percentage((218 - 308)/ 307) 0;
+  background-position: percentage((228 - 321)/ 320) 0;
 }
 .icon-custom-RainbowLink {
-  background-position: percentage((219 - 308)/ 307) 0;
+  background-position: percentage((229 - 321)/ 320) 0;
+}
+.icon-custom-Rat {
+  background-position: percentage((230 - 321)/ 320) 0;
+}
+.icon-custom-RedMage {
+  background-position: percentage((231 - 321)/ 320) 0;
 }
 .icon-custom-Remeer {
-  background-position: percentage((220 - 308)/ 307) 0;
+  background-position: percentage((232 - 321)/ 320) 0;
 }
 .icon-custom-Rick {
-  background-position: percentage((221 - 308)/ 307) 0;
+  background-position: percentage((233 - 321)/ 320) 0;
 }
 .icon-custom-Robo-Link9000 {
-  background-position: percentage((222 - 308)/ 307) 0;
+  background-position: percentage((234 - 321)/ 320) 0;
 }
 .icon-custom-Rocko {
-  background-position: percentage((223 - 308)/ 307) 0;
+  background-position: percentage((235 - 321)/ 320) 0;
 }
 .icon-custom-Rottytops {
-  background-position: percentage((224 - 308)/ 307) 0;
+  background-position: percentage((236 - 321)/ 320) 0;
 }
 .icon-custom-Rover {
-  background-position: percentage((225 - 308)/ 307) 0;
+  background-position: percentage((237 - 321)/ 320) 0;
 }
 .icon-custom-RoyKoopa {
-  background-position: percentage((226 - 308)/ 307) 0;
+  background-position: percentage((238 - 321)/ 320) 0;
 }
 .icon-custom-Rumia {
-  background-position: percentage((227 - 308)/ 307) 0;
+  background-position: percentage((239 - 321)/ 320) 0;
 }
 .icon-custom-Rydia {
-  background-position: percentage((228 - 308)/ 307) 0;
+  background-position: percentage((240 - 321)/ 320) 0;
 }
 .icon-custom-Ryu {
-  background-position: percentage((229 - 308)/ 307) 0;
+  background-position: percentage((241 - 321)/ 320) 0;
 }
 .icon-custom-SailorMoon {
-  background-position: percentage((230 - 308)/ 307) 0;
+  background-position: percentage((242 - 321)/ 320) 0;
 }
 .icon-custom-Saitama {
-  background-position: percentage((231 - 308)/ 307) 0;
+  background-position: percentage((243 - 321)/ 320) 0;
 }
 .icon-custom-SamusSuperMetroid {
-  background-position: percentage((232 - 308)/ 307) 0;
+  background-position: percentage((244 - 321)/ 320) 0;
 }
 .icon-custom-Samus {
-  background-position: percentage((233 - 308)/ 307) 0;
+  background-position: percentage((245 - 321)/ 320) 0;
 }
 .icon-custom-SamusClassic {
-  background-position: percentage((234 - 308)/ 307) 0;
+  background-position: percentage((246 - 321)/ 320) 0;
 }
 .icon-custom-SantaLink {
-  background-position: percentage((235 - 308)/ 307) 0;
+  background-position: percentage((247 - 321)/ 320) 0;
 }
 .icon-custom-Scholar {
-  background-position: percentage((236 - 308)/ 307) 0;
+  background-position: percentage((248 - 321)/ 320) 0;
 }
 .icon-custom-Selan {
-  background-position: percentage((237 - 308)/ 307) 0;
+  background-position: percentage((249 - 321)/ 320) 0;
 }
 .icon-custom-SevenS1ns {
-  background-position: percentage((238 - 308)/ 307) 0;
+  background-position: percentage((250 - 321)/ 320) 0;
 }
 .icon-custom-Shadow {
-  background-position: percentage((239 - 308)/ 307) 0;
+  background-position: percentage((251 - 321)/ 320) 0;
 }
 .icon-custom-ShadowSakura {
-  background-position: percentage((240 - 308)/ 307) 0;
+  background-position: percentage((252 - 321)/ 320) 0;
 }
 .icon-custom-Shantae {
-  background-position: percentage((241 - 308)/ 307) 0;
+  background-position: percentage((253 - 321)/ 320) 0;
 }
 .icon-custom-Shuppet {
-  background-position: percentage((242 - 308)/ 307) 0;
+  background-position: percentage((254 - 321)/ 320) 0;
 }
 .icon-custom-ShyGal {
-  background-position: percentage((243 - 308)/ 307) 0;
+  background-position: percentage((255 - 321)/ 320) 0;
 }
 .icon-custom-ShyGuy {
-  background-position: percentage((244 - 308)/ 307) 0;
+  background-position: percentage((256 - 321)/ 320) 0;
 }
 .icon-custom-SighnWaive {
-  background-position: percentage((245 - 308)/ 307) 0;
+  background-position: percentage((257 - 321)/ 320) 0;
+}
+.icon-custom-Slime {
+  background-position: percentage((258 - 321)/ 320) 0;
 }
 .icon-custom-Slowpoke {
-  background-position: percentage((246 - 308)/ 307) 0;
+  background-position: percentage((259 - 321)/ 320) 0;
 }
 .icon-custom-SNESController {
-  background-position: percentage((247 - 308)/ 307) 0;
+  background-position: percentage((260 - 321)/ 320) 0;
 }
 .icon-custom-SodaCan {
-  background-position: percentage((248 - 308)/ 307) 0;
+  background-position: percentage((261 - 321)/ 320) 0;
 }
 .icon-custom-SolaireofAstora {
-  background-position: percentage((249 - 308)/ 307) 0;
+  background-position: percentage((262 - 321)/ 320) 0;
 }
 .icon-custom-HyruleSoldier {
-  background-position: percentage((250 - 308)/ 307) 0;
+  background-position: percentage((263 - 321)/ 320) 0;
 }
 .icon-custom-SonictheHedgehog {
-  background-position: percentage((251 - 308)/ 307) 0;
+  background-position: percentage((264 - 321)/ 320) 0;
 }
 .icon-custom-Sora {
-  background-position: percentage((252 - 308)/ 307) 0;
+  background-position: percentage((265 - 321)/ 320) 0;
 }
 .icon-custom-SoraKH1 {
-  background-position: percentage((253 - 308)/ 307) 0;
+  background-position: percentage((266 - 321)/ 320) 0;
 }
 .icon-custom-SpongebobSquarepants {
-  background-position: percentage((254 - 308)/ 307) 0;
+  background-position: percentage((267 - 321)/ 320) 0;
 }
 .icon-custom-Squall {
-  background-position: percentage((255 - 308)/ 307) 0;
+  background-position: percentage((268 - 321)/ 320) 0;
 }
 .icon-custom-Squirrel {
-  background-position: percentage((256 - 308)/ 307) 0;
+  background-position: percentage((269 - 321)/ 320) 0;
 }
 .icon-custom-Squirtle {
-  background-position: percentage((257 - 308)/ 307) 0;
+  background-position: percentage((270 - 321)/ 320) 0;
 }
 .icon-custom-Stalfos {
-  background-position: percentage((258 - 308)/ 307) 0;
+  background-position: percentage((271 - 321)/ 320) 0;
 }
 .icon-custom-Stan {
-  background-position: percentage((259 - 308)/ 307) 0;
+  background-position: percentage((272 - 321)/ 320) 0;
 }
 .icon-custom-StaticLink {
-  background-position: percentage((260 - 308)/ 307) 0;
+  background-position: percentage((273 - 321)/ 320) 0;
 }
 .icon-custom-SteamedHams {
-  background-position: percentage((261 - 308)/ 307) 0;
+  background-position: percentage((274 - 321)/ 320) 0;
 }
 .icon-custom-StickMan {
-  background-position: percentage((262 - 308)/ 307) 0;
+  background-position: percentage((275 - 321)/ 320) 0;
 }
 .icon-custom-SuperBomb {
-  background-position: percentage((263 - 308)/ 307) 0;
+  background-position: percentage((276 - 321)/ 320) 0;
 }
 .icon-custom-SuperBunny {
-  background-position: percentage((264 - 308)/ 307) 0;
+  background-position: percentage((277 - 321)/ 320) 0;
 }
 .icon-custom-SuperMeatBoy {
-  background-position: percentage((265 - 308)/ 307) 0;
+  background-position: percentage((278 - 321)/ 320) 0;
 }
 .icon-custom-Susie {
-  background-position: percentage((266 - 308)/ 307) 0;
+  background-position: percentage((279 - 321)/ 320) 0;
 }
 .icon-custom-Swatchy {
-  background-position: percentage((267 - 308)/ 307) 0;
+  background-position: percentage((280 - 321)/ 320) 0;
 }
 .icon-custom-TASBot {
-  background-position: percentage((268 - 308)/ 307) 0;
+  background-position: percentage((281 - 321)/ 320) 0;
 }
 .icon-custom-TeaTime {
-  background-position: percentage((269 - 308)/ 307) 0;
+  background-position: percentage((282 - 321)/ 320) 0;
 }
 .icon-custom-TerraEsper {
-  background-position: percentage((270 - 308)/ 307) 0;
+  background-position: percentage((283 - 321)/ 320) 0;
 }
 .icon-custom-Tetra {
-  background-position: percentage((271 - 308)/ 307) 0;
+  background-position: percentage((284 - 321)/ 320) 0;
 }
 .icon-custom-TGH {
-  background-position: percentage((272 - 308)/ 307) 0;
+  background-position: percentage((285 - 321)/ 320) 0;
 }
 .icon-custom-Thief {
-  background-position: percentage((273 - 308)/ 307) 0;
+  background-position: percentage((286 - 321)/ 320) 0;
 }
 .icon-custom-Thomcrow {
-  background-position: percentage((274 - 308)/ 307) 0;
+  background-position: percentage((287 - 321)/ 320) 0;
 }
 .icon-custom-Tile {
-  background-position: percentage((275 - 308)/ 307) 0;
+  background-position: percentage((288 - 321)/ 320) 0;
 }
 .icon-custom-Tingle {
-  background-position: percentage((276 - 308)/ 307) 0;
+  background-position: percentage((289 - 321)/ 320) 0;
 }
 .icon-custom-TMNT {
-  background-position: percentage((277 - 308)/ 307) 0;
+  background-position: percentage((290 - 321)/ 320) 0;
 }
 .icon-custom-Toad {
-  background-position: percentage((278 - 308)/ 307) 0;
+  background-position: percentage((291 - 321)/ 320) 0;
 }
 .icon-custom-Toadette {
-  background-position: percentage((279 - 308)/ 307) 0;
+  background-position: percentage((292 - 321)/ 320) 0;
 }
 .icon-custom-CaptainToadette {
-  background-position: percentage((280 - 308)/ 307) 0;
+  background-position: percentage((293 - 321)/ 320) 0;
 }
 .icon-custom-TotemLinks {
-  background-position: percentage((281 - 308)/ 307) 0;
+  background-position: percentage((294 - 321)/ 320) 0;
 }
 .icon-custom-TrogdortheBurninator {
-  background-position: percentage((282 - 308)/ 307) 0;
+  background-position: percentage((295 - 321)/ 320) 0;
 }
 .icon-custom-TPZelda {
-  background-position: percentage((283 - 308)/ 307) 0;
+  background-position: percentage((296 - 321)/ 320) 0;
 }
 .icon-custom-TwoFaced {
-  background-position: percentage((284 - 308)/ 307) 0;
+  background-position: percentage((297 - 321)/ 320) 0;
 }
 .icon-custom-TytheTasmanianTiger {
-  background-position: percentage((285 - 308)/ 307) 0;
+  background-position: percentage((298 - 321)/ 320) 0;
 }
 .icon-custom-Ultros {
-  background-position: percentage((286 - 308)/ 307) 0;
+  background-position: percentage((299 - 321)/ 320) 0;
 }
 .icon-custom-Valeera {
-  background-position: percentage((287 - 308)/ 307) 0;
+  background-position: percentage((300 - 321)/ 320) 0;
 }
 .icon-custom-VanillaLink {
-  background-position: percentage((288 - 308)/ 307) 0;
+  background-position: percentage((301 - 321)/ 320) 0;
 }
 .icon-custom-Vaporeon {
-  background-position: percentage((289 - 308)/ 307) 0;
+  background-position: percentage((302 - 321)/ 320) 0;
 }
 .icon-custom-Vegeta {
-  background-position: percentage((290 - 308)/ 307) 0;
+  background-position: percentage((303 - 321)/ 320) 0;
 }
 .icon-custom-Vera {
-  background-position: percentage((291 - 308)/ 307) 0;
+  background-position: percentage((304 - 321)/ 320) 0;
 }
 .icon-custom-Vitreous {
-  background-position: percentage((292 - 308)/ 307) 0;
+  background-position: percentage((305 - 321)/ 320) 0;
 }
 .icon-custom-Vivi {
-  background-position: percentage((293 - 308)/ 307) 0;
+  background-position: percentage((306 - 321)/ 320) 0;
 }
 .icon-custom-Vivian {
-  background-position: percentage((294 - 308)/ 307) 0;
+  background-position: percentage((307 - 321)/ 320) 0;
 }
 .icon-custom-Wario {
-  background-position: percentage((295 - 308)/ 307) 0;
+  background-position: percentage((308 - 321)/ 320) 0;
 }
 .icon-custom-Will {
-  background-position: percentage((296 - 308)/ 307) 0;
+  background-position: percentage((309 - 321)/ 320) 0;
 }
 .icon-custom-Wizzrobe {
-  background-position: percentage((297 - 308)/ 307) 0;
+  background-position: percentage((310 - 321)/ 320) 0;
 }
 .icon-custom-WolfLinkFestive {
-  background-position: percentage((298 - 308)/ 307) 0;
+  background-position: percentage((311 - 321)/ 320) 0;
 }
 .icon-custom-WolfLinkTP {
-  background-position: percentage((299 - 308)/ 307) 0;
+  background-position: percentage((312 - 321)/ 320) 0;
 }
 .icon-custom-Yoshi {
-  background-position: percentage((300 - 308)/ 307) 0;
+  background-position: percentage((313 - 321)/ 320) 0;
 }
 .icon-custom-YunicaTovah {
-  background-position: percentage((301 - 308)/ 307) 0;
+  background-position: percentage((314 - 321)/ 320) 0;
 }
 .icon-custom-Zandra {
-  background-position: percentage((302 - 308)/ 307) 0;
+  background-position: percentage((315 - 321)/ 320) 0;
 }
 .icon-custom-ZebraUnicorn {
-  background-position: percentage((303 - 308)/ 307) 0;
+  background-position: percentage((316 - 321)/ 320) 0;
 }
 .icon-custom-Zeckemyro {
-  background-position: percentage((304 - 308)/ 307) 0;
+  background-position: percentage((317 - 321)/ 320) 0;
 }
 .icon-custom-Zelda {
-  background-position: percentage((305 - 308)/ 307) 0;
+  background-position: percentage((318 - 321)/ 320) 0;
 }
 .icon-custom-ZeroSuitSamus {
-  background-position: percentage((306 - 308)/ 307) 0;
+  background-position: percentage((319 - 321)/ 320) 0;
 }
 .icon-custom-Zora {
-  background-position: percentage((307 - 308)/ 307) 0;
+  background-position: percentage((320 - 321)/ 320) 0;
 }

--- a/resources/sass/_sprites.scss
+++ b/resources/sass/_sprites.scss
@@ -3,879 +3,930 @@
   width: 16px;
   height: 24px;
   vertical-align: bottom;
-  background-image: url("https://alttpr.s3.us-east-2.amazonaws.com/sprites.31.0.6.png");
+  background-image: url("https://alttpr.s3.us-east-2.amazonaws.com/sprites.31.0.7.png");
 }
 
 .icon-custom-Random {
   background-position: 0 0;
 }
 .icon-custom-Link {
-  background-position: percentage((1 - 291)/ 290) 0;
+  background-position: percentage((1 - 308)/ 307) 0;
 }
 .icon-custom-FourSwordsLink {
-  background-position: percentage((2 - 291)/ 290) 0;
+  background-position: percentage((2 - 308)/ 307) 0;
 }
 .icon-custom-Abigail {
-  background-position: percentage((3 - 291)/ 290) 0;
+  background-position: percentage((3 - 308)/ 307) 0;
 }
 .icon-custom-Adol {
-  background-position: percentage((4 - 291)/ 290) 0;
+  background-position: percentage((4 - 308)/ 307) 0;
 }
 .icon-custom-Aggretsuko {
-  background-position: percentage((5 - 291)/ 290) 0;
+  background-position: percentage((5 - 308)/ 307) 0;
 }
 .icon-custom-Alice {
-  background-position: percentage((6 - 291)/ 290) 0;
+  background-position: percentage((6 - 308)/ 307) 0;
 }
 .icon-custom-AngryVideoGameNerd {
-  background-position: percentage((7 - 291)/ 290) 0;
+  background-position: percentage((7 - 308)/ 307) 0;
 }
 .icon-custom-Arcane {
-  background-position: percentage((8 - 291)/ 290) 0;
+  background-position: percentage((8 - 308)/ 307) 0;
 }
-.icon-custom-Ark {
-  background-position: percentage((9 - 291)/ 290) 0;
+.icon-custom-ArkNoCape {
+  background-position: percentage((9 - 308)/ 307) 0;
+}
+.icon-custom-ArkCape {
+  background-position: percentage((10 - 308)/ 307) 0;
 }
 .icon-custom-Arrghus {
-  background-position: percentage((10 - 291)/ 290) 0;
+  background-position: percentage((11 - 308)/ 307) 0;
 }
 .icon-custom-Astronaut {
-  background-position: percentage((11 - 291)/ 290) 0;
+  background-position: percentage((12 - 308)/ 307) 0;
+}
+.icon-custom-Asuna {
+  background-position: percentage((13 - 308)/ 307) 0;
 }
 .icon-custom-Badeline {
-  background-position: percentage((12 - 291)/ 290) 0;
+  background-position: percentage((14 - 308)/ 307) 0;
 }
 .icon-custom-BananasInPyjamas {
-  background-position: percentage((13 - 291)/ 290) 0;
+  background-position: percentage((15 - 308)/ 307) 0;
 }
 .icon-custom-Bandit {
-  background-position: percentage((14 - 291)/ 290) 0;
+  background-position: percentage((16 - 308)/ 307) 0;
 }
 .icon-custom-Batman {
-  background-position: percentage((15 - 291)/ 290) 0;
+  background-position: percentage((17 - 308)/ 307) 0;
 }
 .icon-custom-Beau {
-  background-position: percentage((16 - 291)/ 290) 0;
+  background-position: percentage((18 - 308)/ 307) 0;
 }
 .icon-custom-Bewp {
-  background-position: percentage((17 - 291)/ 290) 0;
+  background-position: percentage((19 - 308)/ 307) 0;
 }
 .icon-custom-BigKey {
-  background-position: percentage((18 - 291)/ 290) 0;
+  background-position: percentage((20 - 308)/ 307) 0;
 }
 .icon-custom-Birb {
-  background-position: percentage((19 - 291)/ 290) 0;
+  background-position: percentage((21 - 308)/ 307) 0;
 }
 .icon-custom-Birdo {
-  background-position: percentage((20 - 291)/ 290) 0;
+  background-position: percentage((22 - 308)/ 307) 0;
 }
 .icon-custom-BlackMage {
-  background-position: percentage((21 - 291)/ 290) 0;
+  background-position: percentage((23 - 308)/ 307) 0;
 }
 .icon-custom-BlacksmithLink {
-  background-position: percentage((22 - 291)/ 290) 0;
+  background-position: percentage((24 - 308)/ 307) 0;
 }
 .icon-custom-Blossom {
-  background-position: percentage((23 - 291)/ 290) 0;
+  background-position: percentage((25 - 308)/ 307) 0;
 }
 .icon-custom-Bob {
-  background-position: percentage((24 - 291)/ 290) 0;
+  background-position: percentage((26 - 308)/ 307) 0;
+}
+.icon-custom-BobRoss {
+  background-position: percentage((27 - 308)/ 307) 0;
 }
 .icon-custom-Boo2 {
-  background-position: percentage((25 - 291)/ 290) 0;
+  background-position: percentage((28 - 308)/ 307) 0;
 }
 .icon-custom-Boo {
-  background-position: percentage((26 - 291)/ 290) 0;
+  background-position: percentage((29 - 308)/ 307) 0;
 }
 .icon-custom-BottleoGoo {
-  background-position: percentage((27 - 291)/ 290) 0;
+  background-position: percentage((30 - 308)/ 307) 0;
 }
 .icon-custom-BotWZelda {
-  background-position: percentage((28 - 291)/ 290) 0;
+  background-position: percentage((31 - 308)/ 307) 0;
 }
 .icon-custom-Bowser {
-  background-position: percentage((29 - 291)/ 290) 0;
+  background-position: percentage((32 - 308)/ 307) 0;
 }
 .icon-custom-Branch {
-  background-position: percentage((30 - 291)/ 290) 0;
+  background-position: percentage((33 - 308)/ 307) 0;
 }
 .icon-custom-Brian {
-  background-position: percentage((31 - 291)/ 290) 0;
+  background-position: percentage((34 - 308)/ 307) 0;
 }
 .icon-custom-Broccoli {
-  background-position: percentage((32 - 291)/ 290) 0;
+  background-position: percentage((35 - 308)/ 307) 0;
 }
 .icon-custom-Bronzor {
-  background-position: percentage((33 - 291)/ 290) 0;
+  background-position: percentage((36 - 308)/ 307) 0;
 }
 .icon-custom-BSBoy {
-  background-position: percentage((34 - 291)/ 290) 0;
+  background-position: percentage((37 - 308)/ 307) 0;
 }
 .icon-custom-BSGirl {
-  background-position: percentage((35 - 291)/ 290) 0;
+  background-position: percentage((38 - 308)/ 307) 0;
 }
 .icon-custom-Bubbles {
-  background-position: percentage((36 - 291)/ 290) 0;
+  background-position: percentage((39 - 308)/ 307) 0;
 }
 .icon-custom-BulletBill {
-  background-position: percentage((37 - 291)/ 290) 0;
+  background-position: percentage((40 - 308)/ 307) 0;
 }
 .icon-custom-Buttercup {
-  background-position: percentage((38 - 291)/ 290) 0;
+  background-position: percentage((41 - 308)/ 307) 0;
 }
 .icon-custom-Cactuar {
-  background-position: percentage((39 - 291)/ 290) 0;
+  background-position: percentage((42 - 308)/ 307) 0;
 }
 .icon-custom-Cadence {
-  background-position: percentage((40 - 291)/ 290) 0;
+  background-position: percentage((43 - 308)/ 307) 0;
 }
 .icon-custom-CarlSagan42 {
-  background-position: percentage((41 - 291)/ 290) 0;
+  background-position: percentage((44 - 308)/ 307) 0;
 }
 .icon-custom-CasualZelda {
-  background-position: percentage((42 - 291)/ 290) 0;
+  background-position: percentage((45 - 308)/ 307) 0;
 }
 .icon-custom-MarvintheCat {
-  background-position: percentage((43 - 291)/ 290) 0;
+  background-position: percentage((46 - 308)/ 307) 0;
 }
 .icon-custom-CatBoo {
-  background-position: percentage((44 - 291)/ 290) 0;
+  background-position: percentage((47 - 308)/ 307) 0;
 }
 .icon-custom-CD-iLink {
-  background-position: percentage((45 - 291)/ 290) 0;
+  background-position: percentage((48 - 308)/ 307) 0;
 }
 .icon-custom-Celes {
-  background-position: percentage((46 - 291)/ 290) 0;
+  background-position: percentage((49 - 308)/ 307) 0;
 }
 .icon-custom-Charizard {
-  background-position: percentage((47 - 291)/ 290) 0;
+  background-position: percentage((50 - 308)/ 307) 0;
 }
 .icon-custom-CheepCheep {
-  background-position: percentage((48 - 291)/ 290) 0;
+  background-position: percentage((51 - 308)/ 307) 0;
 }
 .icon-custom-Chibity {
-  background-position: percentage((49 - 291)/ 290) 0;
+  background-position: percentage((52 - 308)/ 307) 0;
 }
 .icon-custom-Cirno {
-  background-position: percentage((50 - 291)/ 290) 0;
+  background-position: percentage((53 - 308)/ 307) 0;
 }
 .icon-custom-Clifford {
-  background-position: percentage((51 - 291)/ 290) 0;
+  background-position: percentage((54 - 308)/ 307) 0;
 }
 .icon-custom-Clyde {
-  background-position: percentage((52 - 291)/ 290) 0;
+  background-position: percentage((55 - 308)/ 307) 0;
 }
 .icon-custom-Conker {
-  background-position: percentage((53 - 291)/ 290) 0;
+  background-position: percentage((56 - 308)/ 307) 0;
 }
 .icon-custom-Cornelius {
-  background-position: percentage((54 - 291)/ 290) 0;
+  background-position: percentage((57 - 308)/ 307) 0;
 }
 .icon-custom-Corona {
-  background-position: percentage((55 - 291)/ 290) 0;
+  background-position: percentage((58 - 308)/ 307) 0;
+}
+.icon-custom-Crewmate {
+  background-position: percentage((59 - 308)/ 307) 0;
 }
 .icon-custom-Cucco {
-  background-position: percentage((56 - 291)/ 290) 0;
+  background-position: percentage((60 - 308)/ 307) 0;
 }
 .icon-custom-Cursor {
-  background-position: percentage((57 - 291)/ 290) 0;
+  background-position: percentage((61 - 308)/ 307) 0;
 }
 .icon-custom-DOwls {
-  background-position: percentage((58 - 291)/ 290) 0;
+  background-position: percentage((62 - 308)/ 307) 0;
 }
 .icon-custom-DarkPanda {
-  background-position: percentage((59 - 291)/ 290) 0;
+  background-position: percentage((63 - 308)/ 307) 0;
 }
 .icon-custom-DarkBoy {
-  background-position: percentage((60 - 291)/ 290) 0;
+  background-position: percentage((64 - 308)/ 307) 0;
 }
 .icon-custom-DarkGirl {
-  background-position: percentage((61 - 291)/ 290) 0;
+  background-position: percentage((65 - 308)/ 307) 0;
 }
 .icon-custom-DarkLinkTunic {
-  background-position: percentage((62 - 291)/ 290) 0;
+  background-position: percentage((66 - 308)/ 307) 0;
 }
 .icon-custom-DarkLink {
-  background-position: percentage((63 - 291)/ 290) 0;
+  background-position: percentage((67 - 308)/ 307) 0;
 }
 .icon-custom-DarkSwatchy {
-  background-position: percentage((64 - 291)/ 290) 0;
+  background-position: percentage((68 - 308)/ 307) 0;
 }
 .icon-custom-DarkZelda {
-  background-position: percentage((65 - 291)/ 290) 0;
+  background-position: percentage((69 - 308)/ 307) 0;
 }
 .icon-custom-DarkZora {
-  background-position: percentage((66 - 291)/ 290) 0;
+  background-position: percentage((70 - 308)/ 307) 0;
 }
 .icon-custom-DeadpoolMythic {
-  background-position: percentage((67 - 291)/ 290) 0;
+  background-position: percentage((71 - 308)/ 307) 0;
 }
 .icon-custom-DeadpoolSirCzah {
-  background-position: percentage((68 - 291)/ 290) 0;
+  background-position: percentage((72 - 308)/ 307) 0;
 }
 .icon-custom-Deadrock {
-  background-position: percentage((69 - 291)/ 290) 0;
+  background-position: percentage((73 - 308)/ 307) 0;
 }
 .icon-custom-Decidueye {
-  background-position: percentage((70 - 291)/ 290) 0;
+  background-position: percentage((74 - 308)/ 307) 0;
+}
+.icon-custom-Dekar {
+  background-position: percentage((75 - 308)/ 307) 0;
 }
 .icon-custom-DemonLink {
-  background-position: percentage((71 - 291)/ 290) 0;
+  background-position: percentage((76 - 308)/ 307) 0;
 }
 .icon-custom-Dragonite {
-  background-position: percentage((72 - 291)/ 290) 0;
+  background-position: percentage((77 - 308)/ 307) 0;
 }
 .icon-custom-DrakeTheDragon {
-  background-position: percentage((73 - 291)/ 290) 0;
+  background-position: percentage((78 - 308)/ 307) 0;
 }
 .icon-custom-Eggplant {
-  background-position: percentage((74 - 291)/ 290) 0;
+  background-position: percentage((79 - 308)/ 307) 0;
 }
 .icon-custom-EmoSaru {
-  background-position: percentage((75 - 291)/ 290) 0;
+  background-position: percentage((80 - 308)/ 307) 0;
 }
 .icon-custom-Ezlo {
-  background-position: percentage((76 - 291)/ 290) 0;
+  background-position: percentage((81 - 308)/ 307) 0;
 }
 .icon-custom-FierceDeityLink {
-  background-position: percentage((77 - 291)/ 290) 0;
+  background-position: percentage((82 - 308)/ 307) 0;
 }
 .icon-custom-FinnMerten {
-  background-position: percentage((78 - 291)/ 290) 0;
+  background-position: percentage((83 - 308)/ 307) 0;
 }
 .icon-custom-FinnyBear {
-  background-position: percentage((79 - 291)/ 290) 0;
+  background-position: percentage((84 - 308)/ 307) 0;
 }
 .icon-custom-FloodgateFish {
-  background-position: percentage((80 - 291)/ 290) 0;
+  background-position: percentage((85 - 308)/ 307) 0;
 }
 .icon-custom-FlavorGuy {
-  background-position: percentage((81 - 291)/ 290) 0;
+  background-position: percentage((86 - 308)/ 307) 0;
 }
 .icon-custom-FoxLink {
-  background-position: percentage((82 - 291)/ 290) 0;
+  background-position: percentage((87 - 308)/ 307) 0;
 }
 .icon-custom-FreyaCrescent {
-  background-position: percentage((83 - 291)/ 290) 0;
+  background-position: percentage((88 - 308)/ 307) 0;
 }
 .icon-custom-Frisk {
-  background-position: percentage((84 - 291)/ 290) 0;
+  background-position: percentage((89 - 308)/ 307) 0;
 }
 .icon-custom-FrogLink {
-  background-position: percentage((85 - 291)/ 290) 0;
+  background-position: percentage((90 - 308)/ 307) 0;
 }
 .icon-custom-Fujin {
-  background-position: percentage((86 - 291)/ 290) 0;
+  background-position: percentage((91 - 308)/ 307) 0;
 }
 .icon-custom-FutureTrunks {
-  background-position: percentage((87 - 291)/ 290) 0;
+  background-position: percentage((92 - 308)/ 307) 0;
 }
 .icon-custom-Gamer {
-  background-position: percentage((88 - 291)/ 290) 0;
+  background-position: percentage((93 - 308)/ 307) 0;
 }
 .icon-custom-MiniGanon {
-  background-position: percentage((89 - 291)/ 290) 0;
+  background-position: percentage((94 - 308)/ 307) 0;
 }
 .icon-custom-Ganondorf {
-  background-position: percentage((90 - 291)/ 290) 0;
+  background-position: percentage((95 - 308)/ 307) 0;
 }
 .icon-custom-Garfield {
-  background-position: percentage((91 - 291)/ 290) 0;
+  background-position: percentage((96 - 308)/ 307) 0;
 }
 .icon-custom-Garnet {
-  background-position: percentage((92 - 291)/ 290) 0;
+  background-position: percentage((97 - 308)/ 307) 0;
 }
 .icon-custom-GaroMaster {
-  background-position: percentage((93 - 291)/ 290) 0;
+  background-position: percentage((98 - 308)/ 307) 0;
 }
 .icon-custom-GBCLink {
-  background-position: percentage((94 - 291)/ 290) 0;
+  background-position: percentage((99 - 308)/ 307) 0;
 }
 .icon-custom-Geno {
-  background-position: percentage((95 - 291)/ 290) 0;
+  background-position: percentage((100 - 308)/ 307) 0;
+}
+.icon-custom-GliitchWiitch {
+  background-position: percentage((101 - 308)/ 307) 0;
 }
 .icon-custom-Gobli {
-  background-position: percentage((96 - 291)/ 290) 0;
+  background-position: percentage((102 - 308)/ 307) 0;
 }
 .icon-custom-Goomba {
-  background-position: percentage((97 - 291)/ 290) 0;
+  background-position: percentage((103 - 308)/ 307) 0;
 }
 .icon-custom-Goose {
-  background-position: percentage((98 - 291)/ 290) 0;
+  background-position: percentage((104 - 308)/ 307) 0;
 }
 .icon-custom-GrandPOOBear {
-  background-position: percentage((99 - 291)/ 290) 0;
+  background-position: percentage((105 - 308)/ 307) 0;
+}
+.icon-custom-Gretis {
+  background-position: percentage((106 - 308)/ 307) 0;
 }
 .icon-custom-GruncleStan {
-  background-position: percentage((100 - 291)/ 290) 0;
+  background-position: percentage((107 - 308)/ 307) 0;
 }
 .icon-custom-Guiz {
-  background-position: percentage((101 - 291)/ 290) 0;
+  background-position: percentage((108 - 308)/ 307) 0;
+}
+.icon-custom-Hanna {
+  background-position: percentage((109 - 308)/ 307) 0;
 }
 .icon-custom-HardhatBeetle {
-  background-position: percentage((102 - 291)/ 290) 0;
+  background-position: percentage((110 - 308)/ 307) 0;
 }
 .icon-custom-HatKid {
-  background-position: percentage((103 - 291)/ 290) 0;
+  background-position: percentage((111 - 308)/ 307) 0;
 }
 .icon-custom-HeadlessLink {
-  background-position: percentage((104 - 291)/ 290) 0;
+  background-position: percentage((112 - 308)/ 307) 0;
 }
 .icon-custom-HelloKitty {
-  background-position: percentage((105 - 291)/ 290) 0;
+  background-position: percentage((113 - 308)/ 307) 0;
 }
 .icon-custom-Hidari {
-  background-position: percentage((106 - 291)/ 290) 0;
+  background-position: percentage((114 - 308)/ 307) 0;
 }
 .icon-custom-HintTile {
-  background-position: percentage((107 - 291)/ 290) 0;
-}
-.icon-custom-Hitsuyan1337 {
-  background-position: percentage((108 - 291)/ 290) 0;
+  background-position: percentage((115 - 308)/ 307) 0;
 }
 .icon-custom-HoarderBush {
-  background-position: percentage((109 - 291)/ 290) 0;
+  background-position: percentage((116 - 308)/ 307) 0;
 }
 .icon-custom-HoarderPot {
-  background-position: percentage((110 - 291)/ 290) 0;
+  background-position: percentage((117 - 308)/ 307) 0;
 }
 .icon-custom-HoarderRock {
-  background-position: percentage((111 - 291)/ 290) 0;
+  background-position: percentage((118 - 308)/ 307) 0;
 }
 .icon-custom-HomerSimpson {
-  background-position: percentage((112 - 291)/ 290) 0;
+  background-position: percentage((119 - 308)/ 307) 0;
 }
 .icon-custom-HyruleKnight {
-  background-position: percentage((113 - 291)/ 290) 0;
+  background-position: percentage((120 - 308)/ 307) 0;
 }
 .icon-custom-iBazly {
-  background-position: percentage((114 - 291)/ 290) 0;
+  background-position: percentage((121 - 308)/ 307) 0;
 }
 .icon-custom-Ignignokt {
-  background-position: percentage((115 - 291)/ 290) 0;
+  background-position: percentage((122 - 308)/ 307) 0;
 }
 .icon-custom-InformantWoman {
-  background-position: percentage((116 - 291)/ 290) 0;
+  background-position: percentage((123 - 308)/ 307) 0;
 }
 .icon-custom-Inkling {
-  background-position: percentage((117 - 291)/ 290) 0;
+  background-position: percentage((124 - 308)/ 307) 0;
 }
 .icon-custom-InvisibleLink {
-  background-position: percentage((118 - 291)/ 290) 0;
+  background-position: percentage((125 - 308)/ 307) 0;
 }
 .icon-custom-JackFrost {
-  background-position: percentage((119 - 291)/ 290) 0;
+  background-position: percentage((126 - 308)/ 307) 0;
 }
 .icon-custom-JasonFrudnick {
-  background-position: percentage((120 - 291)/ 290) 0;
+  background-position: percentage((127 - 308)/ 307) 0;
 }
 .icon-custom-Jasp {
-  background-position: percentage((121 - 291)/ 290) 0;
+  background-position: percentage((128 - 308)/ 307) 0;
 }
 .icon-custom-Jogurt {
-  background-position: percentage((122 - 291)/ 290) 0;
+  background-position: percentage((129 - 308)/ 307) 0;
 }
 .icon-custom-Katsura {
-  background-position: percentage((123 - 291)/ 290) 0;
+  background-position: percentage((130 - 308)/ 307) 0;
 }
 .icon-custom-Kecleon {
-  background-position: percentage((124 - 291)/ 290) 0;
+  background-position: percentage((131 - 308)/ 307) 0;
 }
 .icon-custom-KennyMcCormick {
-  background-position: percentage((125 - 291)/ 290) 0;
+  background-position: percentage((132 - 308)/ 307) 0;
 }
 .icon-custom-Ketchup {
-  background-position: percentage((126 - 291)/ 290) 0;
+  background-position: percentage((133 - 308)/ 307) 0;
 }
 .icon-custom-Kholdstare {
-  background-position: percentage((127 - 291)/ 290) 0;
+  background-position: percentage((134 - 308)/ 307) 0;
 }
 .icon-custom-KingGothalion {
-  background-position: percentage((128 - 291)/ 290) 0;
+  background-position: percentage((135 - 308)/ 307) 0;
 }
 .icon-custom-KingGraham {
-  background-position: percentage((129 - 291)/ 290) 0;
+  background-position: percentage((136 - 308)/ 307) 0;
 }
 .icon-custom-Kirby {
-  background-position: percentage((130 - 291)/ 290) 0;
+  background-position: percentage((137 - 308)/ 307) 0;
 }
 .icon-custom-Kore8 {
-  background-position: percentage((131 - 291)/ 290) 0;
+  background-position: percentage((138 - 308)/ 307) 0;
 }
 .icon-custom-Lakitu {
-  background-position: percentage((132 - 291)/ 290) 0;
+  background-position: percentage((139 - 308)/ 307) 0;
 }
 .icon-custom-Lapras {
-  background-position: percentage((133 - 291)/ 290) 0;
+  background-position: percentage((140 - 308)/ 307) 0;
 }
 .icon-custom-Lest {
-  background-position: percentage((134 - 291)/ 290) 0;
+  background-position: percentage((141 - 308)/ 307) 0;
 }
 .icon-custom-Lily {
-  background-position: percentage((135 - 291)/ 290) 0;
+  background-position: percentage((142 - 308)/ 307) 0;
 }
 .icon-custom-Linja {
-  background-position: percentage((136 - 291)/ 290) 0;
+  background-position: percentage((143 - 308)/ 307) 0;
+}
+.icon-custom-LinkRedrawn {
+  background-position: percentage((144 - 308)/ 307) 0;
 }
 .icon-custom-HatColorLink {
-  background-position: percentage((137 - 291)/ 290) 0;
+  background-position: percentage((145 - 308)/ 307) 0;
 }
 .icon-custom-TunicColorLink {
-  background-position: percentage((138 - 291)/ 290) 0;
+  background-position: percentage((146 - 308)/ 307) 0;
+}
+.icon-custom-LittleHylian {
+  background-position: percentage((147 - 308)/ 307) 0;
 }
 .icon-custom-Pony {
-  background-position: percentage((139 - 291)/ 290) 0;
+  background-position: percentage((148 - 308)/ 307) 0;
 }
 .icon-custom-FigaroMerchant {
-  background-position: percentage((140 - 291)/ 290) 0;
+  background-position: percentage((149 - 308)/ 307) 0;
 }
 .icon-custom-Lucario {
-  background-position: percentage((141 - 291)/ 290) 0;
+  background-position: percentage((150 - 308)/ 307) 0;
+}
+.icon-custom-Luffy {
+  background-position: percentage((151 - 308)/ 307) 0;
 }
 .icon-custom-Luigi {
-  background-position: percentage((142 - 291)/ 290) 0;
+  background-position: percentage((152 - 308)/ 307) 0;
 }
 .icon-custom-Madeline {
-  background-position: percentage((143 - 291)/ 290) 0;
+  background-position: percentage((153 - 308)/ 307) 0;
 }
 .icon-custom-Magus {
-  background-position: percentage((144 - 291)/ 290) 0;
+  background-position: percentage((154 - 308)/ 307) 0;
 }
 .icon-custom-Maiden {
-  background-position: percentage((145 - 291)/ 290) 0;
+  background-position: percentage((155 - 308)/ 307) 0;
 }
 .icon-custom-MallowCat {
-  background-position: percentage((146 - 291)/ 290) 0;
+  background-position: percentage((156 - 308)/ 307) 0;
 }
 .icon-custom-MangaLink {
-  background-position: percentage((147 - 291)/ 290) 0;
+  background-position: percentage((157 - 308)/ 307) 0;
 }
 .icon-custom-MapleQueen {
-  background-position: percentage((148 - 291)/ 290) 0;
+  background-position: percentage((158 - 308)/ 307) 0;
 }
 .icon-custom-Marin {
-  background-position: percentage((149 - 291)/ 290) 0;
+  background-position: percentage((159 - 308)/ 307) 0;
 }
 .icon-custom-MarioClassic {
-  background-position: percentage((150 - 291)/ 290) 0;
+  background-position: percentage((160 - 308)/ 307) 0;
 }
 .icon-custom-TanookiMario {
-  background-position: percentage((151 - 291)/ 290) 0;
+  background-position: percentage((161 - 308)/ 307) 0;
 }
 .icon-custom-MarioandCappy {
-  background-position: percentage((152 - 291)/ 290) 0;
+  background-position: percentage((162 - 308)/ 307) 0;
 }
 .icon-custom-MarisaKirisame {
-  background-position: percentage((153 - 291)/ 290) 0;
+  background-position: percentage((163 - 308)/ 307) 0;
 }
 .icon-custom-Matthias {
-  background-position: percentage((154 - 291)/ 290) 0;
+  background-position: percentage((164 - 308)/ 307) 0;
 }
 .icon-custom-Meatwad {
-  background-position: percentage((155 - 291)/ 290) 0;
+  background-position: percentage((165 - 308)/ 307) 0;
 }
 .icon-custom-Medallions {
-  background-position: percentage((156 - 291)/ 290) 0;
+  background-position: percentage((166 - 308)/ 307) 0;
 }
 .icon-custom-Medli {
-  background-position: percentage((157 - 291)/ 290) 0;
+  background-position: percentage((167 - 308)/ 307) 0;
 }
 .icon-custom-MegamanX {
-  background-position: percentage((158 - 291)/ 290) 0;
+  background-position: percentage((168 - 308)/ 307) 0;
 }
 .icon-custom-BabyMetroid {
-  background-position: percentage((159 - 291)/ 290) 0;
+  background-position: percentage((169 - 308)/ 307) 0;
 }
 .icon-custom-MewLp {
-  background-position: percentage((160 - 291)/ 290) 0;
+  background-position: percentage((170 - 308)/ 307) 0;
 }
 .icon-custom-MikeJones {
-  background-position: percentage((161 - 291)/ 290) 0;
+  background-position: percentage((171 - 308)/ 307) 0;
 }
 .icon-custom-MinishLink {
-  background-position: percentage((162 - 291)/ 290) 0;
+  background-position: percentage((172 - 308)/ 307) 0;
 }
 .icon-custom-MinishCapLink {
-  background-position: percentage((163 - 291)/ 290) 0;
+  background-position: percentage((173 - 308)/ 307) 0;
 }
 .icon-custom-missingno {
-  background-position: percentage((164 - 291)/ 290) 0;
+  background-position: percentage((174 - 308)/ 307) 0;
+}
+.icon-custom-Moblin {
+  background-position: percentage((175 - 308)/ 307) 0;
 }
 .icon-custom-ModernLink {
-  background-position: percentage((165 - 291)/ 290) 0;
+  background-position: percentage((176 - 308)/ 307) 0;
 }
 .icon-custom-Mog {
-  background-position: percentage((166 - 291)/ 290) 0;
+  background-position: percentage((177 - 308)/ 307) 0;
 }
 .icon-custom-MomijiInubashiri {
-  background-position: percentage((167 - 291)/ 290) 0;
+  background-position: percentage((178 - 308)/ 307) 0;
 }
 .icon-custom-Moosh {
-  background-position: percentage((168 - 291)/ 290) 0;
+  background-position: percentage((179 - 308)/ 307) 0;
 }
 .icon-custom-Mouse {
-  background-position: percentage((169 - 291)/ 290) 0;
+  background-position: percentage((180 - 308)/ 307) 0;
 }
 .icon-custom-MsPaintDog {
-  background-position: percentage((170 - 291)/ 290) 0;
+  background-position: percentage((181 - 308)/ 307) 0;
 }
 .icon-custom-PowerUpwithPrideMushroom {
-  background-position: percentage((171 - 291)/ 290) 0;
+  background-position: percentage((182 - 308)/ 307) 0;
 }
 .icon-custom-NatureLink {
-  background-position: percentage((172 - 291)/ 290) 0;
+  background-position: percentage((183 - 308)/ 307) 0;
 }
 .icon-custom-Navi {
-  background-position: percentage((173 - 291)/ 290) 0;
+  background-position: percentage((184 - 308)/ 307) 0;
 }
 .icon-custom-Navirou {
-  background-position: percentage((174 - 291)/ 290) 0;
+  background-position: percentage((185 - 308)/ 307) 0;
 }
 .icon-custom-NedFlanders {
-  background-position: percentage((175 - 291)/ 290) 0;
+  background-position: percentage((186 - 308)/ 307) 0;
 }
 .icon-custom-NegativeLink {
-  background-position: percentage((176 - 291)/ 290) 0;
+  background-position: percentage((187 - 308)/ 307) 0;
 }
 .icon-custom-Neosad {
-  background-position: percentage((177 - 291)/ 290) 0;
+  background-position: percentage((188 - 308)/ 307) 0;
 }
 .icon-custom-NESLink {
-  background-position: percentage((178 - 291)/ 290) 0;
+  background-position: percentage((189 - 308)/ 307) 0;
 }
 .icon-custom-Ness {
-  background-position: percentage((179 - 291)/ 290) 0;
+  background-position: percentage((190 - 308)/ 307) 0;
 }
 .icon-custom-Nia {
-  background-position: percentage((180 - 291)/ 290) 0;
+  background-position: percentage((191 - 308)/ 307) 0;
+}
+.icon-custom-Niddraig {
+  background-position: percentage((192 - 308)/ 307) 0;
 }
 .icon-custom-Niko {
-  background-position: percentage((181 - 291)/ 290) 0;
+  background-position: percentage((193 - 308)/ 307) 0;
 }
 .icon-custom-OldMan {
-  background-position: percentage((182 - 291)/ 290) 0;
+  background-position: percentage((194 - 308)/ 307) 0;
 }
 .icon-custom-Ori {
-  background-position: percentage((183 - 291)/ 290) 0;
+  background-position: percentage((195 - 308)/ 307) 0;
 }
 .icon-custom-OutlineLink {
-  background-position: percentage((184 - 291)/ 290) 0;
+  background-position: percentage((196 - 308)/ 307) 0;
 }
 .icon-custom-ParallelWorldsLink {
-  background-position: percentage((185 - 291)/ 290) 0;
+  background-position: percentage((197 - 308)/ 307) 0;
 }
 .icon-custom-Paula {
-  background-position: percentage((186 - 291)/ 290) 0;
+  background-position: percentage((198 - 308)/ 307) 0;
 }
 .icon-custom-PrincessPeach {
-  background-position: percentage((187 - 291)/ 290) 0;
+  background-position: percentage((199 - 308)/ 307) 0;
 }
 .icon-custom-PenguinLink {
-  background-position: percentage((188 - 291)/ 290) 0;
+  background-position: percentage((200 - 308)/ 307) 0;
 }
 .icon-custom-Pete {
-  background-position: percentage((189 - 291)/ 290) 0;
+  background-position: percentage((201 - 308)/ 307) 0;
 }
 .icon-custom-PhoenixWright {
-  background-position: percentage((190 - 291)/ 290) 0;
+  background-position: percentage((202 - 308)/ 307) 0;
 }
 .icon-custom-Pikachu {
-  background-position: percentage((191 - 291)/ 290) 0;
+  background-position: percentage((203 - 308)/ 307) 0;
 }
 .icon-custom-PinkRibbonLink {
-  background-position: percentage((192 - 291)/ 290) 0;
+  background-position: percentage((204 - 308)/ 307) 0;
 }
 .icon-custom-PiranhaPlant {
-  background-position: percentage((193 - 291)/ 290) 0;
+  background-position: percentage((205 - 308)/ 307) 0;
 }
 .icon-custom-PlagueKnight {
-  background-position: percentage((194 - 291)/ 290) 0;
+  background-position: percentage((206 - 308)/ 307) 0;
 }
 .icon-custom-Pokey {
-  background-position: percentage((195 - 291)/ 290) 0;
+  background-position: percentage((207 - 308)/ 307) 0;
 }
 .icon-custom-Popoi {
-  background-position: percentage((196 - 291)/ 290) 0;
+  background-position: percentage((208 - 308)/ 307) 0;
 }
 .icon-custom-Poppy {
-  background-position: percentage((197 - 291)/ 290) 0;
+  background-position: percentage((209 - 308)/ 307) 0;
 }
 .icon-custom-PorgKnight {
-  background-position: percentage((198 - 291)/ 290) 0;
+  background-position: percentage((210 - 308)/ 307) 0;
 }
 .icon-custom-PowerpuffGirl {
-  background-position: percentage((199 - 291)/ 290) 0;
+  background-position: percentage((211 - 308)/ 307) 0;
 }
 .icon-custom-PrideLink {
-  background-position: percentage((200 - 291)/ 290) 0;
+  background-position: percentage((212 - 308)/ 307) 0;
 }
 .icon-custom-Primm {
-  background-position: percentage((201 - 291)/ 290) 0;
+  background-position: percentage((213 - 308)/ 307) 0;
 }
 .icon-custom-PrincessBubblegum {
-  background-position: percentage((202 - 291)/ 290) 0;
+  background-position: percentage((214 - 308)/ 307) 0;
 }
 .icon-custom-Psyduck {
-  background-position: percentage((203 - 291)/ 290) 0;
+  background-position: percentage((215 - 308)/ 307) 0;
 }
 .icon-custom-ThePug {
-  background-position: percentage((204 - 291)/ 290) 0;
+  background-position: percentage((216 - 308)/ 307) 0;
 }
 .icon-custom-PurpleChest {
-  background-position: percentage((205 - 291)/ 290) 0;
+  background-position: percentage((217 - 308)/ 307) 0;
 }
 .icon-custom-Pyro {
-  background-position: percentage((206 - 291)/ 290) 0;
+  background-position: percentage((218 - 308)/ 307) 0;
 }
 .icon-custom-RainbowLink {
-  background-position: percentage((207 - 291)/ 290) 0;
+  background-position: percentage((219 - 308)/ 307) 0;
 }
 .icon-custom-Remeer {
-  background-position: percentage((208 - 291)/ 290) 0;
+  background-position: percentage((220 - 308)/ 307) 0;
 }
 .icon-custom-Rick {
-  background-position: percentage((209 - 291)/ 290) 0;
+  background-position: percentage((221 - 308)/ 307) 0;
 }
 .icon-custom-Robo-Link9000 {
-  background-position: percentage((210 - 291)/ 290) 0;
+  background-position: percentage((222 - 308)/ 307) 0;
 }
 .icon-custom-Rocko {
-  background-position: percentage((211 - 291)/ 290) 0;
+  background-position: percentage((223 - 308)/ 307) 0;
 }
 .icon-custom-Rottytops {
-  background-position: percentage((212 - 291)/ 290) 0;
+  background-position: percentage((224 - 308)/ 307) 0;
+}
+.icon-custom-Rover {
+  background-position: percentage((225 - 308)/ 307) 0;
 }
 .icon-custom-RoyKoopa {
-  background-position: percentage((213 - 291)/ 290) 0;
+  background-position: percentage((226 - 308)/ 307) 0;
 }
 .icon-custom-Rumia {
-  background-position: percentage((214 - 291)/ 290) 0;
+  background-position: percentage((227 - 308)/ 307) 0;
 }
 .icon-custom-Rydia {
-  background-position: percentage((215 - 291)/ 290) 0;
+  background-position: percentage((228 - 308)/ 307) 0;
 }
 .icon-custom-Ryu {
-  background-position: percentage((216 - 291)/ 290) 0;
+  background-position: percentage((229 - 308)/ 307) 0;
 }
 .icon-custom-SailorMoon {
-  background-position: percentage((217 - 291)/ 290) 0;
+  background-position: percentage((230 - 308)/ 307) 0;
 }
 .icon-custom-Saitama {
-  background-position: percentage((218 - 291)/ 290) 0;
+  background-position: percentage((231 - 308)/ 307) 0;
 }
 .icon-custom-SamusSuperMetroid {
-  background-position: percentage((219 - 291)/ 290) 0;
+  background-position: percentage((232 - 308)/ 307) 0;
 }
 .icon-custom-Samus {
-  background-position: percentage((220 - 291)/ 290) 0;
+  background-position: percentage((233 - 308)/ 307) 0;
 }
 .icon-custom-SamusClassic {
-  background-position: percentage((221 - 291)/ 290) 0;
+  background-position: percentage((234 - 308)/ 307) 0;
 }
 .icon-custom-SantaLink {
-  background-position: percentage((222 - 291)/ 290) 0;
+  background-position: percentage((235 - 308)/ 307) 0;
 }
 .icon-custom-Scholar {
-  background-position: percentage((223 - 291)/ 290) 0;
+  background-position: percentage((236 - 308)/ 307) 0;
 }
 .icon-custom-Selan {
-  background-position: percentage((224 - 291)/ 290) 0;
+  background-position: percentage((237 - 308)/ 307) 0;
 }
 .icon-custom-SevenS1ns {
-  background-position: percentage((225 - 291)/ 290) 0;
+  background-position: percentage((238 - 308)/ 307) 0;
 }
 .icon-custom-Shadow {
-  background-position: percentage((226 - 291)/ 290) 0;
+  background-position: percentage((239 - 308)/ 307) 0;
 }
 .icon-custom-ShadowSakura {
-  background-position: percentage((227 - 291)/ 290) 0;
+  background-position: percentage((240 - 308)/ 307) 0;
 }
 .icon-custom-Shantae {
-  background-position: percentage((228 - 291)/ 290) 0;
+  background-position: percentage((241 - 308)/ 307) 0;
 }
 .icon-custom-Shuppet {
-  background-position: percentage((229 - 291)/ 290) 0;
+  background-position: percentage((242 - 308)/ 307) 0;
 }
 .icon-custom-ShyGal {
-  background-position: percentage((230 - 291)/ 290) 0;
+  background-position: percentage((243 - 308)/ 307) 0;
 }
 .icon-custom-ShyGuy {
-  background-position: percentage((231 - 291)/ 290) 0;
+  background-position: percentage((244 - 308)/ 307) 0;
 }
 .icon-custom-SighnWaive {
-  background-position: percentage((232 - 291)/ 290) 0;
+  background-position: percentage((245 - 308)/ 307) 0;
+}
+.icon-custom-Slowpoke {
+  background-position: percentage((246 - 308)/ 307) 0;
 }
 .icon-custom-SNESController {
-  background-position: percentage((233 - 291)/ 290) 0;
+  background-position: percentage((247 - 308)/ 307) 0;
 }
 .icon-custom-SodaCan {
-  background-position: percentage((234 - 291)/ 290) 0;
+  background-position: percentage((248 - 308)/ 307) 0;
 }
 .icon-custom-SolaireofAstora {
-  background-position: percentage((235 - 291)/ 290) 0;
+  background-position: percentage((249 - 308)/ 307) 0;
 }
 .icon-custom-HyruleSoldier {
-  background-position: percentage((236 - 291)/ 290) 0;
+  background-position: percentage((250 - 308)/ 307) 0;
 }
 .icon-custom-SonictheHedgehog {
-  background-position: percentage((237 - 291)/ 290) 0;
+  background-position: percentage((251 - 308)/ 307) 0;
 }
 .icon-custom-Sora {
-  background-position: percentage((238 - 291)/ 290) 0;
+  background-position: percentage((252 - 308)/ 307) 0;
 }
 .icon-custom-SoraKH1 {
-  background-position: percentage((239 - 291)/ 290) 0;
+  background-position: percentage((253 - 308)/ 307) 0;
+}
+.icon-custom-SpongebobSquarepants {
+  background-position: percentage((254 - 308)/ 307) 0;
 }
 .icon-custom-Squall {
-  background-position: percentage((240 - 291)/ 290) 0;
+  background-position: percentage((255 - 308)/ 307) 0;
 }
 .icon-custom-Squirrel {
-  background-position: percentage((241 - 291)/ 290) 0;
+  background-position: percentage((256 - 308)/ 307) 0;
 }
 .icon-custom-Squirtle {
-  background-position: percentage((242 - 291)/ 290) 0;
+  background-position: percentage((257 - 308)/ 307) 0;
 }
 .icon-custom-Stalfos {
-  background-position: percentage((243 - 291)/ 290) 0;
+  background-position: percentage((258 - 308)/ 307) 0;
 }
 .icon-custom-Stan {
-  background-position: percentage((244 - 291)/ 290) 0;
+  background-position: percentage((259 - 308)/ 307) 0;
 }
 .icon-custom-StaticLink {
-  background-position: percentage((245 - 291)/ 290) 0;
+  background-position: percentage((260 - 308)/ 307) 0;
+}
+.icon-custom-SteamedHams {
+  background-position: percentage((261 - 308)/ 307) 0;
 }
 .icon-custom-StickMan {
-  background-position: percentage((246 - 291)/ 290) 0;
+  background-position: percentage((262 - 308)/ 307) 0;
 }
 .icon-custom-SuperBomb {
-  background-position: percentage((247 - 291)/ 290) 0;
+  background-position: percentage((263 - 308)/ 307) 0;
 }
 .icon-custom-SuperBunny {
-  background-position: percentage((248 - 291)/ 290) 0;
+  background-position: percentage((264 - 308)/ 307) 0;
 }
 .icon-custom-SuperMeatBoy {
-  background-position: percentage((249 - 291)/ 290) 0;
+  background-position: percentage((265 - 308)/ 307) 0;
+}
+.icon-custom-Susie {
+  background-position: percentage((266 - 308)/ 307) 0;
 }
 .icon-custom-Swatchy {
-  background-position: percentage((250 - 291)/ 290) 0;
+  background-position: percentage((267 - 308)/ 307) 0;
 }
 .icon-custom-TASBot {
-  background-position: percentage((251 - 291)/ 290) 0;
+  background-position: percentage((268 - 308)/ 307) 0;
 }
 .icon-custom-TeaTime {
-  background-position: percentage((252 - 291)/ 290) 0;
+  background-position: percentage((269 - 308)/ 307) 0;
 }
 .icon-custom-TerraEsper {
-  background-position: percentage((253 - 291)/ 290) 0;
+  background-position: percentage((270 - 308)/ 307) 0;
 }
 .icon-custom-Tetra {
-  background-position: percentage((254 - 291)/ 290) 0;
+  background-position: percentage((271 - 308)/ 307) 0;
 }
 .icon-custom-TGH {
-  background-position: percentage((255 - 291)/ 290) 0;
+  background-position: percentage((272 - 308)/ 307) 0;
 }
 .icon-custom-Thief {
-  background-position: percentage((256 - 291)/ 290) 0;
+  background-position: percentage((273 - 308)/ 307) 0;
 }
 .icon-custom-Thomcrow {
-  background-position: percentage((257 - 291)/ 290) 0;
+  background-position: percentage((274 - 308)/ 307) 0;
 }
 .icon-custom-Tile {
-  background-position: percentage((258 - 291)/ 290) 0;
+  background-position: percentage((275 - 308)/ 307) 0;
 }
 .icon-custom-Tingle {
-  background-position: percentage((259 - 291)/ 290) 0;
+  background-position: percentage((276 - 308)/ 307) 0;
 }
 .icon-custom-TMNT {
-  background-position: percentage((260 - 291)/ 290) 0;
+  background-position: percentage((277 - 308)/ 307) 0;
 }
 .icon-custom-Toad {
-  background-position: percentage((261 - 291)/ 290) 0;
+  background-position: percentage((278 - 308)/ 307) 0;
 }
 .icon-custom-Toadette {
-  background-position: percentage((262 - 291)/ 290) 0;
+  background-position: percentage((279 - 308)/ 307) 0;
 }
 .icon-custom-CaptainToadette {
-  background-position: percentage((263 - 291)/ 290) 0;
+  background-position: percentage((280 - 308)/ 307) 0;
 }
 .icon-custom-TotemLinks {
-  background-position: percentage((264 - 291)/ 290) 0;
+  background-position: percentage((281 - 308)/ 307) 0;
 }
 .icon-custom-TrogdortheBurninator {
-  background-position: percentage((265 - 291)/ 290) 0;
+  background-position: percentage((282 - 308)/ 307) 0;
 }
 .icon-custom-TPZelda {
-  background-position: percentage((266 - 291)/ 290) 0;
+  background-position: percentage((283 - 308)/ 307) 0;
 }
 .icon-custom-TwoFaced {
-  background-position: percentage((267 - 291)/ 290) 0;
+  background-position: percentage((284 - 308)/ 307) 0;
 }
 .icon-custom-TytheTasmanianTiger {
-  background-position: percentage((268 - 291)/ 290) 0;
+  background-position: percentage((285 - 308)/ 307) 0;
 }
 .icon-custom-Ultros {
-  background-position: percentage((269 - 291)/ 290) 0;
+  background-position: percentage((286 - 308)/ 307) 0;
 }
 .icon-custom-Valeera {
-  background-position: percentage((270 - 291)/ 290) 0;
+  background-position: percentage((287 - 308)/ 307) 0;
 }
 .icon-custom-VanillaLink {
-  background-position: percentage((271 - 291)/ 290) 0;
+  background-position: percentage((288 - 308)/ 307) 0;
 }
 .icon-custom-Vaporeon {
-  background-position: percentage((272 - 291)/ 290) 0;
+  background-position: percentage((289 - 308)/ 307) 0;
 }
 .icon-custom-Vegeta {
-  background-position: percentage((273 - 291)/ 290) 0;
+  background-position: percentage((290 - 308)/ 307) 0;
 }
 .icon-custom-Vera {
-  background-position: percentage((274 - 291)/ 290) 0;
+  background-position: percentage((291 - 308)/ 307) 0;
 }
 .icon-custom-Vitreous {
-  background-position: percentage((275 - 291)/ 290) 0;
+  background-position: percentage((292 - 308)/ 307) 0;
 }
 .icon-custom-Vivi {
-  background-position: percentage((276 - 291)/ 290) 0;
+  background-position: percentage((293 - 308)/ 307) 0;
 }
 .icon-custom-Vivian {
-  background-position: percentage((277 - 291)/ 290) 0;
+  background-position: percentage((294 - 308)/ 307) 0;
 }
 .icon-custom-Wario {
-  background-position: percentage((278 - 291)/ 290) 0;
+  background-position: percentage((295 - 308)/ 307) 0;
 }
 .icon-custom-Will {
-  background-position: percentage((279 - 291)/ 290) 0;
+  background-position: percentage((296 - 308)/ 307) 0;
 }
 .icon-custom-Wizzrobe {
-  background-position: percentage((280 - 291)/ 290) 0;
+  background-position: percentage((297 - 308)/ 307) 0;
 }
 .icon-custom-WolfLinkFestive {
-  background-position: percentage((281 - 291)/ 290) 0;
+  background-position: percentage((298 - 308)/ 307) 0;
 }
 .icon-custom-WolfLinkTP {
-  background-position: percentage((282 - 291)/ 290) 0;
+  background-position: percentage((299 - 308)/ 307) 0;
 }
 .icon-custom-Yoshi {
-  background-position: percentage((283 - 291)/ 290) 0;
+  background-position: percentage((300 - 308)/ 307) 0;
 }
 .icon-custom-YunicaTovah {
-  background-position: percentage((284 - 291)/ 290) 0;
+  background-position: percentage((301 - 308)/ 307) 0;
 }
 .icon-custom-Zandra {
-  background-position: percentage((285 - 291)/ 290) 0;
+  background-position: percentage((302 - 308)/ 307) 0;
 }
 .icon-custom-ZebraUnicorn {
-  background-position: percentage((286 - 291)/ 290) 0;
+  background-position: percentage((303 - 308)/ 307) 0;
 }
 .icon-custom-Zeckemyro {
-  background-position: percentage((287 - 291)/ 290) 0;
+  background-position: percentage((304 - 308)/ 307) 0;
 }
 .icon-custom-Zelda {
-  background-position: percentage((288 - 291)/ 290) 0;
+  background-position: percentage((305 - 308)/ 307) 0;
 }
 .icon-custom-ZeroSuitSamus {
-  background-position: percentage((289 - 291)/ 290) 0;
+  background-position: percentage((306 - 308)/ 307) 0;
 }
 .icon-custom-Zora {
-  background-position: percentage((290 - 291)/ 290) 0;
+  background-position: percentage((307 - 308)/ 307) 0;
 }

--- a/resources/views/updates.blade.php
+++ b/resources/views/updates.blade.php
@@ -10,7 +10,7 @@
             <li>Indoor music will now properly fade to half volume. (Patch by qwertymodo)</li>
             <li>Fixes a rare issue with specific SNES consoles and custom shops causing VRAM corruption or crashes.</li>
             <li>Fixes a very rare issue where the game may crash on a Save and Quit.</li>
-            <li>Fixes an issue where dying in the high stakes chest game in the Lost Woods results in respawning at the pyramid, 
+            <li>Fixes an issue where dying in the high stakes chest game in the Lost Woods results in respawning at the pyramid,
                 regardless of the status of Agahnim 1 or the Magic Mirror. (Thank you Catobat for the report and fix).</li>
             <li>The Village of Outcasts chest game is no longer incrementing the checked locations counter on subsequent plays of the game. (Patch by CaitSith2)</li>
             <li>New chest key counters exist in the SRAM that may be read by auto-trackers. (Patch by Aerinon)</li>
@@ -23,7 +23,12 @@
             <li>Fixed weird behavior when engaging Aghanim 2.</li>
             <li>Enemizer no longer adds "EN 6.0.32" to the file select screen.</li>
         </ul>
+        <li>When spoilers is set to "mystery", the intro text will always be the same text, regardless of game settings.</li>
+        <li>New Maseya-based pallete shuffle algorithm.  This new palette shuffle will also shuffle the map's colors!  (Patch by SWR)</li>
         <li>A new "Load Custom Sprite" option is available to let you use your own .zspr file.  This allows you to use any Link Sprite you wish for racing.  Thank you Krelbel for the patch!</li>
+        <li>Added new player options<br />
+            <img src="https://alttpr.s3.us-east-2.amazonaws.com/sprites.31.0.7.lg.png"
+                alt="Link sprite options" style="width:50%" /></li>
     </ul>
 </div>
 

--- a/resources/views/updates.blade.php
+++ b/resources/views/updates.blade.php
@@ -8,7 +8,7 @@
         <li>This release contains serveral ROM fixes.</li>
         <ul>
             <li>Indoor music will now properly fade to half volume. (Patch by qwertymodo)</li>
-            <li>Fixes a rare issue with specific SNES consoles and custom shops causing VRAM corruption or crashes.</li>
+            <li>Fixes a rare issue with specific SNES consoles and custom shops causing VRAM corruption or crashes. Thank you Bonta for identifying the cause of this issue.</li>
             <li>Fixes a very rare issue where the game may crash on a Save and Quit.</li>
             <li>Fixes an issue where dying in the high stakes chest game in the Lost Woods results in respawning at the pyramid, regardless of the status of Agahnim 1 or the Magic Mirror. (Thank you Catobat for the report and fix).</li>
             <li>The Village of Outcasts chest game is no longer incrementing the checked locations counter on subsequent plays of the game. (Patch by CaitSith2)</li>
@@ -23,7 +23,7 @@
             <li>Enemizer no longer adds "EN 6.0.32" to the file select screen.</li>
         </ul>
         <li>When spoilers is set to "mystery", the intro text will always be the same text, regardless of game settings.</li>
-        <li>New Maseya-based pallete shuffle algorithm.  This new palette shuffle will also shuffle the map's colors!  (Patch by SWR)</li>
+        <li>New Maseya-based pallete shuffle algorithm.  This new palette shuffle will also shuffle the map's colors!  Thank you SWR!</li>
         <li>A new "Load Custom Sprite" option is available to let you use your own .zspr file.  This allows you to use any Link Sprite you wish for racing.  Thank you Krelbel for the patch!</li>
         <li>Added new player options<br />
             <img src="https://alttpr.s3.us-east-2.amazonaws.com/sprites.31.0.7.lg.png"

--- a/resources/views/updates.blade.php
+++ b/resources/views/updates.blade.php
@@ -10,8 +10,7 @@
             <li>Indoor music will now properly fade to half volume. (Patch by qwertymodo)</li>
             <li>Fixes a rare issue with specific SNES consoles and custom shops causing VRAM corruption or crashes.</li>
             <li>Fixes a very rare issue where the game may crash on a Save and Quit.</li>
-            <li>Fixes an issue where dying in the high stakes chest game in the Lost Woods results in respawning at the pyramid,
-                regardless of the status of Agahnim 1 or the Magic Mirror. (Thank you Catobat for the report and fix).</li>
+            <li>Fixes an issue where dying in the high stakes chest game in the Lost Woods results in respawning at the pyramid, regardless of the status of Agahnim 1 or the Magic Mirror. (Thank you Catobat for the report and fix).</li>
             <li>The Village of Outcasts chest game is no longer incrementing the checked locations counter on subsequent plays of the game. (Patch by CaitSith2)</li>
             <li>New chest key counters exist in the SRAM that may be read by auto-trackers. (Patch by Aerinon)</li>
             <li>The left side of Swamp Palace will now remain flooded if the key has been collected. (Patch by CaitSith2)</li>

--- a/resources/views/updates.blade.php
+++ b/resources/views/updates.blade.php
@@ -5,13 +5,13 @@
 <h2>v31.0.7</h2>
 <div class="card card-body bg-light mb-3">
     <ul>
-        <li>This release contains serveral ROM fixes.</li>
+        <li>This release contains several ROM fixes.</li>
         <ul>
             <li>Indoor music will now properly fade to half volume. (Patch by qwertymodo)</li>
             <li>Fixes a rare issue with specific SNES consoles and custom shops causing VRAM corruption or crashes. Thank you Bonta for identifying the cause of this issue.</li>
             <li>Fixes a very rare issue where the game may crash on a Save and Quit.</li>
             <li>Fixes an issue where dying in the high stakes chest game in the Lost Woods results in respawning at the pyramid, regardless of the status of Agahnim 1 or the Magic Mirror. (Thank you Catobat for the report and fix).</li>
-            <li>The Village of Outcasts chest game is no longer incrementing the checked locations counter on subsequent plays of the game. (Patch by CaitSith2)</li>
+            <li>The Village of Outcasts chest game no longer increments the checked locations counter on subsequent plays of the game after receiving the game's item. (Patch by CaitSith2)</li>
             <li>New chest key counters exist in the SRAM that may be read by auto-trackers. (Patch by Aerinon)</li>
             <li>The left side of Swamp Palace will now remain flooded if the key has been collected. (Patch by CaitSith2)</li>
             <li>Fixes fake world when fluting to pyramid twice.  (Patch by compiling)</li>


### PR DESCRIPTION
- Updates sprite list based on what was provided by Fish
- Mystery games now have the intro text "masked", making it harder to identify if a game is inverted, or entrance randomizer.
- Updates patch notes (notes assume that https://github.com/sporchia/alttp_vt_randomizer/pull/890 will be merged)

This PR also relies on assets being uploaded to S3.