### PR TITLE
v31.0.9 updates

### DIFF
--- a/app/Console/Commands/Distribution.php
+++ b/app/Console/Commands/Distribution.php
@@ -55,7 +55,7 @@ class Distribution extends Command
             'none' => 'NoGlitches',
             'overworld_glitches' => 'OverworldGlitches',
             'major_glitches' => 'MajorGlitches',
-            'no_logic' => 'None',
+            'no_logic' => 'NoLogic',
         ][$this->option('glitches')];
 
         $this->state = $this->option('state');

--- a/app/Console/Commands/Randomize.php
+++ b/app/Console/Commands/Randomize.php
@@ -145,7 +145,7 @@ class Randomize extends Command
                 'none' => 'NoGlitches',
                 'overworld_glitches' => 'OverworldGlitches',
                 'major_glitches' => 'MajorGlitches',
-                'no_logic' => 'None',
+                'no_logic' => 'NoLogic',
             ][$this->option('glitches')];
 
             $world = World::factory($this->option('state'), [

--- a/app/Http/Controllers/CustomizerController.php
+++ b/app/Http/Controllers/CustomizerController.php
@@ -113,7 +113,7 @@ class CustomizerController extends Controller
             'none' => 'NoGlitches',
             'overworld_glitches' => 'OverworldGlitches',
             'major_glitches' => 'MajorGlitches',
-            'no_logic' => 'None',
+            'no_logic' => 'NoLogic',
         ][$request->input('glitches', 'none')];
 
         $spoilers = $request->input('spoilers', 'off');
@@ -180,7 +180,7 @@ class CustomizerController extends Controller
             'mode.weapons' => $request->input('weapons', 'randomized'),
             'tournament' => $request->input('tournament', true),
             'spoilers' => $spoilers,
-            'allow_quickswap' => $request->input('allow_quickswap', false),
+            'allow_quickswap' => $request->input('allow_quickswap', true),
             'override_start_screen' => $request->input('override_start_screen', false),
             'logic' => $logic,
             'item.pool' => $request->input('item.pool', 'normal'),

--- a/app/Http/Controllers/CustomizerController.php
+++ b/app/Http/Controllers/CustomizerController.php
@@ -250,6 +250,11 @@ class CustomizerController extends Controller
         $rand = new Randomizer([$world]);
 
         $rand->randomize();
+
+        foreach ($request->input('texts', []) as $key => $value) {
+            $world->setText($key, $value);
+        }
+
         $world->writeToRom($rom, $save);
 
         $worlds = new WorldCollection($rand->getWorlds());

--- a/app/Http/Controllers/CustomizerController.php
+++ b/app/Http/Controllers/CustomizerController.php
@@ -80,7 +80,7 @@ class CustomizerController extends Controller
             ]));
             Cache::put('hash.' . $payload['hash'], $save_data, now()->addDays(7));
 
-            return json_encode($return_payload);
+            return response()->json($return_payload);
         } catch (Exception $exception) {
             if (app()->bound('sentry')) {
                 app('sentry')->captureException($exception);
@@ -93,7 +93,7 @@ class CustomizerController extends Controller
     public function testGenerateSeed(Request $request)
     {
         try {
-            return json_encode(Arr::except($this->prepSeed($request), ['patch', 'seed', 'hash']));
+            return response()->json(Arr::except($this->prepSeed($request), ['patch', 'seed', 'hash']));
         } catch (Exception $exception) {
             if (app()->bound('sentry')) {
                 app('sentry')->captureException($exception);

--- a/app/Http/Controllers/MultiworldController.php
+++ b/app/Http/Controllers/MultiworldController.php
@@ -55,9 +55,10 @@ class MultiworldController extends Controller
                 'no_logic' => 'NoLogic',
             ][$config['glitches'] ?? 'none'];
 
-            // quick fix for CC and Basic
+            // quick fix for CC and Basic/Entrance
             if (($config['item.pool'] ?? 'normal') === 'crowd_control') {
                 $request->merge(['item_placement' => 'advanced']);
+                $request->merge(['entrances' => 'none']);
             }
 
             $worlds[] = World::factory($config['mode'] ?? 'standard', [

--- a/app/Http/Controllers/MultiworldController.php
+++ b/app/Http/Controllers/MultiworldController.php
@@ -52,7 +52,7 @@ class MultiworldController extends Controller
                 'none' => 'NoGlitches',
                 'overworld_glitches' => 'OverworldGlitches',
                 'major_glitches' => 'MajorGlitches',
-                'no_logic' => 'None',
+                'no_logic' => 'NoLogic',
             ][$config['glitches'] ?? 'none'];
 
             // quick fix for CC and Basic

--- a/app/Http/Controllers/RandomizerController.php
+++ b/app/Http/Controllers/RandomizerController.php
@@ -108,7 +108,7 @@ class RandomizerController extends Controller
             'none' => 'NoGlitches',
             'overworld_glitches' => 'OverworldGlitches',
             'major_glitches' => 'MajorGlitches',
-            'no_logic' => 'None',
+            'no_logic' => 'NoLogic',
         ][$request->input('glitches', 'none')];
 
         $spoilers = $request->input('spoilers', 'off');
@@ -134,7 +134,7 @@ class RandomizerController extends Controller
             'mode.weapons' => $request->input('weapons', 'randomized'),
             'tournament' => $request->input('tournament', false),
             'spoilers' => $spoilers,
-            'allow_quickswap' => $request->input('allow_quickswap', false),
+            'allow_quickswap' => $request->input('allow_quickswap', true),
             'override_start_screen' => $request->input('override_start_screen', false),
             'spoil.Hints' => $request->input('hints', 'on'),
             'logic' => $logic,

--- a/app/Http/Controllers/RandomizerController.php
+++ b/app/Http/Controllers/RandomizerController.php
@@ -75,7 +75,7 @@ class RandomizerController extends Controller
             ]));
             Cache::put('hash.' . $payload['hash'], $save_data, now()->addDays(7));
 
-            return json_encode($return_payload);
+            return response()->json($return_payload);
         } catch (Exception $exception) {
             if (app()->bound('sentry')) {
                 app('sentry')->captureException($exception);
@@ -88,7 +88,7 @@ class RandomizerController extends Controller
     public function testGenerateSeed(CreateRandomizedGame $request)
     {
         try {
-            return json_encode(Arr::except($this->prepSeed($request, false), ['patch', 'seed', 'hash']));
+            return response()->json(Arr::except($this->prepSeed($request, false), ['patch', 'seed', 'hash']));
         } catch (Exception $exception) {
             if (app()->bound('sentry')) {
                 app('sentry')->captureException($exception);

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -211,11 +211,23 @@ class SettingsController extends Controller
     public function sprites(): array
     {
         return collect(config('sprites'))->map(function ($info, $file) {
+            if ($file === '001.link.1.zspr') {
+                return [
+                    'name' => $info['name'],
+                    'author' => $info['author'],
+                    'version' => $info['version'],
+                    'file' => null,
+                    'preview' => null,
+                    'tags' => $info['tags'] ?? [],
+                    'usage' => $info['usage'] ?? []
+                ];
+            }
             return [
                 'name' => $info['name'],
                 'author' => $info['author'],
                 'version' => $info['version'],
                 'file' => 'https://alttpr.s3.us-east-2.amazonaws.com/' . $file,
+                'preview' => 'https://alttpr.s3.us-east-2.amazonaws.com/' . $file . '.png',
                 'tags' => $info['tags'] ?? [],
                 'usage' => $info['usage'] ?? []
             ];

--- a/app/Randomizer.php
+++ b/app/Randomizer.php
@@ -113,7 +113,7 @@ class Randomizer implements RandomizerContract
         $trash_items = $world->getItemPool();
 
         // @todo check a flag instead of logic here, as well as difficulty
-        if (in_array($world->config('logic'), ['MajorGlitches', 'OverworldGlitches', 'None']) && $world->config('difficulty') !== 'custom') {
+        if (in_array($world->config('logic'), ['MajorGlitches', 'OverworldGlitches', 'NoLogic']) && $world->config('difficulty') !== 'custom') {
             $world->addPreCollectedItem(Item::get('PegasusBoots', $world));
             foreach ($advancement_items as $key => $item) {
                 if ($item == Item::get('PegasusBoots', $world)) {

--- a/app/Randomizer.php
+++ b/app/Randomizer.php
@@ -868,6 +868,7 @@ class Randomizer implements RandomizerContract
                 'tavern_man' => $this->getTextArray('strings/tavern_man.txt'),
                 'blind' => $this->getTextArray('strings/blind.txt'),
                 'ganon_1' => $this->getTextArray('strings/ganon_1.txt'),
+                'ganon_phase_3_no_silvers' => $this->getTextArray('strings/ganon_phase_3_no_silvers.txt'),
                 'triforce' => $this->getTextArray('strings/triforce.txt'),
             ];
         });
@@ -933,7 +934,7 @@ class Randomizer implements RandomizerContract
         }
 
         if (!$silver_arrows_location) {
-            $world->setText('ganon_phase_3_no_silvers', "Did you find\nthe arrows on\nPlanet Zebes?");
+            $world->setText('ganon_phase_3_no_silvers', Arr::first(fy_shuffle($strings['ganon_phase_3_no_silvers'])));
         } else {
             switch ($silver_arrows_location->getRegion()->getName()) {
                 case "Ganons Tower":

--- a/app/Region/Standard/DarkWorld/NorthEast.php
+++ b/app/Region/Standard/DarkWorld/NorthEast.php
@@ -214,7 +214,7 @@ class NorthEast extends Region
                 return false;
             }
 
-            return $items->has('MoonPearl')
+            return ($items->has('MoonPearl') || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
                 && ($items->has('DefeatAgahnim2') || $this->world->config('goal') === 'fast_ganon')
                 && (!$this->world->config('region.requireBetterBow', false) || $items->canShootArrows($this->world, 2))
                 && (

--- a/app/Rom.php
+++ b/app/Rom.php
@@ -12,8 +12,8 @@ use Log;
  */
 class Rom
 {
-    const BUILD = '2021-02-18';
-    const HASH = 'daefb54a0ad81808f8d8790eeeb4d3e6';
+    const BUILD = '2021-05-04';
+    const HASH = 'be0fc80afd464bfcadc913ae2137f25d';
     const SIZE = 2097152;
 
     private $tmp_file;

--- a/app/Rom.php
+++ b/app/Rom.php
@@ -12,8 +12,8 @@ use Log;
  */
 class Rom
 {
-    const BUILD = '2021-05-14';
-    const HASH = '41ceb8792178371f0b0d2a04e8b14b22';
+    const BUILD = '2021-05-18';
+    const HASH = '4fd7118901401d417100619cd94e10a3';
     const SIZE = 2097152;
 
     private $tmp_file;

--- a/app/Rom.php
+++ b/app/Rom.php
@@ -12,8 +12,8 @@ use Log;
  */
 class Rom
 {
-    const BUILD = '2021-05-04';
-    const HASH = 'be0fc80afd464bfcadc913ae2137f25d';
+    const BUILD = '2021-05-09';
+    const HASH = 'e59f19625b32f85c4fa38d9a29c658b1';
     const SIZE = 2097152;
 
     private $tmp_file;

--- a/app/Rom.php
+++ b/app/Rom.php
@@ -12,8 +12,8 @@ use Log;
  */
 class Rom
 {
-    const BUILD = '2021-05-18';
-    const HASH = '4fd7118901401d417100619cd94e10a3';
+    const BUILD = '2021-05-22';
+    const HASH = '78520fa865249324c1a0e9d13c56665e';
     const SIZE = 2097152;
 
     private $tmp_file;

--- a/app/Rom.php
+++ b/app/Rom.php
@@ -12,8 +12,8 @@ use Log;
  */
 class Rom
 {
-    const BUILD = '2021-05-09';
-    const HASH = 'e59f19625b32f85c4fa38d9a29c658b1';
+    const BUILD = '2021-05-14';
+    const HASH = '41ceb8792178371f0b0d2a04e8b14b22';
     const SIZE = 2097152;
 
     private $tmp_file;

--- a/app/Text.php
+++ b/app/Text.php
@@ -3,6 +3,7 @@
 namespace ALttP;
 
 use ALttP\Support\Dialog;
+use Exception;
 use Log;
 
 /**
@@ -35,6 +36,10 @@ class Text
      */
     public function setString(string $id, string $value, ...$flags)
     {
+        if (!array_key_exists($id, $this->text_array)) {
+            throw new Exception("Attempted to update a non-existant text id ($id).");
+        }
+
         $this->text_array[$id] = $this->converter->convertDialogCompressed($value, ...$flags);
     }
 

--- a/app/World.php
+++ b/app/World.php
@@ -127,6 +127,11 @@ abstract class World
                 $free_item_text |= 0x16;
                 $free_item_menu |= 0x0C;
         }
+
+        if (in_array($this->config('logic'), ['MajorGlitches', 'None']) || $this->config('canOneFrameClipUW', false)) {
+            $free_item_menu |= 0x10;
+        }
+
         $this->config['rom.freeItemText'] = $free_item_text;
         $this->config['rom.freeItemMenu'] = $free_item_menu;
 

--- a/app/World.php
+++ b/app/World.php
@@ -1150,7 +1150,7 @@ abstract class World
             case 'OverworldGlitches':
                 $rom->setPreAgahnimDarkWorldDeathInDungeon(false);
                 $rom->setSaveAndQuitFromBossRoom(true);
-                $rom->setWorldOnAgahnimDeath(true);
+                $rom->setWorldOnAgahnimDeath(false);
                 $rom->setRandomizerSeedType('OverworldGlitches');
                 $rom->setWarningFlags(bindec('01000000'));
                 $rom->setPODEGfix(false);

--- a/app/World.php
+++ b/app/World.php
@@ -1058,8 +1058,8 @@ abstract class World
             0x51, 0x06, 0x52, 0xFF, // 6 +5 bomb upgrades -> +10 bomb upgrade
             0x53, 0x06, 0x54, 0xFF, // 6 +5 arrow upgrades -> +10 arrow upgrade
             0x58, 0x01, $this->config('rom.rupeeBow', false) ? 0x36 : 0x43, 0xFF, // silver arrows -> 1 arrow
-            0x3E, $this->config('item.overflow.count.BossHeartContainer', 10), 0x47, 0xFF, // boss heart -> 20 rupees
-            0x17, $this->config('item.overflow.count.PieceOfHeart', 24), 0x47, 0xFF, // piece of heart -> 20 rupees
+            0x3E, $this->config('item.overflow.count.BossHeartContainer', 10), Item::get($this->config('item.overflow.replacement.BossHeartContainer', 'TwentyRupees2'), $this)->getBytes()[0], 0xFF, // boss heart -> 20 rupees
+            0x17, $this->config('item.overflow.count.PieceOfHeart', 24), Item::get($this->config('item.overflow.replacement.PieceOfHeart', 'TwentyRupees2'), $this)->getBytes()[0], 0xFF, // piece of heart -> 20 rupees
         ]);
 
         switch ($this->config['goal']) {

--- a/app/World.php
+++ b/app/World.php
@@ -90,7 +90,7 @@ abstract class World
         // Initialize the Logic and Prizes for each Region that has them and
         // fill our LocationsCollection
         foreach ($this->regions as $region) {
-            if ($this->config('logic') !== 'None') {
+            if ($this->config('logic') !== 'NoLogic') {
                 $region->initalize();
             }
             $this->locations = $this->locations->merge($region->getLocations());
@@ -128,7 +128,7 @@ abstract class World
                 $free_item_menu |= 0x0C;
         }
 
-        if (in_array($this->config('logic'), ['MajorGlitches', 'None']) || $this->config('canOneFrameClipUW', false)) {
+        if (in_array($this->config('logic'), ['MajorGlitches', 'NoLogic']) || $this->config('canOneFrameClipUW', false)) {
             $free_item_menu |= 0x10;
         }
 
@@ -313,7 +313,7 @@ abstract class World
     public function getGanonsTowerJunkFillRange(): array
     {
         if (
-            $this->config['logic'] === 'None'
+            $this->config['logic'] === 'NoLogic'
             || ($this->config['mode.state'] !== 'inverted'
                 && in_array($this->config['logic'], ['OverworldGlitches', 'MajorGlitches']))
         ) {
@@ -909,7 +909,7 @@ abstract class World
             'size' => 2,
             'hints' => $this->config('spoil.Hints'),
             'spoilers' => $this->config('spoilers', 'off'),
-            'allow_quickswap' => $this->config('allow_quickswap'),
+            'allow_quickswap' => $this->config('allow_quickswap', true),
             'enemizer.boss_shuffle' => $this->config('enemizer.bossShuffle'),
             'enemizer.enemy_shuffle' => $this->config('enemizer.enemyShuffle'),
             'enemizer.enemy_damage' => $this->config('enemizer.enemyDamage'),
@@ -1140,7 +1140,7 @@ abstract class World
 
         switch ($this->config('rom.logicMode', $this->config['logic'])) {
             case 'MajorGlitches':
-            case 'None':
+            case 'NoLogic':
                 $rom->setSwampWaterLevel(false);
                 $rom->setPreAgahnimDarkWorldDeathInDungeon(false);
                 $rom->setSaveAndQuitFromBossRoom(true);
@@ -1167,11 +1167,7 @@ abstract class World
 
         $rom->setGanonsTowerOpen($this->config('crystals.tower') === 0);
 
-        if ($this->config('allow_quickswap', false)) {
-            $rom->setGameType('entrance');
-        } else {
-            $rom->setGameType('item');
-        }
+        $rom->setGameType('item');
 
         $rom->setMysteryMasking($this->config('spoilers', 'on') === 'mystery');
 

--- a/app/World.php
+++ b/app/World.php
@@ -135,8 +135,6 @@ abstract class World
         $this->config['rom.freeItemText'] = $free_item_text;
         $this->config['rom.freeItemMenu'] = $free_item_menu;
 
-        $this->config['item.overflow.count.Bow'] = 2;
-
         switch ($this->config('item.pool')) {
             case 'expert':
                 $this->config['item.overflow.count.Sword'] = 2;

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "source": {
           "url": "https://github.com/KatDevsGames/z3randomizer",
           "type": "git",
-          "reference": "02ec4ded4bea03668fe2ab11aa5a3a05be59debe"
+          "reference": "b76efe6df417c981c8c503b4c1ad491535a3e864"
         }
       }
     },

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "source": {
           "url": "https://github.com/KatDevsGames/z3randomizer",
           "type": "git",
-          "reference": "b76efe6df417c981c8c503b4c1ad491535a3e864"
+          "reference": "abd3dbe1fc3787e131af28b4d863340aa9bb9205"
         }
       }
     },

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "source": {
           "url": "https://github.com/KatDevsGames/z3randomizer",
           "type": "git",
-          "reference": "feb3105c5a5700d72ebf5b49a116133eb429d9cf"
+          "reference": "1bbf359198beb74746e6b2779c3fff0698c1b77a"
         }
       }
     },

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "source": {
           "url": "https://github.com/KatDevsGames/z3randomizer",
           "type": "git",
-          "reference": "abd3dbe1fc3787e131af28b4d863340aa9bb9205"
+          "reference": "feb3105c5a5700d72ebf5b49a116133eb429d9cf"
         }
       }
     },

--- a/composer.json
+++ b/composer.json
@@ -47,11 +47,11 @@
       "type": "package",
       "package": {
         "name": "z3/randomizer",
-        "version": "31.0.8",
+        "version": "31.0.9",
         "source": {
           "url": "https://github.com/KatDevsGames/z3randomizer",
           "type": "git",
-          "reference": "37f7125198db2971fe2fbb84792cbb111a689749"
+          "reference": "02ec4ded4bea03668fe2ab11aa5a3a05be59debe"
         }
       }
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "62c2a01d0c0957027c3a54fba5584dab",
+    "content-hash": "421b3caff5c672f790dfb699225fc552",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -7027,11 +7027,11 @@
         },
         {
             "name": "z3/randomizer",
-            "version": "31.0.8",
+            "version": "31.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/KatDevsGames/z3randomizer",
-                "reference": "37f7125198db2971fe2fbb84792cbb111a689749"
+                "reference": "02ec4ded4bea03668fe2ab11aa5a3a05be59debe"
             },
             "type": "library"
         }

--- a/composer.lock
+++ b/composer.lock
@@ -7031,7 +7031,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/KatDevsGames/z3randomizer",
-                "reference": "02ec4ded4bea03668fe2ab11aa5a3a05be59debe"
+                "reference": "b76efe6df417c981c8c503b4c1ad491535a3e864"
             },
             "type": "library"
         }

--- a/composer.lock
+++ b/composer.lock
@@ -7031,7 +7031,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/KatDevsGames/z3randomizer",
-                "reference": "feb3105c5a5700d72ebf5b49a116133eb429d9cf"
+                "reference": "1bbf359198beb74746e6b2779c3fff0698c1b77a"
             },
             "type": "library"
         }

--- a/composer.lock
+++ b/composer.lock
@@ -7031,7 +7031,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/KatDevsGames/z3randomizer",
-                "reference": "abd3dbe1fc3787e131af28b4d863340aa9bb9205"
+                "reference": "feb3105c5a5700d72ebf5b49a116133eb429d9cf"
             },
             "type": "library"
         }

--- a/composer.lock
+++ b/composer.lock
@@ -7031,7 +7031,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/KatDevsGames/z3randomizer",
-                "reference": "b76efe6df417c981c8c503b4c1ad491535a3e864"
+                "reference": "abd3dbe1fc3787e131af28b4d863340aa9bb9205"
             },
             "type": "library"
         }

--- a/config/sprites.php
+++ b/config/sprites.php
@@ -194,7 +194,7 @@ return [
         'author' => 'Malmo',
         'file' => 'astronaut.2.zspr',
         'version' => 2,
-        'vtversion' => '31.0.9',
+        'vtversion' => '31.0.5',
         'tags' => [
             0 => 'IRL',
         ],
@@ -814,7 +814,7 @@ return [
         'author' => 'Hidari',
         'file' => 'catgirl-hidari.1.zspr',
         'version' => 1,
-        'vtversion' => '31.0.9',
+        'vtversion' => '31.0.5',
         'tags' => [
             0 => 'Personality',
         ],
@@ -929,7 +929,7 @@ return [
         'author' => 'norskmatty',
         'file' => 'cinna.2.zspr',
         'version' => 2,
-        'vtversion' => '31.0.9',
+        'vtversion' => '31.0.8',
         'tags' => [
             0 => 'Personality',
         ],
@@ -958,7 +958,7 @@ return [
         'author' => 'PlaguedOne',
         'file' => 'clifford.2.zspr',
         'version' => 2,
-        'vtversion' => '31.0.9',
+        'vtversion' => '30',
         'tags' => [
             0 => 'Animal',
             1 => 'Dog',
@@ -1087,7 +1087,7 @@ return [
         'author' => 'PlaguedOne',
         'file' => 'cursor.2.zspr',
         'version' => 2,
-        'vtversion' => '31.0.9',
+        'vtversion' => '29',
         'tags' => [
             0 => 'Personality',
         ],
@@ -1784,7 +1784,7 @@ return [
         'author' => 'Lougaroc',
         'file' => 'gooey.2.zspr',
         'version' => 2,
-        'vtversion' => '31.0.9',
+        'vtversion' => '31.0.8',
         'tags' => [
             0 => 'Kirby',
         ],
@@ -1902,7 +1902,7 @@ return [
         'author' => 'Maya-Neko',
         'file' => 'hanna.2.zspr',
         'version' => 2,
-        'vtversion' => '31.0.9',
+        'vtversion' => '31.0.7',
         'tags' => [
             0 => 'Female',
             1 => 'Personality',
@@ -2294,7 +2294,7 @@ return [
         'author' => 'Chew Terr',
         'file' => 'kain.2.zspr',
         'version' => 2,
-        'vtversion' => '31.0.9',
+        'vtversion' => '31.0.8',
         'tags' => [
             0 => 'Final Fantasy',
             1 => 'Male',
@@ -2338,7 +2338,7 @@ return [
         'author' => 'Chew Terr',
         'file' => 'kefka.2.zspr',
         'version' => 2,
-        'vtversion' => '31.0.9',
+        'vtversion' => '31.0.8',
         'tags' => [
             0 => 'Final Fantasy',
             1 => 'Male',
@@ -2593,7 +2593,7 @@ return [
         'author' => 'Spiffy',
         'file' => 'link-redrawn.3.zspr',
         'version' => 3,
-        'vtversion' => '31.0.9',
+        'vtversion' => '31.0.7',
         'tags' => [
             0 => 'Link',
             1 => 'ALTTP',
@@ -2847,7 +2847,7 @@ return [
         'author' => 'kan',
         'file' => 'mangalink.3.zspr',
         'version' => 3,
-        'vtversion' => '31.0.9',
+        'vtversion' => '29',
         'tags' => [
             0 => 'Link',
             1 => 'Male',
@@ -3418,7 +3418,7 @@ return [
         'author' => 'Jakebob',
         'file' => 'niddraig.2.zspr',
         'version' => 2,
-        'vtversion' => '31.0.9',
+        'vtversion' => '31.0.7',
         'tags' => [
             0 => 'Final Fantasy',
             1 => 'Personality',
@@ -4017,7 +4017,7 @@ return [
         'author' => 'PlaguedOne',
         'file' => 'rottytops.2.zspr',
         'version' => 2,
-        'vtversion' => '31.0.9',
+        'vtversion' => '30.5',
         'tags' => [
             0 => 'Cartoon',
         ],
@@ -4091,7 +4091,7 @@ return [
         'author' => 'PlaguedOne',
         'file' => 'ryu.2.zspr',
         'version' => 2,
-        'vtversion' => '31.0.9',
+        'vtversion' => '30',
         'tags' => [
             0 => 'Male',
             1 => 'Street Fighter',
@@ -4193,7 +4193,7 @@ return [
         'author' => 'HOHOHO',
         'file' => 'santalink.3.zspr',
         'version' => 3,
-        'vtversion' => '31.0.9',
+        'vtversion' => '26',
         'tags' => [
             0 => 'Link',
             1 => 'Male',
@@ -5023,7 +5023,7 @@ return [
         'author' => 'PlaguedOne',
         'file' => 'ultros.2.zspr',
         'version' => 2,
-        'vtversion' => '31.0.9',
+        'vtversion' => '30',
         'tags' => [
             0 => 'Final Fantasy',
         ],

--- a/config/sprites.php
+++ b/config/sprites.php
@@ -29,8 +29,8 @@ return [
             2 => 'Legend of Zelda',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'abigail.1.zspr' => [
@@ -57,8 +57,21 @@ return [
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
+        ],
+    ],
+    'adventure-2600.1.zspr' => [
+        'name' => 'Adventure 2600',
+        'author' => 'Purple Peak',
+        'file' => 'adventure-2600.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.9',
+        'tags' => [
+            0 => 'Atari',
+        ],
+        'usage' => [
+            0 => 'smz3',
         ],
     ],
     'aggretsuko.1.zspr' => [
@@ -100,8 +113,8 @@ return [
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'arcane.1.zspr' => [
@@ -112,6 +125,20 @@ return [
         'vtversion' => '31.0.5',
         'tags' => [
             0 => 'Personality',
+        ],
+        'usage' => [
+            0 => 'smz3',
+        ],
+    ],
+    'aria.1.zspr' => [
+        'name' => 'Aria',
+        'author' => 'Maya Neko Comics',
+        'file' => 'aria.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.9',
+        'tags' => [
+            0 => 'Female',
+            1 => 'Personality',
         ],
         'usage' => [
             0 => 'smz3',
@@ -128,8 +155,8 @@ return [
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'ark.1.zspr' => [
@@ -162,18 +189,18 @@ return [
             0 => 'smz3',
         ],
     ],
-    'astronaut.1.zspr' => [
+    'astronaut.2.zspr' => [
         'name' => 'Astronaut',
         'author' => 'Malmo',
-        'file' => 'astronaut.1.zspr',
-        'version' => 1,
-        'vtversion' => '31.0.5',
+        'file' => 'astronaut.2.zspr',
+        'version' => 2,
+        'vtversion' => '31.0.9',
         'tags' => [
             0 => 'IRL',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'asuna.2.zspr' => [
@@ -187,8 +214,8 @@ return [
             1 => 'Sword Art Online',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'badeline.1.zspr' => [
@@ -202,8 +229,8 @@ return [
             1 => 'Female',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'bananas-in-pyjamas.1.zspr' => [
@@ -216,8 +243,8 @@ return [
             0 => 'Cartoon',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'bandit.1.zspr' => [
@@ -230,8 +257,8 @@ return [
             0 => 'Mario',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'batman.1.zspr' => [
@@ -246,8 +273,8 @@ return [
             2 => 'DC Comics',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'beau.1.zspr' => [
@@ -262,8 +289,23 @@ return [
             2 => 'Animal',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
+        ],
+    ],
+    'bee.1.zspr' => [
+        'name' => 'Bee',
+        'author' => 'TarThoron',
+        'file' => 'bee.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.9',
+        'tags' => [
+            0 => 'ALTTP',
+            1 => 'NPC',
+            2 => 'Animal',
+        ],
+        'usage' => [
+            0 => 'smz3',
         ],
     ],
     'bewp.1.zspr' => [
@@ -306,8 +348,8 @@ return [
             2 => 'Streamer',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'birdo.1.zspr' => [
@@ -350,8 +392,8 @@ return [
             3 => 'ALTTP NPC',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'blazer.1.zspr' => [
@@ -364,8 +406,8 @@ return [
             0 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'blossom.1.zspr' => [
@@ -410,8 +452,8 @@ return [
             1 => 'Personality',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'boco.2.zspr' => [
@@ -425,8 +467,8 @@ return [
             1 => 'Animal',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'boo-two.1.zspr' => [
@@ -440,8 +482,8 @@ return [
             1 => 'Ghost',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'boo.2.zspr' => [
@@ -455,8 +497,8 @@ return [
             1 => 'Ghost',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'bottle_o_goo.1.zspr' => [
@@ -483,8 +525,8 @@ return [
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'botw-zelda.1.zspr' => [
@@ -557,8 +599,8 @@ return [
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'brian.1.zspr' => [
@@ -572,8 +614,8 @@ return [
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'broccoli.2.zspr' => [
@@ -763,8 +805,21 @@ return [
             2 => 'Cat',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
+        ],
+    ],
+    'catgirl-hidari.1.zspr' => [
+        'name' => 'Catgirl (Hidari)',
+        'author' => 'Hidari',
+        'file' => 'catgirl-hidari.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.9',
+        'tags' => [
+            0 => 'Personality',
+        ],
+        'usage' => [
+            0 => 'smz3',
         ],
     ],
     'cdilink.1.zspr' => [
@@ -779,8 +834,8 @@ return [
             2 => 'Legend of Zelda',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'celes.1.zspr' => [
@@ -794,8 +849,22 @@ return [
             1 => 'Female',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
+        ],
+    ],
+    'centaur-enos.1.zspr' => [
+        'name' => 'Centaur Enos',
+        'author' => 'Ziusudra',
+        'file' => 'centaur-enos.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.9',
+        'tags' => [
+            0 => 'Male',
+            1 => 'Personality',
+        ],
+        'usage' => [
+            0 => 'smz3',
         ],
     ],
     'charizard.1.zspr' => [
@@ -822,8 +891,8 @@ return [
             1 => 'Fish',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'chibity.1.zspr' => [
@@ -836,8 +905,8 @@ return [
             0 => 'Personality',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'chrizzz.1.zspr' => [
@@ -851,22 +920,22 @@ return [
             1 => 'Personality',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
-    'cinna.1.zspr' => [
+    'cinna.2.zspr' => [
         'name' => 'Cinna',
         'author' => 'norskmatty',
-        'file' => 'cinna.1.zspr',
-        'version' => 1,
-        'vtversion' => '31.0.8',
+        'file' => 'cinna.2.zspr',
+        'version' => 2,
+        'vtversion' => '31.0.9',
         'tags' => [
             0 => 'Personality',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'cirno.1.zspr' => [
@@ -880,19 +949,46 @@ return [
             1 => 'Female',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
-    'clifford.1.zspr' => [
+    'clifford.2.zspr' => [
         'name' => 'Clifford',
         'author' => 'PlaguedOne',
-        'file' => 'clifford.1.zspr',
-        'version' => 1,
-        'vtversion' => '30',
+        'file' => 'clifford.2.zspr',
+        'version' => 2,
+        'vtversion' => '31.0.9',
         'tags' => [
             0 => 'Animal',
             1 => 'Dog',
+        ],
+        'usage' => [
+            0 => 'smz3',
+        ],
+    ],
+    'clippy.1.zspr' => [
+        'name' => 'Clippy',
+        'author' => 'PlaguedOne',
+        'file' => 'clippy.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.9',
+        'tags' => [
+            0 => 'Personality',
+        ],
+        'usage' => [
+            0 => 'smz3',
+        ],
+    ],
+    'cloud.1.zspr' => [
+        'name' => 'Cloud',
+        'author' => 'FedoraFriday',
+        'file' => 'cloud.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.9',
+        'tags' => [
+            0 => 'Male',
+            1 => 'Final Fantasy',
         ],
         'usage' => [
             0 => 'smz3',
@@ -938,8 +1034,8 @@ return [
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'corona.2.zspr' => [
@@ -953,8 +1049,8 @@ return [
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'crewmate.2.zspr' => [
@@ -982,16 +1078,16 @@ return [
             2 => 'Bird',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
-    'cursor.1.zspr' => [
+    'cursor.2.zspr' => [
         'name' => 'Cursor',
         'author' => 'PlaguedOne',
-        'file' => 'cursor.1.zspr',
-        'version' => 1,
-        'vtversion' => '29',
+        'file' => 'cursor.2.zspr',
+        'version' => 2,
+        'vtversion' => '31.0.9',
         'tags' => [
             0 => 'Personality',
         ],
@@ -1068,8 +1164,8 @@ return [
             2 => 'Legend of Zelda',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'darklink.1.zspr' => [
@@ -1099,8 +1195,8 @@ return [
             2 => 'Legend of Zelda',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'darkzelda.1.zspr' => [
@@ -1128,8 +1224,8 @@ return [
             1 => 'ALTTP NPC',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'deadpool-mythic.1.zspr' => [
@@ -1173,8 +1269,8 @@ return [
             1 => 'ALTTP NPC',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'decidueye.1.zspr' => [
@@ -1188,8 +1284,8 @@ return [
             1 => 'Bird',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'dekar.1.zspr' => [
@@ -1218,8 +1314,35 @@ return [
             2 => 'Legend of Zelda',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
+        ],
+    ],
+    'dennsen86.1.zspr' => [
+        'name' => 'Dennsen86',
+        'author' => 'Bonzaibier',
+        'file' => 'dennsen86.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.9',
+        'tags' => [
+            0 => 'Male',
+            1 => 'Personality',
+        ],
+        'usage' => [
+            0 => 'smz3',
+        ],
+    ],
+    'digdug.1.zspr' => [
+        'name' => 'Dig Dug',
+        'author' => 'kan',
+        'file' => 'digdug.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.9',
+        'tags' => [
+            0 => 'Dig Dug',
+        ],
+        'usage' => [
+            0 => 'smz3',
         ],
     ],
     'dipper.1.zspr' => [
@@ -1230,6 +1353,20 @@ return [
         'vtversion' => '31.0.8',
         'tags' => [
             0 => 'Gravity Falls',
+            1 => 'Male',
+        ],
+        'usage' => [
+            0 => 'smz3',
+        ],
+    ],
+    'discord-mlp.1.zspr' => [
+        'name' => 'Discord',
+        'author' => 'JerryEris',
+        'file' => 'discord-mlp.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.9',
+        'tags' => [
+            0 => 'My Little Pony',
             1 => 'Male',
         ],
         'usage' => [
@@ -1314,8 +1451,23 @@ return [
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
+        ],
+    ],
+    'fi.1.zspr' => [
+        'name' => 'Fi',
+        'author' => 'Lougaroc',
+        'file' => 'fi.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.9',
+        'tags' => [
+            0 => 'Legend of Zelda',
+            1 => 'female',
+            2 => 'Skyward Sword',
+        ],
+        'usage' => [
+            0 => 'smz3',
         ],
     ],
     'fierce-deity-link.3.zspr' => [
@@ -1373,8 +1525,8 @@ return [
             2 => 'Animal',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'flavor_guy.1.zspr' => [
@@ -1402,8 +1554,8 @@ return [
             1 => 'Animal',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'freya.1.zspr' => [
@@ -1430,8 +1582,8 @@ return [
             0 => 'Undertale',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'froglink.3.zspr' => [
@@ -1445,8 +1597,8 @@ return [
             1 => 'Animal',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'fujin.2.zspr' => [
@@ -1487,8 +1639,8 @@ return [
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'ganon.2.zspr' => [
@@ -1505,8 +1657,8 @@ return [
             4 => 'Boss',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'ganondorf.2.zspr' => [
@@ -1537,8 +1689,8 @@ return [
             1 => 'Animal',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'garnet.1.zspr' => [
@@ -1565,8 +1717,8 @@ return [
             0 => 'Legend of Zelda',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'gbc-link.1.zspr' => [
@@ -1595,8 +1747,8 @@ return [
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'gliitchwiitch.1.zspr' => [
@@ -1627,18 +1779,18 @@ return [
             0 => 'smz3',
         ],
     ],
-    'gooey.1.zspr' => [
+    'gooey.2.zspr' => [
         'name' => 'Gooey',
         'author' => 'Lougaroc',
-        'file' => 'gooey.1.zspr',
-        'version' => 1,
-        'vtversion' => '31.0.8',
+        'file' => 'gooey.2.zspr',
+        'version' => 2,
+        'vtversion' => '31.0.9',
         'tags' => [
             0 => 'Kirby',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'goomba.1.zspr' => [
@@ -1665,8 +1817,22 @@ return [
             1 => 'Animal',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
+        ],
+    ],
+    'graalian-noob.1.zspr' => [
+        'name' => 'Graalian Noob',
+        'author' => 'EGamer2',
+        'file' => 'graalian-noob.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.9',
+        'tags' => [
+            0 => 'Graal',
+            1 => 'Male',
+        ],
+        'usage' => [
+            0 => 'smz3',
         ],
     ],
     'grandpoobear.2.zspr' => [
@@ -1697,8 +1863,8 @@ return [
             2 => 'Streamer',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'grunclestan.1.zspr' => [
@@ -1727,23 +1893,23 @@ return [
             2 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
-    'hanna.1.zspr' => [
+    'hanna.2.zspr' => [
         'name' => 'Hanna',
         'author' => 'Maya-Neko',
-        'file' => 'hanna.1.zspr',
-        'version' => 1,
-        'vtversion' => '31.0.7',
+        'file' => 'hanna.2.zspr',
+        'version' => 2,
+        'vtversion' => '31.0.9',
         'tags' => [
             0 => 'Female',
             1 => 'Personality',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'hardhat_beetle.1.zspr' => [
@@ -1769,6 +1935,21 @@ return [
         'tags' => [
             0 => 'Female',
             1 => 'A Hat in Time',
+        ],
+        'usage' => [
+            0 => 'smz3',
+        ],
+    ],
+    'head-link.1.zspr' => [
+        'name' => 'Head Link',
+        'author' => 'TarThoron',
+        'file' => 'head-link.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.9',
+        'tags' => [
+            0 => 'ALTTP',
+            1 => 'Link',
+            2 => 'Male',
         ],
         'usage' => [
             0 => 'smz3',
@@ -1801,8 +1982,8 @@ return [
             2 => 'Animal',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'hero-of-awakening.1.zspr' => [
@@ -1816,8 +1997,8 @@ return [
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'hero-of-hyrule.1.zspr' => [
@@ -1831,23 +2012,8 @@ return [
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
-        ],
-    ],
-    'hidari.1.zspr' => [
-        'name' => 'Hidari',
-        'author' => 'Hidari',
-        'file' => 'hidari.1.zspr',
-        'version' => 1,
-        'vtversion' => '31.0.5',
-        'tags' => [
-            0 => 'Legend of Zelda',
-            1 => 'ALTTP NPC',
-        ],
-        'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'hint_tile.1.zspr' => [
@@ -1915,8 +2081,8 @@ return [
             0 => 'Hollow Knight',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'hollow-knight.2.zspr' => [
@@ -1929,8 +2095,8 @@ return [
             0 => 'Hollow Knight',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'homer.1.zspr' => [
@@ -1944,8 +2110,22 @@ return [
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
+        ],
+    ],
+    'hornet.1.zspr' => [
+        'name' => 'Hornet',
+        'author' => 'Spiffy',
+        'file' => 'hornet.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.9',
+        'tags' => [
+            0 => 'Hollow Knight',
+            1 => 'Female',
+        ],
+        'usage' => [
+            0 => 'smz3',
         ],
     ],
     'hotdog.1.zspr' => [
@@ -1973,8 +2153,8 @@ return [
             1 => 'Legend of Zelda',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'ibazly.1.zspr' => [
@@ -2020,8 +2200,8 @@ return [
             2 => 'Legend of Zelda',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'inkling.1.zspr' => [
@@ -2049,8 +2229,8 @@ return [
             2 => 'Legend of Zelda',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'jack-frost.1.zspr' => [
@@ -2063,8 +2243,8 @@ return [
             0 => 'Shin Megami Tensei',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'jason_frudnick.1.zspr' => [
@@ -2091,8 +2271,8 @@ return [
             0 => 'Personality',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'jogurt.1.zspr' => [
@@ -2105,23 +2285,23 @@ return [
             0 => 'Personality',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
-    'kain.1.zspr' => [
+    'kain.2.zspr' => [
         'name' => 'Kain',
         'author' => 'Chew Terr',
-        'file' => 'kain.1.zspr',
-        'version' => 1,
-        'vtversion' => '31.0.8',
+        'file' => 'kain.2.zspr',
+        'version' => 2,
+        'vtversion' => '31.0.9',
         'tags' => [
             0 => 'Final Fantasy',
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'katsura.2.zspr' => [
@@ -2136,8 +2316,8 @@ return [
             2 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'kecleon.1.zspr' => [
@@ -2153,20 +2333,20 @@ return [
             0 => 'smz3',
         ],
     ],
-    'kefka.1.zspr' => [
+    'kefka.2.zspr' => [
         'name' => 'Kefka',
         'author' => 'Chew Terr',
-        'file' => 'kefka.1.zspr',
-        'version' => 1,
-        'vtversion' => '31.0.8',
+        'file' => 'kefka.2.zspr',
+        'version' => 2,
+        'vtversion' => '31.0.9',
         'tags' => [
             0 => 'Final Fantasy',
             1 => 'Male',
             2 => 'Villain',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'kenny_mccormick.1.zspr' => [
@@ -2194,8 +2374,8 @@ return [
             1 => 'IRL',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'kholdstare.2.zspr' => [
@@ -2239,8 +2419,8 @@ return [
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'kinu.1.zspr' => [
@@ -2253,8 +2433,8 @@ return [
             0 => 'Temtem',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'kirby-d3.1.zspr' => [
@@ -2267,8 +2447,8 @@ return [
             0 => 'Kirby',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'kirby-meta.1.zspr' => [
@@ -2282,8 +2462,8 @@ return [
             1 => 'Kirby',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'kore8.1.zspr' => [
@@ -2311,8 +2491,8 @@ return [
             2 => 'NPC',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'kriv.1.zspr' => [
@@ -2364,6 +2544,20 @@ return [
             0 => 'smz3',
         ],
     ],
+    'lestat.1.zspr' => [
+        'name' => 'Lestat',
+        'author' => 'Ziusudra',
+        'file' => 'lestat.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.9',
+        'tags' => [
+            0 => 'Male',
+            1 => 'Bahamut Lagoon',
+        ],
+        'usage' => [
+            0 => 'smz3',
+        ],
+    ],
     'lily.1.zspr' => [
         'name' => 'Lily',
         'author' => 'ScatlinkSean',
@@ -2375,8 +2569,8 @@ return [
             1 => 'Female',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'linja.1.zspr' => [
@@ -2394,12 +2588,12 @@ return [
             0 => 'smz3',
         ],
     ],
-    'link-redrawn.1.zspr' => [
+    'link-redrawn.3.zspr' => [
         'name' => 'Link Redrawn',
         'author' => 'Spiffy',
-        'file' => 'link-redrawn.1.zspr',
-        'version' => 1,
-        'vtversion' => '31.0.7',
+        'file' => 'link-redrawn.3.zspr',
+        'version' => 3,
+        'vtversion' => '31.0.9',
         'tags' => [
             0 => 'Link',
             1 => 'ALTTP',
@@ -2421,8 +2615,8 @@ return [
             2 => 'Legend of Zelda',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'linktuniccolor.1.zspr' => [
@@ -2508,8 +2702,8 @@ return [
             0 => 'Pokemon',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'luffy.2.zspr' => [
@@ -2539,8 +2733,8 @@ return [
             2 => 'Superhero',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'luna-maindo.1.zspr' => [
@@ -2568,8 +2762,8 @@ return [
             1 => 'Villain',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'madeline.1.zspr' => [
@@ -2583,8 +2777,8 @@ return [
             1 => 'Celeste',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'magus.1.zspr' => [
@@ -2617,6 +2811,21 @@ return [
             0 => 'smz3',
         ],
     ],
+    'majora.1.zspr' => [
+        'name' => 'Majora\'s Mask',
+        'author' => 'Dawn',
+        'file' => 'majora.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.9',
+        'tags' => [
+            0 => 'Legend of Zelda',
+            1 => 'Majora\'s Mask',
+            2 => 'villain',
+        ],
+        'usage' => [
+            0 => 'smz3',
+        ],
+    ],
     'mallow-cat.1.zspr' => [
         'name' => 'Mallow (Cat)',
         'author' => 'FedoraFriday',
@@ -2629,16 +2838,16 @@ return [
             2 => 'Streamer',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
-    'mangalink.2.zspr' => [
+    'mangalink.3.zspr' => [
         'name' => 'Manga Link',
         'author' => 'kan',
-        'file' => 'mangalink.2.zspr',
-        'version' => 2,
-        'vtversion' => '29',
+        'file' => 'mangalink.3.zspr',
+        'version' => 3,
+        'vtversion' => '31.0.9',
         'tags' => [
             0 => 'Link',
             1 => 'Male',
@@ -2658,8 +2867,8 @@ return [
             0 => 'Female',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'marin.2.zspr' => [
@@ -2687,8 +2896,8 @@ return [
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'mario_tanooki.2.zspr' => [
@@ -2716,8 +2925,8 @@ return [
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'marisa.1.zspr' => [
@@ -2731,8 +2940,8 @@ return [
             1 => 'Female',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'matthias.1.zspr' => [
@@ -2777,8 +2986,8 @@ return [
             1 => 'Legend of Zelda',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'medli.1.zspr' => [
@@ -2793,8 +3002,8 @@ return [
             2 => 'Bird',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'megaman-x.2.zspr' => [
@@ -2803,6 +3012,34 @@ return [
         'file' => 'megaman-x.2.zspr',
         'version' => 2,
         'vtversion' => '28',
+        'tags' => [
+            0 => 'Male',
+            1 => 'Megaman',
+        ],
+        'usage' => [
+            0 => 'smz3',
+        ],
+    ],
+    'megaman-x2.1.zspr' => [
+        'name' => 'Megaman X2',
+        'author' => 'PlaguedOne',
+        'file' => 'megaman-x2.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.9',
+        'tags' => [
+            0 => 'Male',
+            1 => 'Megaman',
+        ],
+        'usage' => [
+            0 => 'smz3',
+        ],
+    ],
+    'megaman.1.zspr' => [
+        'name' => 'Mega Man (Classic)',
+        'author' => 'CrebleStar',
+        'file' => 'megaman.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.9',
         'tags' => [
             0 => 'Male',
             1 => 'Megaman',
@@ -2822,8 +3059,8 @@ return [
             1 => 'Alien',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'mew.1.zspr' => [
@@ -2848,6 +3085,20 @@ return [
         'tags' => [
             0 => 'StarTropics',
             1 => 'Male',
+        ],
+        'usage' => [
+            0 => 'smz3',
+        ],
+    ],
+    'mimic.1.zspr' => [
+        'name' => 'Mimic',
+        'author' => 'Chew Terr',
+        'file' => 'mimic.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.9',
+        'tags' => [
+            0 => 'Villain',
+            1 => 'Dragon Quest',
         ],
         'usage' => [
             0 => 'smz3',
@@ -2880,8 +3131,23 @@ return [
             2 => 'Legend of Zelda',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
+        ],
+    ],
+    'mipha.1.zspr' => [
+        'name' => 'Mipha',
+        'author' => 'RippedSnorlax',
+        'file' => 'mipha.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.9',
+        'tags' => [
+            0 => 'Legend of Zelda',
+            1 => 'Breath of the Wild',
+            2 => 'female',
+        ],
+        'usage' => [
+            0 => 'smz3',
         ],
     ],
     'missingno.2.zspr' => [
@@ -2894,8 +3160,8 @@ return [
             0 => 'Pokemon',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'moblin.2.zspr' => [
@@ -2909,8 +3175,8 @@ return [
             1 => 'ALTTP',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'modernlink.1.zspr' => [
@@ -2938,8 +3204,8 @@ return [
             0 => 'Final Fantasy',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'momiji.1.zspr' => [
@@ -2953,8 +3219,8 @@ return [
             1 => 'Female',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'moosh.1.zspr' => [
@@ -3039,8 +3305,8 @@ return [
             1 => 'Legend of Zelda',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'navirou.3.zspr' => [
@@ -3053,8 +3319,8 @@ return [
             0 => 'Monster Hunter',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'ned-flanders.1.zspr' => [
@@ -3069,8 +3335,8 @@ return [
             2 => 'Simpsons',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'negativelink.1.zspr' => [
@@ -3099,8 +3365,8 @@ return [
             1 => 'Streamer',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'neslink.2.zspr' => [
@@ -3115,8 +3381,8 @@ return [
             2 => 'Legend of Zelda',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'ness.2.zspr' => [
@@ -3147,19 +3413,19 @@ return [
             0 => 'smz3',
         ],
     ],
-    'niddraig.1.zspr' => [
+    'niddraig.2.zspr' => [
         'name' => 'Niddraig',
         'author' => 'Jakebob',
-        'file' => 'niddraig.1.zspr',
-        'version' => 1,
-        'vtversion' => '31.0.7',
+        'file' => 'niddraig.2.zspr',
+        'version' => 2,
+        'vtversion' => '31.0.9',
         'tags' => [
             0 => 'Final Fantasy',
             1 => 'Personality',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'niko.1.zspr' => [
@@ -3173,8 +3439,8 @@ return [
             1 => 'Cat',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'oldman.2.zspr' => [
@@ -3189,8 +3455,8 @@ return [
             2 => 'Legend of Zelda',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'ori.2.zspr' => [
@@ -3204,8 +3470,8 @@ return [
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'outlinelink.1.zspr' => [
@@ -3220,8 +3486,8 @@ return [
             2 => 'Legend of Zelda',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'parallelworldslink.1.zspr' => [
@@ -3236,8 +3502,8 @@ return [
             2 => 'Legend of Zelda',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'paula.1.zspr' => [
@@ -3308,8 +3574,8 @@ return [
             1 => 'Ace Attorney',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'pikachu.2.zspr' => [
@@ -3322,8 +3588,8 @@ return [
             0 => 'Pokemon',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'pinkribbonlink.3.zspr' => [
@@ -3352,8 +3618,8 @@ return [
             1 => 'Villain',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'plagueknight.1.zspr' => [
@@ -3365,6 +3631,33 @@ return [
         'tags' => [
             0 => 'Shovel Knight',
             1 => 'Male',
+        ],
+        'usage' => [
+            0 => 'smz3',
+        ],
+    ],
+    'plouni.1.zspr' => [
+        'name' => 'Plouni',
+        'author' => 'Plouni',
+        'file' => 'plouni.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.9',
+        'tags' => [
+            0 => 'Personality',
+        ],
+        'usage' => [
+            0 => 'smz3',
+        ],
+    ],
+    'pokey-subtle.1.zspr' => [
+        'name' => 'Pokey (subtle)',
+        'author' => 'kan',
+        'file' => 'pokey-subtle.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.9',
+        'tags' => [
+            0 => 'ALTTP NPC',
+            1 => 'Legend of Zelda',
         ],
         'usage' => [
             0 => 'smz3',
@@ -3395,8 +3688,8 @@ return [
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'poppy.1.zspr' => [
@@ -3410,8 +3703,8 @@ return [
             1 => 'Female',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'porg_knight.1.zspr' => [
@@ -3424,8 +3717,8 @@ return [
             0 => 'Star Wars',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'power-ranger.1.zspr' => [
@@ -3438,8 +3731,8 @@ return [
             0 => 'Power Ranger',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'powerpuff_girl.1.zspr' => [
@@ -3502,6 +3795,19 @@ return [
             0 => 'smz3',
         ],
     ],
+    'prof-renderer-grizzleton.1.zspr' => [
+        'name' => 'Prof. Renderer Grizzleton',
+        'author' => 'Professor Renderer',
+        'file' => 'prof-renderer-grizzleton.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.9',
+        'tags' => [
+            0 => 'Personality',
+        ],
+        'usage' => [
+            0 => 'smz3',
+        ],
+    ],
     'professor.1.zspr' => [
         'name' => 'The Professor',
         'author' => 'PlaguedOne',
@@ -3543,8 +3849,8 @@ return [
             3 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'purplechest-bottle.1.zspr' => [
@@ -3558,8 +3864,8 @@ return [
             1 => 'Legend of Zelda',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'pyro.1.zspr' => [
@@ -3573,8 +3879,8 @@ return [
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'quadbanger.1.zspr' => [
@@ -3617,8 +3923,8 @@ return [
             1 => 'Legend of Zelda',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'red-mage.1.zspr' => [
@@ -3645,8 +3951,8 @@ return [
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'remus-ruldufus-black.1.zspr' => [
@@ -3702,16 +4008,16 @@ return [
             1 => 'Nickelodeon',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
-    'rottytops.1.zspr' => [
+    'rottytops.2.zspr' => [
         'name' => 'Rottytops',
         'author' => 'PlaguedOne',
-        'file' => 'rottytops.1.zspr',
-        'version' => 1,
-        'vtversion' => '30.5',
+        'file' => 'rottytops.2.zspr',
+        'version' => 2,
+        'vtversion' => '31.0.9',
         'tags' => [
             0 => 'Cartoon',
         ],
@@ -3731,8 +4037,8 @@ return [
             2 => 'Cat',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'roykoopa.1.zspr' => [
@@ -3746,8 +4052,8 @@ return [
             1 => 'Mario',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'rumia.1.zspr' => [
@@ -3761,8 +4067,8 @@ return [
             1 => 'Female',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'rydia.1.zspr' => [
@@ -3776,16 +4082,16 @@ return [
             1 => 'Female',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
-    'ryu.1.zspr' => [
+    'ryu.2.zspr' => [
         'name' => 'Ryu',
         'author' => 'PlaguedOne',
-        'file' => 'ryu.1.zspr',
-        'version' => 1,
-        'vtversion' => '30',
+        'file' => 'ryu.2.zspr',
+        'version' => 2,
+        'vtversion' => '31.0.9',
         'tags' => [
             0 => 'Male',
             1 => 'Street Fighter',
@@ -3820,8 +4126,8 @@ return [
             1 => 'Superhero',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'samus-sm.1.zspr' => [
@@ -3835,8 +4141,8 @@ return [
             1 => 'Female',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'samus.2.zspr' => [
@@ -3878,16 +4184,16 @@ return [
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
-    'santalink.2.zspr' => [
+    'santalink.3.zspr' => [
         'name' => 'Santa Link',
         'author' => 'HOHOHO',
-        'file' => 'santalink.2.zspr',
-        'version' => 2,
-        'vtversion' => '26',
+        'file' => 'santalink.3.zspr',
+        'version' => 3,
+        'vtversion' => '31.0.9',
         'tags' => [
             0 => 'Link',
             1 => 'Male',
@@ -3895,8 +4201,8 @@ return [
             3 => 'Festive',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'scholar.1.zspr' => [
@@ -3910,8 +4216,8 @@ return [
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'selan.2.zspr' => [
@@ -3925,8 +4231,8 @@ return [
             1 => 'Female',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'sevens1ns.1.zspr' => [
@@ -4012,8 +4318,8 @@ return [
             1 => 'Female',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'shy-guy.1.zspr' => [
@@ -4039,8 +4345,8 @@ return [
             0 => 'Personality',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'skunk.1.zspr' => [
@@ -4053,8 +4359,8 @@ return [
             0 => 'Personality',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'slime.1.zspr' => [
@@ -4067,8 +4373,8 @@ return [
             0 => 'Dragon Quest',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'slowpoke.2.zspr' => [
@@ -4081,8 +4387,8 @@ return [
             0 => 'Pokemon',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'snes-controller.2.zspr' => [
@@ -4095,8 +4401,8 @@ return [
             0 => 'SNES',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'sodacan.1.zspr' => [
@@ -4111,8 +4417,8 @@ return [
             2 => 'IRL',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'solaire.1.zspr' => [
@@ -4140,8 +4446,8 @@ return [
             1 => 'ALTTP NPC',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'sonic.1.zspr' => [
@@ -4155,8 +4461,8 @@ return [
             1 => 'Sonic the Hedgehog',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'sora.1.zspr' => [
@@ -4170,8 +4476,8 @@ return [
             1 => 'Kingdom Hearts',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'sora_kh1.1.zspr' => [
@@ -4185,8 +4491,22 @@ return [
             1 => 'Kingdom Hearts',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
+        ],
+    ],
+    'spikedroller.1.zspr' => [
+        'name' => 'Spiked Roller',
+        'author' => 'PlaguedOne',
+        'file' => 'spikedroller.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.9',
+        'tags' => [
+            0 => 'ALTTP',
+            1 => 'NPC',
+        ],
+        'usage' => [
+            0 => 'smz3',
         ],
     ],
     'spongebob.1.zspr' => [
@@ -4200,8 +4520,8 @@ return [
             1 => 'Spongebob Squarepants',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'squall.1.zspr' => [
@@ -4243,8 +4563,8 @@ return [
             0 => 'Pokemon',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'stalfos.1.zspr' => [
@@ -4329,8 +4649,8 @@ return [
             1 => 'Legend of Zelda',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'superbunny.2.zspr' => [
@@ -4345,8 +4665,8 @@ return [
             2 => 'Legend of Zelda',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'supermeatboy.1.zspr' => [
@@ -4360,8 +4680,8 @@ return [
             1 => 'Meat Boy',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'susie.1.zspr' => [
@@ -4391,8 +4711,23 @@ return [
             2 => 'Legend of Zelda',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
+        ],
+    ],
+    'swiper.1.zspr' => [
+        'name' => 'Swiper',
+        'author' => 'Purple Peak',
+        'file' => 'swiper.1.zspr',
+        'version' => 1,
+        'vtversion' => '31.0.9',
+        'tags' => [
+            0 => 'Male',
+            1 => 'Villain',
+            2 => 'Dora the Explorer',
+        ],
+        'usage' => [
+            0 => 'smz3',
         ],
     ],
     'tasbot.1.zspr' => [
@@ -4476,8 +4811,8 @@ return [
             2 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'thief.1.zspr' => [
@@ -4522,8 +4857,8 @@ return [
             3 => 'Bird',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'tile.3.zspr' => [
@@ -4551,8 +4886,8 @@ return [
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'tmnt.1.zspr' => [
@@ -4581,8 +4916,8 @@ return [
             1 => 'Mario',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'toadette.2.zspr' => [
@@ -4638,8 +4973,8 @@ return [
             0 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'twilightprincesszelda.2.zspr' => [
@@ -4683,12 +5018,12 @@ return [
             0 => 'smz3',
         ],
     ],
-    'ultros.1.zspr' => [
+    'ultros.2.zspr' => [
         'name' => 'Ultros',
         'author' => 'PlaguedOne',
-        'file' => 'ultros.1.zspr',
-        'version' => 1,
-        'vtversion' => '30',
+        'file' => 'ultros.2.zspr',
+        'version' => 2,
+        'vtversion' => '31.0.9',
         'tags' => [
             0 => 'Final Fantasy',
         ],
@@ -4707,8 +5042,8 @@ return [
             1 => 'Female',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'vanillalink.1.zspr' => [
@@ -4763,8 +5098,8 @@ return [
             0 => 'Personality',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'vitreous.1.zspr' => [
@@ -4779,8 +5114,8 @@ return [
             2 => 'Boss',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'vivi.1.zspr' => [
@@ -4823,8 +5158,8 @@ return [
             2 => 'Villain',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'whitemage.1.zspr' => [
@@ -4851,8 +5186,8 @@ return [
             1 => 'Male',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'wizzrobe.2.zspr' => [
@@ -4899,8 +5234,8 @@ return [
             3 => 'Animal',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'yoshi.1.zspr' => [
@@ -4942,8 +5277,8 @@ return [
             2 => 'Female',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'zebraunicorn.1.zspr' => [
@@ -4971,8 +5306,8 @@ return [
             0 => 'Personality',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'zelda.1.zspr' => [
@@ -4987,8 +5322,8 @@ return [
             2 => 'Legend of Zelda',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
     'zerosuitsamus.2.zspr' => [
@@ -5016,8 +5351,8 @@ return [
             1 => 'Legend of Zelda',
         ],
         'usage' => [
-            0 => 'commercial',
-            1 => 'smz3',
+            0 => 'smz3',
+            1 => 'commercial',
         ],
     ],
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -4161,6 +4161,23 @@
 			"integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
 			"dev": true
 		},
+		"align-text": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/align-text/-/align-text-1.0.2.tgz",
+			"integrity": "sha512-uBPDs72zrRTdiTBY0YjBbuBOdXtRyT4qsKPb4bL4O7vH4utz/7KjwTJVsVbdThxMbVzkRGAfk8Ml3xoMvXSEYw==",
+			"requires": {
+				"kind-of": "^5.0.2",
+				"longest": "^2.0.1",
+				"repeat-string": "^1.6.1"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+				}
+			}
+		},
 		"alphanum-sort": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
@@ -5348,6 +5365,15 @@
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 			"dev": true
+		},
+		"center-align": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/center-align/-/center-align-1.0.1.tgz",
+			"integrity": "sha1-Kh/f22zQ3S0l+/z2dR50azE+UKQ=",
+			"requires": {
+				"align-text": "^1.0.0",
+				"repeat-string": "^1.6.1"
+			}
 		},
 		"chalk": {
 			"version": "2.4.2",
@@ -12562,6 +12588,11 @@
 				"@sinonjs/commons": "^1.7.0"
 			}
 		},
+		"longest": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/longest/-/longest-2.0.1.tgz",
+			"integrity": "sha1-eB4YMpaqlPbU2RbcM10NF676I/g="
+		},
 		"loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -15144,8 +15175,7 @@
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-			"dev": true
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
 		},
 		"replace-ext": {
 			"version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18802,9 +18802,9 @@
 			"dev": true
 		},
 		"y18n": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-			"integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
 			"dev": true
 		},
 		"yallist": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"@sentry/browser": "^5.18.1",
 		"@stardazed/zlib": "^1.0.1",
 		"ajv": "^6.12.2",
+		"center-align": "^1.0.1",
 		"es6-promise": "^4.2.8",
 		"file-saver": "^2.0.2",
 		"localforage": "^1.7.4",

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@
 ### System Setup
 This assumes you're running Ubuntu 20.04 (either natively, or via Windows Subsystem for Linux).
 Native Windows is not currently supported.
-Users of other Linux distributions will need to install the appropriate packages for their distribution.
+Users of either Mac OS or other Linux distributions will need to install the appropriate packages for their system.
 
 This version of the randomizer requires version 7.4 of PHP.
 

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,8 @@ $ php artisan migrate
 
 In you .env file, update `ENEMIZER_BASE=` to the **absolute path** of an unheadered Japanese 1.0 ROM of A Link to the Past.
 
+Then, in the command line run this to create the base patch.
+
 ```
 php artisan alttp:updatebuildrecord
 ```

--- a/readme.md
+++ b/readme.md
@@ -2,30 +2,28 @@
 
 # ALttP VT Randomizer
 
-## First and foremost, big thanks to Dessyreqt, Christos, Smallhacker, and Karkat for their work.
+## First and foremost, big thanks to Dessyreqt, Christos, Smallhacker, and KatDevsGames for their work.
 ### Without their work none of this would even be remotely possible.
 
-## Installing dependencies
+## Local Setup
+
+### System Setup
+This assumes you're running Ubuntu 20.04 (either natively, or via Windows Subsystem for Linux).
+Native Windows is not currently supported.
+Users of other Linux distributions will need to install the appropriate packages for their distribution.
+
+This version of the randomizer requires version 7.4 of PHP.
+
+```
+sudo apt-get install php7.4 php7.4-bcmath php7.4-dom php7.4-mbstring php7.4-curl -y
+```
+
+### Installing PHP dependencies
 You will need [Composer](https://getcomposer.org/) for the Laravel Dependency. Once you have that, run the following
 
 ```
 $ composer install
 ```
-
-## Running from the command line
-To generate a game one simply runs the command:
-
-```
-$ php artisan alttp:randomize {input_file.sfc} {output_directory}
-```
-
-For help (and all the options):
-
-```
-$ php artisan alttp:randomize -h
-```
-
-## Running the Web Interface
 
 ### Database setup
 Create a new mysql database for the randomizer (see mysql documentation for how to do this, you'll need to install mysql server if it's not installed already)
@@ -59,6 +57,29 @@ Now run the db migration command:
 ```
 $ php artisan migrate
 ```
+
+### Generate a base patch
+
+In you .env file, update `ENEMIZER_BASE=` to the **absolute path** of an unheadered Japanese 1.0 ROM of A Link to the Past.
+
+```
+php artisan alttp:updatebuildrecord
+```
+
+## Running from the command line
+To generate a game one simply runs the command:
+
+```
+$ php artisan alttp:randomize {input_file.sfc} {output_directory}
+```
+
+For help (and all the options):
+
+```
+$ php artisan alttp:randomize -h
+```
+
+## Running the Web Interface
 
 ### Web server setup
 You will need to build assets the first time (you will need [NPM](https://www.npmjs.com/get-npm) to install the javascript dependencies).

--- a/readme.md
+++ b/readme.md
@@ -25,13 +25,15 @@ You will need [Composer](https://getcomposer.org/) for the Laravel Dependency. O
 $ composer install
 ```
 
-### Database setup
-Create a new mysql database for the randomizer (see mysql documentation for how to do this, you'll need to install mysql server if it's not installed already)
+## Database setup
 
 Run the following command to create a new config for the app
 ```
 $ cp .env.example .env
 ```
+
+### MySQL
+Create a new mysql database for the randomizer (see mysql documentation for how to do this, you'll need to install mysql server if it's not installed already)
 
 Then modify .env with appropriate username, password, and database name. Change the db connection to mysql
 Example:
@@ -44,8 +46,17 @@ DB_USERNAME=foo
 DB_PASSWORD=bar
 ```
 
+### SQLite
+SQLite can also be used too, this might be a better option for a quick setup.
+
+```
+DB_CONNECTION=sqlite
+DB_DATABASE=/absolute/path/to/existing/folder/db.sqlite
+```
+
 Then run the following commands to setup the app configuration
 
+### Last steps on DB setup
 ```
 $ php artisan key:generate
 $ php artisan config:cache
@@ -58,13 +69,14 @@ Now run the db migration command:
 $ php artisan migrate
 ```
 
-### Generate a base patch
+## Generate a base patch
 
 In you .env file, update `ENEMIZER_BASE=` to the **absolute path** of an unheadered Japanese 1.0 ROM of A Link to the Past.
 
 Then, in the command line run this to create the base patch.
 
 ```
+php artisan config:cache
 php artisan alttp:updatebuildrecord
 ```
 

--- a/resources/js/components/Customizer/Glitches.vue
+++ b/resources/js/components/Customizer/Glitches.vue
@@ -67,7 +67,7 @@ export default {
           name: "randomizer.glitches_required.options.major_glitches"
         },
         {
-          value: "None",
+          value: "NoLogic",
           name: "randomizer.glitches_required.options.no_logic"
         }
       ]

--- a/resources/js/components/VTRomSettings.vue
+++ b/resources/js/components/VTRomSettings.vue
@@ -75,6 +75,22 @@
         >{{ $t('rom.settings.palette_shuffle') }}</Toggle>
       </div>
     </div>
+    <div v-if="rom.build >= '2021-05-04'" class="row mb-3">
+      <div class="col-md-12">
+        <Toggle
+          :value="reduceFlashing"
+          @input="setReduceFlashing"
+        >{{ $t('rom.settings.reduce_flashing') }}
+        <sup
+          v-if="reduceFlashing"
+        >*</sup></Toggle>
+      </div>
+      <div
+        v-if="reduceFlashing"
+        class="logic-warning text-info"
+        v-html="'* ' + $t('rom.settings.reduce_flashing_warning')"
+      />
+    </div>
   </div>
 </template>
 
@@ -173,7 +189,8 @@ export default {
       "setHeartColor",
       "setQuickswap",
       "setMusicOn",
-      "setPaletteShuffle"
+      "setPaletteShuffle",
+      "setReduceFlashing"
     ])
   },
   computed: {
@@ -186,7 +203,8 @@ export default {
       heartColor: state => state.heartColor,
       quickswap: state => state.quickswap,
       musicOn: state => state.musicOn,
-      paletteShuffle: state => state.paletteShuffle
+      paletteShuffle: state => state.paletteShuffle,
+      reduceFlashing: state => state.reduceFlashing
     })
   }
 };

--- a/resources/js/components/VTSpriteSelect.vue
+++ b/resources/js/components/VTSpriteSelect.vue
@@ -96,7 +96,7 @@ export default {
       }
       vm.$emit('load-custom-sprite', false);
 
-      while (pickedSprite.file === null) {
+      while (pickedSprite.name === "Random") {
         pickedSprite =
           vm.sprites[Math.floor(Math.random() * vm.sprites.length)];
       }
@@ -108,30 +108,32 @@ export default {
             resolve(spr);
             return;
           }
-          axios
-            .get(pickedSprite.file, {
-              transformRequest: [
-                (data, headers) => {
-                  delete headers.common;
-                  return data;
-                }
-              ],
-              responseType: "arraybuffer"
-            })
-            .then(response => {
-              var spr_array = new Uint8Array(response.data);
-              localforage
-                .setItem("vt_sprites." + sprite_name, spr_array)
-                .then(function(spr) {
-                  resolve(spr);
-                })
-                .catch(function() {
-                  reject("could not save sprite to local storage");
-                });
-            })
-            .catch(function() {
-              reject("cannot find sprite file");
-            });
+          if (pickedSprite.name !== "Link") {
+            axios
+              .get(pickedSprite.file, {
+                transformRequest: [
+                  (data, headers) => {
+                    delete headers.common;
+                    return data;
+                  }
+                ],
+                responseType: "arraybuffer"
+              })
+              .then(response => {
+                var spr_array = new Uint8Array(response.data);
+                localforage
+                  .setItem("vt_sprites." + sprite_name, spr_array)
+                  .then(function(spr) {
+                    resolve(spr);
+                  })
+                  .catch(function() {
+                    reject("could not save sprite to local storage");
+                  });
+              })
+              .catch(function() {
+                reject("cannot find sprite file");
+              });
+          }
         });
       }).then(rom.parseSprGfx.bind(rom));
     }

--- a/resources/js/rom.js
+++ b/resources/js/rom.js
@@ -175,155 +175,89 @@ export default class ROM {
       const palette_offset =
         (zspr[18] << 24) | (zspr[17] << 16) | (zspr[16] << 8) | zspr[15];
 
-      // Metadata
-      // Array raw_metadata = zspr.slice(0x1D, gfx_offset);
-      var metadata_index = 0x1D
+      // ZSPR Metadata
+      var metadata_index = 0x1D;
 
-      var sprite_name = ""
-      var sprite_author = ""
-      var sprite_author_short = ""
+      var sprite_author_short = "";
 
-      while (metadata_index < gfx_offset) {
-        var raw_chars = zspr.slice(metadata_index, metadata_index + 2)
-        var char_val = (raw_chars[1] << 8 | raw_chars[0])
-        if (char_val == 0x00) {
-          metadata_index = metadata_index + 2;
-          break;
+      // skip past unicode title and author
+      let junk = 2;
+      while (metadata_index < gfx_offset && junk > 0) {
+        if (zspr[metadata_index + 1] === 0 && zspr[metadata_index] === 0) {
+          junk--;
         }
-        sprite_name += String.fromCharCode(char_val);
         metadata_index = metadata_index + 2;
       }
 
-      while (metadata_index < gfx_offset) {
-        var raw_chars = zspr.slice(metadata_index, metadata_index + 2)
-        var char_val = (raw_chars[1] << 8 | raw_chars[0])
-        if (char_val == 0x00) {
-          metadata_index = metadata_index + 2;
-          break;
-        }
-        sprite_author += String.fromCharCode(char_val);
-        metadata_index = metadata_index + 2;
+      while (metadata_index < gfx_offset && zspr[metadata_index] !== 0x00) {
+        sprite_author_short += String.fromCharCode(zspr[metadata_index]);
+        metadata_index++;
       }
 
-      while (metadata_index < gfx_offset) {
-        var raw_chars = zspr.slice(metadata_index, metadata_index + 1)
-        var char_val = raw_chars[0]
-        if (char_val == 0x00) {
-          metadata_index = metadata_index + 1;
-          break;
-        }
-        sprite_author_short += String.fromCharCode(char_val);
-        metadata_index = metadata_index + 1;
+      var formatted_sprite_author = center(sprite_author_short.substring(0, 28), 28).toUpperCase();
+      if (formatted_sprite_author.length == 27) {
+        formatted_sprite_author = " " + formatted_sprite_author;
       }
 
-      const formatted_sprite_author = center(sprite_author_short.substring(0, 28), 28).toUpperCase();
-
-      const sprite_author_hi = formatted_sprite_author.split("").map(item => {
-        switch(item) {
-          case " ": return 0x9F
-          case "0": return 0x53
-          case "1": return 0x54
-          case "2": return 0x55
-          case "3": return 0x56
-          case "4": return 0x57
-          case "5": return 0x58
-          case "6": return 0x59
-          case "7": return 0x5A
-          case "8": return 0x5B
-          case "9": return 0x5C
-          case "A": return 0x5D
-          case "B": return 0x5E
-          case "C": return 0x5F
-          case "D": return 0x60
-          case "E": return 0x61
-          case "F": return 0x62
-          case "G": return 0x63
-          case "H": return 0x64
-          case "I": return 0x65
-          case "J": return 0x66
-          case "K": return 0x67
-          case "L": return 0x68
-          case "M": return 0x69
-          case "N": return 0x6A
-          case "O": return 0x6B
-          case "P": return 0x6C
-          case "Q": return 0x6D
-          case "R": return 0x6E
-          case "S": return 0x6F
-          case "T": return 0x70
-          case "U": return 0x71
-          case "V": return 0x72
-          case "W": return 0x73
-          case "X": return 0x74
-          case "Y": return 0x75
-          case "Z": return 0x76
-          case "'": return 0x77
-          case ".": return 0xA0
-          case "/": return 0xA2
-          case ":": return 0xA3
-          case "_": return 0xA6
-          default: return 0x9F
-        }
-      })
-
-      const sprite_author_lo = formatted_sprite_author.split("").map(item => {
-        switch(item) {
-          case " ": return 0x9F
-          case "0": return 0x79
-          case "1": return 0x7A
-          case "2": return 0x7B
-          case "3": return 0x7C
-          case "4": return 0x7D
-          case "5": return 0x7E
-          case "6": return 0x7F
-          case "7": return 0x80
-          case "8": return 0x81
-          case "9": return 0x82
-          case "A": return 0x83
-          case "B": return 0x84
-          case "C": return 0x85
-          case "D": return 0x86
-          case "E": return 0x87
-          case "F": return 0x88
-          case "G": return 0x89
-          case "H": return 0x8A
-          case "I": return 0x8B
-          case "J": return 0x8C
-          case "K": return 0x8D
-          case "L": return 0x8E
-          case "M": return 0x8F
-          case "N": return 0x90
-          case "O": return 0x91
-          case "P": return 0x92
-          case "Q": return 0x93
-          case "R": return 0x94
-          case "S": return 0x95
-          case "T": return 0x96
-          case "U": return 0x97
-          case "V": return 0x98
-          case "W": return 0x99
-          case "X": return 0x9A
-          case "Y": return 0x9B
-          case "Z": return 0x9C
-          case "'": return 0x9d
-          case ".": return 0xC0
-          case "/": return 0xC2
-          case ":": return 0xC3
-          case "_": return 0xC6
-          default: return 0x9F
-        }
-      })
+      const sprite_author = formatted_sprite_author.split("").map(item => {
+          switch (item) {
+              case " ": return [0x9F, 0x9F];
+              case "0": return [0x53, 0x79];
+              case "1": return [0x54, 0x7A];
+              case "2": return [0x55, 0x7B];
+              case "3": return [0x56, 0x7C];
+              case "4": return [0x57, 0x7D];
+              case "5": return [0x58, 0x7E];
+              case "6": return [0x59, 0x7F];
+              case "7": return [0x5A, 0x80];
+              case "8": return [0x5B, 0x81];
+              case "9": return [0x5C, 0x82];
+              case "A": return [0x5D, 0x83];
+              case "B": return [0x5E, 0x84];
+              case "C": return [0x5F, 0x85];
+              case "D": return [0x60, 0x86];
+              case "E": return [0x61, 0x87];
+              case "F": return [0x62, 0x88];
+              case "G": return [0x63, 0x89];
+              case "H": return [0x64, 0x8A];
+              case "I": return [0x65, 0x8B];
+              case "J": return [0x66, 0x8C];
+              case "K": return [0x67, 0x8D];
+              case "L": return [0x68, 0x8E];
+              case "M": return [0x69, 0x8F];
+              case "N": return [0x6A, 0x90];
+              case "O": return [0x6B, 0x91];
+              case "P": return [0x6C, 0x92];
+              case "Q": return [0x6D, 0x93];
+              case "R": return [0x6E, 0x94];
+              case "S": return [0x6F, 0x95];
+              case "T": return [0x70, 0x96];
+              case "U": return [0x71, 0x97];
+              case "V": return [0x72, 0x98];
+              case "W": return [0x73, 0x99];
+              case "X": return [0x74, 0x9A];
+              case "Y": return [0x75, 0x9B];
+              case "Z": return [0x76, 0x9C];
+              case "'": return [0x77, 0x9d];
+              case ".": return [0xA0, 0xC0];
+              case "/": return [0xA2, 0xC2];
+              case ":": return [0xA3, 0xC3];
+              case "_": return [0xA6, 0xC6];
+              default: return [0x9F, 0x9F];
+          }
+      });
 
       // Do not write sprite author to older rom builds, or the game will crash.
-      if (this.build >= "2021-05-04") {
-        // Top part of sprite author
+      // This checks for the line header bytes are what we expect, so we're not
+      // inavertently writing over executable code that was relocated from it's
+      // vanilla location.
+      if (this.u_array[0x118000] === 0x02
+          && this.u_array[0x118001] === 0x37
+          && this.u_array[0x11801E] === 0x02
+          && this.u_array[0x11801F] === 0x37) {
         for (let i = 0; i < 28; i++) {
-          this.u_array[0x118002 + i] = sprite_author_hi[i];
-        }
-
-        // Bottom part of sprite author
-        for (let i = 0; i < 28; i++) {
-          this.u_array[0x118020 + i] = sprite_author_lo[i];
+          this.u_array[0x118002 + i] = sprite_author[i][0];
+          this.u_array[0x118020 + i] = sprite_author[i][1];
         }
       }
 
@@ -481,7 +415,7 @@ export default class ROM {
 
   setReduceFlashing(enable) {
     return new Promise(resolve => {
-      if (this.build > "2021-05-03") {
+      if (this.build >= "2021-05-04") {
         this.write(0x18017f, enable ? 0x01 : 0x00);
       }
 

--- a/resources/js/rom.js
+++ b/resources/js/rom.js
@@ -4,6 +4,7 @@ import Prando from "prando";
 import BPS from "./bps";
 import * as Z3PR from "@maseya/z3pr";
 import localforage from "localforage";
+import center from "center-align";
 
 export default class ROM {
   constructor(blob, loadedCallback) {
@@ -173,6 +174,158 @@ export default class ROM {
         (zspr[12] << 24) | (zspr[11] << 16) | (zspr[10] << 8) | zspr[9];
       const palette_offset =
         (zspr[18] << 24) | (zspr[17] << 16) | (zspr[16] << 8) | zspr[15];
+
+      // Metadata
+      // Array raw_metadata = zspr.slice(0x1D, gfx_offset);
+      var metadata_index = 0x1D
+
+      var sprite_name = ""
+      var sprite_author = ""
+      var sprite_author_short = ""
+
+      while (metadata_index < gfx_offset) {
+        var raw_chars = zspr.slice(metadata_index, metadata_index + 2)
+        var char_val = (raw_chars[1] << 8 | raw_chars[0])
+        if (char_val == 0x00) {
+          metadata_index = metadata_index + 2;
+          break;
+        }
+        sprite_name += String.fromCharCode(char_val);
+        metadata_index = metadata_index + 2;
+      }
+
+      while (metadata_index < gfx_offset) {
+        var raw_chars = zspr.slice(metadata_index, metadata_index + 2)
+        var char_val = (raw_chars[1] << 8 | raw_chars[0])
+        if (char_val == 0x00) {
+          metadata_index = metadata_index + 2;
+          break;
+        }
+        sprite_author += String.fromCharCode(char_val);
+        metadata_index = metadata_index + 2;
+      }
+
+      while (metadata_index < gfx_offset) {
+        var raw_chars = zspr.slice(metadata_index, metadata_index + 1)
+        var char_val = raw_chars[0]
+        if (char_val == 0x00) {
+          metadata_index = metadata_index + 1;
+          break;
+        }
+        sprite_author_short += String.fromCharCode(char_val);
+        metadata_index = metadata_index + 1;
+      }
+
+      const formatted_sprite_author = center(sprite_author_short.substring(0, 28), 28).toUpperCase();
+
+      const sprite_author_hi = formatted_sprite_author.split("").map(item => {
+        switch(item) {
+          case " ": return 0x9F
+          case "0": return 0x53
+          case "1": return 0x54
+          case "2": return 0x55
+          case "3": return 0x56
+          case "4": return 0x57
+          case "5": return 0x58
+          case "6": return 0x59
+          case "7": return 0x5A
+          case "8": return 0x5B
+          case "9": return 0x5C
+          case "A": return 0x5D
+          case "B": return 0x5E
+          case "C": return 0x5F
+          case "D": return 0x60
+          case "E": return 0x61
+          case "F": return 0x62
+          case "G": return 0x63
+          case "H": return 0x64
+          case "I": return 0x65
+          case "J": return 0x66
+          case "K": return 0x67
+          case "L": return 0x68
+          case "M": return 0x69
+          case "N": return 0x6A
+          case "O": return 0x6B
+          case "P": return 0x6C
+          case "Q": return 0x6D
+          case "R": return 0x6E
+          case "S": return 0x6F
+          case "T": return 0x70
+          case "U": return 0x71
+          case "V": return 0x72
+          case "W": return 0x73
+          case "X": return 0x74
+          case "Y": return 0x75
+          case "Z": return 0x76
+          case "'": return 0x77
+          case ".": return 0xA0
+          case "/": return 0xA2
+          case ":": return 0xA3
+          case "_": return 0xA6
+          default: return 0x9F
+        }
+      })
+
+      const sprite_author_lo = formatted_sprite_author.split("").map(item => {
+        switch(item) {
+          case " ": return 0x9F
+          case "0": return 0x79
+          case "1": return 0x7A
+          case "2": return 0x7B
+          case "3": return 0x7C
+          case "4": return 0x7D
+          case "5": return 0x7E
+          case "6": return 0x7F
+          case "7": return 0x80
+          case "8": return 0x81
+          case "9": return 0x82
+          case "A": return 0x83
+          case "B": return 0x84
+          case "C": return 0x85
+          case "D": return 0x86
+          case "E": return 0x87
+          case "F": return 0x88
+          case "G": return 0x89
+          case "H": return 0x8A
+          case "I": return 0x8B
+          case "J": return 0x8C
+          case "K": return 0x8D
+          case "L": return 0x8E
+          case "M": return 0x8F
+          case "N": return 0x90
+          case "O": return 0x91
+          case "P": return 0x92
+          case "Q": return 0x93
+          case "R": return 0x94
+          case "S": return 0x95
+          case "T": return 0x96
+          case "U": return 0x97
+          case "V": return 0x98
+          case "W": return 0x99
+          case "X": return 0x9A
+          case "Y": return 0x9B
+          case "Z": return 0x9C
+          case "'": return 0x9d
+          case ".": return 0xC0
+          case "/": return 0xC2
+          case ":": return 0xC3
+          case "_": return 0xC6
+          default: return 0x9F
+        }
+      })
+
+      // Do not write sprite author to older rom builds, or the game will crash.
+      if (this.build >= "2021-05-04") {
+        // Top part of sprite author
+        for (let i = 0; i < 28; i++) {
+          this.u_array[0x118002 + i] = sprite_author_hi[i];
+        }
+
+        // Bottom part of sprite author
+        for (let i = 0; i < 28; i++) {
+          this.u_array[0x118020 + i] = sprite_author_lo[i];
+        }
+      }
 
       // GFX
       for (let i = 0; i < 0x7000; i++) {

--- a/resources/js/rom.js
+++ b/resources/js/rom.js
@@ -196,7 +196,7 @@ export default class ROM {
 
       var formatted_sprite_author = center(sprite_author_short.substring(0, 28), 28).toUpperCase();
       if (formatted_sprite_author.length == 27) {
-        formatted_sprite_author = " " + formatted_sprite_author;
+        formatted_sprite_author = formatted_sprite_author + " ";
       }
 
       const sprite_author = formatted_sprite_author.split("").map(item => {

--- a/resources/js/rom.js
+++ b/resources/js/rom.js
@@ -249,7 +249,7 @@ export default class ROM {
 
       // Do not write sprite author to older rom builds, or the game will crash.
       // This checks for the line header bytes are what we expect, so we're not
-      // inavertently writing over executable code that was relocated from it's
+      // inadvertently writing over executable code that was relocated from it's
       // vanilla location.
       if (this.u_array[0x118000] === 0x02
           && this.u_array[0x118001] === 0x37

--- a/resources/js/rom.js
+++ b/resources/js/rom.js
@@ -115,7 +115,7 @@ export default class ROM {
     });
   }
 
-  save(filename, { paletteShuffle, quickswap, musicOn }) {
+  save(filename, { paletteShuffle, quickswap, musicOn, reduceFlashing }) {
     let preProcess = this.arrayBuffer.slice(0);
 
     if (paletteShuffle) {
@@ -127,6 +127,8 @@ export default class ROM {
       this.setQuickswap(false);
     }
     this.setMusicVolume(musicOn);
+
+    this.setReduceFlashing(reduceFlashing);
 
     this.updateChecksum().then(() => {
       FileSaver.saveAs(new Blob([this.u_array], {type: 'application/octet-stream'}), filename);
@@ -322,6 +324,16 @@ export default class ROM {
       seed: this.rand.nextInt(0, 4294967295)
     });
     this.rand.reset()
+  }
+
+  setReduceFlashing(enable) {
+    return new Promise(resolve => {
+      if (this.build > "2021-05-03") {
+        this.write(0x18017f, enable ? 0x01 : 0x00);
+      }
+
+      resolve(this);
+    });
   }
 
   parsePatch(data, progressCallback) {

--- a/resources/js/store/modules/defaults.js
+++ b/resources/js/store/modules/defaults.js
@@ -73,7 +73,7 @@ export default {
     name: "randomizer.enemy_health.options.default"
   },
   spoiler: {
-    value: "off",
-    name: "randomizer.spoiler.options.off"
+    value: "on",
+    name: "randomizer.spoiler.options.on"
   }
 };

--- a/resources/js/store/modules/randomizer.js
+++ b/resources/js/store/modules/randomizer.js
@@ -216,6 +216,9 @@ export default {
         if (["full", "standard"].indexOf(state.dungeon_items.value) === -1) {
           commit("setDungeonItems", "standard");
         }
+        if (state.item_pool.value === "crowd_control") {
+          commit("setItemPool", "expert");
+        }
       }
     },
     setItemPool({ commit, state }, value) {
@@ -226,6 +229,12 @@ export default {
         state.item_placement.value !== "advanced"
       ) {
         commit("setItemPlacement", "advanced");
+      }
+      if (
+        state.item_pool.value === "crowd_control" &&
+        state.entrance_shuffle.value !== "none"
+      ) {
+        commit("setEntranceShuffle", "none");
       }
     }
   },

--- a/resources/js/store/modules/romSettings.js
+++ b/resources/js/store/modules/romSettings.js
@@ -17,6 +17,7 @@ export default {
     quickswap: false,
     musicOn: true,
     paletteShuffle: false,
+    reduceFlashing: false,
     options: {
       heartSpeed: [
         { value: "off", name: "rom.settings.heart_speeds.off" },
@@ -49,7 +50,8 @@ export default {
         dispatch("load", ["heart_colors", "setHeartColor"]),
         dispatch("load", ["quickswap", "setQuickswap"]),
         dispatch("load", ["music_on", "setMusicOn"]),
-        dispatch("load", ["palette_shuffle", "setPaletteShuffle"])
+        dispatch("load", ["palette_shuffle", "setPaletteShuffle"]),
+        dispatch("load", ["reduce_flashing", "setReduceFlashing"]),
       ]).then(() => {
         commit("setInitalizing", false);
       });
@@ -88,6 +90,10 @@ export default {
     setPaletteShuffle(state, paletteShuffle) {
       state.paletteShuffle = paletteShuffle;
       localforage.setItem("rom.palette_shuffle", paletteShuffle);
+    },
+    setReduceFlashing(state, reduceFlashing) {
+      state.reduceFlashing = reduceFlashing;
+      localforage.setItem("rom.reduce_flashing", reduceFlashing);
     },
     setInitalizing(state, init) {
       state.initializing = init;

--- a/resources/js/views/Customizer.vue
+++ b/resources/js/views/Customizer.vue
@@ -606,7 +606,8 @@ export default {
       return this.rom.save(this.rom.downloadFilename() + ".sfc", {
         quickswap: this.quickswap,
         paletteShuffle: this.paletteShuffle,
-        musicOn: this.musicOn
+        musicOn: this.musicOn,
+        reduceFlashing: this.reduceFlashing
       });
     },
     saveSpoiler() {
@@ -770,7 +771,8 @@ export default {
       heartColor: state => state.heartColor,
       quickswap: state => state.quickswap,
       musicOn: state => state.musicOn,
-      paletteShuffle: state => state.paletteShuffle
+      paletteShuffle: state => state.paletteShuffle,
+      reduceFlashing: state => state.reduceFlashing
     }),
     flatItemPool() {
       return this.$store.getters["itemLocations/flatItemPool"];

--- a/resources/js/views/HashLoader.vue
+++ b/resources/js/views/HashLoader.vue
@@ -194,7 +194,8 @@ export default {
       return this.rom.save(this.rom.downloadFilename() + ".sfc", {
         quickswap: this.quickswap,
         paletteShuffle: this.paletteShuffle,
-        musicOn: this.musicOn
+        musicOn: this.musicOn,
+        reduceFlashing: this.reduceFlashing
       });
     },
     saveSpoiler() {
@@ -223,7 +224,8 @@ export default {
       heartColor: state => state.heartColor,
       quickswap: state => state.quickswap,
       musicOn: state => state.musicOn,
-      paletteShuffle: state => state.paletteShuffle
+      paletteShuffle: state => state.paletteShuffle,
+      reduceFlashing: state => state.reduceFlashing
     })
   }
 };

--- a/resources/js/views/Randomizer.vue
+++ b/resources/js/views/Randomizer.vue
@@ -537,7 +537,8 @@ export default {
       return this.rom.save(this.rom.downloadFilename() + ".sfc", {
         quickswap: this.quickswap,
         paletteShuffle: this.paletteShuffle,
-        musicOn: this.musicOn
+        musicOn: this.musicOn,
+        reduceFlashing: this.reduceFlashing
       });
     },
     saveSpoiler() {
@@ -605,7 +606,8 @@ export default {
       heartColor: state => state.heartColor,
       quickswap: state => state.quickswap,
       musicOn: state => state.musicOn,
-      paletteShuffle: state => state.paletteShuffle
+      paletteShuffle: state => state.paletteShuffle,
+      reduceFlashing: state => state.reduceFlashing
     }),
     editable() {
       return this.$store.state.randomizer.preset.value === "custom";

--- a/resources/js/views/Sprites.vue
+++ b/resources/js/views/Sprites.vue
@@ -11,7 +11,7 @@
         class="sprite"
         v-show="searchEx.test(sprite.name) || searchEx.test(sprite.author)"
       >
-        <div :class="'sprite-preview icon-custom-' + sprite.name.replace(/[ \.\(\)\']/g, '')"></div>
+        <div :class="'sprite-preview icon-custom-' + sprite.name.replace(/[ \.\(\)\'\/]/g, '')"></div>
         <div class="sprite-name">{{ sprite.name }}</div>
         <div class="sprite-author">by: {{ sprite.author }}</div>
       </div>

--- a/resources/js/vue-i18n-locales.generated.js
+++ b/resources/js/vue-i18n-locales.generated.js
@@ -2465,7 +2465,7 @@ export default {
                 }
             },
             "entrance_shuffle": {
-                "title": "Mélangeur d'Entrées",
+                "title": "Mélangeur d’Entrées",
                 "options": {
                     "none": "Désactivé",
                     "simple": "Simple",
@@ -2485,7 +2485,7 @@ export default {
                 }
             },
             "enemy_shuffle": {
-                "title": "Mélangeur d'Ennemis",
+                "title": "Mélangeur d’Ennemis",
                 "options": {
                     "none": "Désactivé",
                     "shuffled": "Intervertis",
@@ -2517,7 +2517,7 @@ export default {
                     "expert": "Expert",
                     "crowd_control": "Crowd Control"
                 },
-                "crowd_control_warning": "<sup>*</sup> Ce paramètre est prévu pour être utilisé avec l'extension Twitch Crowd Control. En savoir plus: <a href=\"https://crowdcontrol.live/\" target=\"_blank\" rel=”noopener noreferrer”>https://crowdcontrol.live/</a>"
+                "crowd_control_warning": "<sup>*</sup> Ce paramètre est prévu pour être utilisé avec l’extension Twitch Crowd Control. En savoir plus: <a href=\"https://crowdcontrol.live/\" target=\"_blank\" rel=”noopener noreferrer”>https://crowdcontrol.live/</a>"
             },
             "item_functionality": {
                 "title": "Fonctionnalité des Objets",
@@ -2613,11 +2613,11 @@ export default {
                 },
                 "canBunnySurf": {
                     "title": "Lapin Surfeur",
-                    "description": "Il peut être requis de marcher sur l'eau en tant que Lapin."
+                    "description": "Il peut être requis de marcher sur l’eau en tant que Lapin."
                 },
                 "canDungeonRevive": {
                     "title": "Résurrection en Donjon",
-                    "description": "Il peut être requis d'entrer dans un donjon en Lapin, et de mourir, afin de redevenir Link pour collecter des objets."
+                    "description": "Il peut être requis d’entrer dans un donjon en Lapin, et de mourir, afin de redevenir Link pour collecter des objets."
                 },
                 "canFakeFlipper": {
                     "title": "Fausses Palmes",
@@ -2625,11 +2625,11 @@ export default {
                 },
                 "canMirrorClip": {
                     "title": "Clip au Miroir",
-                    "description": "Il peut être requis d'utiliser des rebonds avec le Miroir pour se transporter hors des limites du jeu."
+                    "description": "Il peut être requis d’utiliser des rebonds avec le Miroir pour se transporter hors des limites du jeu."
                 },
                 "canMirrorWrap": {
                     "title": "Wrap au Miroir",
-                    "description": "Il peut être requis d\\utiliser le Miroir afin de défiler l'écran à un endroit normalement inaccessible."
+                    "description": "Il peut être requis d\\utiliser le Miroir afin de défiler l’écran à un endroit normalement inaccessible."
                 },
                 "canOneFrameClipOW": {
                     "title": "Clip d\\Une Image (Monde extérieur)",
@@ -2641,27 +2641,27 @@ export default {
                 },
                 "canOWYBA": {
                     "title": "YBA (Monde extérieur)",
-                    "description": "Il peut être requis d'utiliser des Bocaux dans le monde extérieur afin de se rendre à un endroit normalement inaccessible."
+                    "description": "Il peut être requis d’utiliser des Bocaux dans le monde extérieur afin de se rendre à un endroit normalement inaccessible."
                 },
                 "canSuperBunny": {
                     "title": "Super Lapin",
-                    "description": "Il peut être requis d'activer la technique du Super Lapin pour accéder à certains endroits et objets."
+                    "description": "Il peut être requis d’activer la technique du Super Lapin pour accéder à certains endroits et objets."
                 },
                 "canSuperSpeed": {
                     "title": "Super Vitesse",
-                    "description": "Il peut être requis d'utiliser la Super Vitesse afin de passer à travers une barrière dans le monde extérieur."
+                    "description": "Il peut être requis d’utiliser la Super Vitesse afin de passer à travers une barrière dans le monde extérieur."
                 },
                 "canWaterFairyRevive": {
-                    "title": "Résurrection par une Fée dans l'Eau",
-                    "description": "Cette technique est ridicule et requiert un grand nombre d'objets."
+                    "title": "Résurrection par une Fée dans l’Eau",
+                    "description": "Cette technique est ridicule et requiert un grand nombre d’objets."
                 },
                 "canWaterWalk": {
-                    "title": "Marche sur l'Eau",
-                    "description": "Il peut être requis d'utiliser les Bottes pour marcher sur l\\eau."
+                    "title": "Marche sur l’Eau",
+                    "description": "Il peut être requis d’utiliser les Bottes pour marcher sur l\\eau."
                 },
                 "noLogic": {
                     "title": "Désactiver la Logique",
-                    "description": "Quand ceci est activé, les dés en sont jetés, et rien d'autre n'importe.."
+                    "description": "Quand ceci est activé, les dés en sont jetés, et rien d’autre n’importe.."
                 }
             }
         },
@@ -2896,7 +2896,7 @@ export default {
                 "build": "Création de ROM",
                 "difficulty": "Difficulté",
                 "variation": "Variation",
-                "shuffle": "Mélangeur d'Entrées",
+                "shuffle": "Mélangeur d’Entrées",
                 "mode": "État du Monde",
                 "weapons": "Épées",
                 "goal": "Objectif",

--- a/resources/js/vue-i18n-locales.generated.js
+++ b/resources/js/vue-i18n-locales.generated.js
@@ -572,7 +572,9 @@ export default {
                 "music_info": "(setze zu \"Keine\" für <a href=\"https://alttprlinks.page.link/SjiP\" target=\"_blank\" rel=\"noopener noreferrer\">MSU-1 Support</a>)",
                 "quickswap": "Gegenstand Schnellwechsel",
                 "palette_shuffle": "Palette Shuffle",
-                "race_warning": "Funktioniert nicht in einer Rom für Rennen"
+                "race_warning": "Funktioniert nicht in einer Rom für Rennen",
+                "reduce_flashing": "Blitzeffekte reduzieren",
+                "reduce_flashing_warning": "Diese Option reduziert die Intensität von Blitzeffekten. Individuelle Lichtempfindlichkeitsreaktionen sind nicht ganz ausgeschlossen."
             }
         },
         "entrance": {
@@ -1297,7 +1299,7 @@ export default {
                 "palette_shuffle": "Palette Shuffle",
                 "race_warning": "Does not work in Race Roms",
                 "reduce_flashing": "Reduce Flashing",
-                "reduce_flashing_warning": "This option only reduces the effects of flashing, individual photosensitivity to effects may still vary."
+                "reduce_flashing_warning": "This option only reduces the effects of flashing. Individual photosensitivity to effects may still vary."
             }
         },
         "entrance": {
@@ -2236,7 +2238,9 @@ export default {
                 "music_info": "(poner en \"No\" para <a href=\"https://alttprlinks.page.link/SjiP\" target=\"_blank\" rel=\"noopener noreferrer\">soporte con MSU-1</a>)",
                 "quickswap": "Cambio Rápido de Objetos",
                 "palette_shuffle": "Paletas aleatorias",
-                "race_warning": "No funciona en ROMs para carreras"
+                "race_warning": "No funciona en ROMs para carreras",
+                "reduce_flashing": "Reducir Parpadeos intermitentes",
+                "reduce_flashing_warning": "Esta opcion solo reduce el efecto del parpadeo, tu sensibilidad a estos efectos aun puede variar."
             }
         },
         "entrance": {
@@ -2930,7 +2934,9 @@ export default {
                 "music_info": "(définie sur \"Non\" pour <a href=\"https://alttprlinks.page.link/SjiP\" target=\"_blank\" rel=\"noopener noreferrer\">le support MSU-1</a>)",
                 "quickswap": "Changement rapide d’objets",
                 "palette_shuffle": "Mélange des Couleurs de Palettes",
-                "race_warning": "Ne fonctionne pas dans les ROMs de course"
+                "race_warning": "Ne fonctionne pas dans les ROMs de course",
+                "reduce_flashing": "Réduit le clignotement",
+                "reduce_flashing_warning": "Cette option réduit l'effet de clignotement. Votre sensibilité aux effets de clignotement peut varier."
             }
         },
         "entrance": {

--- a/resources/js/vue-i18n-locales.generated.js
+++ b/resources/js/vue-i18n-locales.generated.js
@@ -1295,7 +1295,9 @@ export default {
                 "music_info": "(set to \"No\" for <a href=\"https://alttprlinks.page.link/SjiP\" target=\"_blank\" rel=\"noopener noreferrer\">MSU-1 support</a>)",
                 "quickswap": "Item Quickswap",
                 "palette_shuffle": "Palette Shuffle",
-                "race_warning": "Does not work in Race Roms"
+                "race_warning": "Does not work in Race Roms",
+                "reduce_flashing": "Reduce Flashing",
+                "reduce_flashing_warning": "This option only reduces the effects of flashing, individual photosensitivity to effects may still vary."
             }
         },
         "entrance": {

--- a/resources/lang/de/options.php
+++ b/resources/lang/de/options.php
@@ -617,6 +617,12 @@ return [
                         'Die Farbpalleten werden zufällig ausgewählt im Spiel. Dadurch könnte alles sehr bizarr aussehen. Mit Vorsicht aktivieren!',
                     ],
                 ],
+                'reduce_flashing' => [
+                    'header' => __('rom.settings.reduce_flashing'),
+                    'content' => [
+                        'Die Intensität von Blitzeffekten im Spiel wird deutlich reduziert oder sie werden ganz ausgeschaltet.  Vorsicht: Deine Lichtempfindlichkeit kann möglicherweise dennoch auf manche Effekte reagieren.',
+                    ],
+                ],
             ],
         ],
         'item_pool' => 'Gegendstandspool',

--- a/resources/lang/de/options.php
+++ b/resources/lang/de/options.php
@@ -602,13 +602,13 @@ return [
                 'music' => [
                     'header' => __('rom.settings.music'),
                     'content' => [
-                        'Aktiviere oder deaktiviere die originale Hintergrundmusik. Du musst es nicht deaktivieren um  MSU-1 Packs zu nutzen. Falls es aktiviert bleibt während man einen MSU-1 Pack nutzt, dient es als SPC-Fallback und spielt nur Hintergrundmusik ab, falls ein Fehler in der MSU-1 Spur vorliegt (anstatt kompletter Stille)..',
+                        'Aktiviere oder deaktiviere die originale Hintergrundmusik.',
                     ],
                 ],
                 'quickswap' => [
                     'header' => __('rom.settings.quickswap'),
                     'content' => [
-                        'Erlaubt es den Gegendstand mit L und R zu wechseln ohne das Menü zu öffnen. Dies ist nicht für Rennen verfügbar (außer für Entrance Randomizer).',
+                        'Erlaubt es den Gegendstand mit L und R zu wechseln ohne das Menü zu öffnen.',
                     ],
                 ],
                 'palette_shuffle' => [

--- a/resources/lang/de/races.php
+++ b/resources/lang/de/races.php
@@ -1,38 +1,39 @@
 <?php
 return [
-    'header' => 'Organisierte Spiele',
+    'header' => 'Organisiertes Spielen',
     'cards' => [
         'races' => [
-            'header' => 'Rennen',
+            'header' => 'Tägliche und wöchentliche Rennen',
             'sections' => [
                 [
                     'header' => '',
                     'content' => [
-                        'Die meisten Rennen werden auf <a href="https://speedracing.tv/" target="_blank" rel="noopener noreferrer">SpeedRacing.tv</a> oder <a href="http://speedrunslive.com" target="_blank" rel="noopener noreferrer">SpeedRunsLive.com</a> ausgetragen. Gehe sicher beide Seiten anzusehen um mehr Informationen zu erhalten wie du bei der Aktion mitmachen kannst!',
+                        'Die meisten Rennen werden auf <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a> geführt. Macht euch am besten im Vorfeld mit der Seite vertraut, damit später dem Rennen nichts im Weg steht.',
+                        'Bevor ihr mit den Rennen anfangt, lest euch die <a href="http://alttp.mymm1.com/wiki/ALTTPR_Racing_Ruleset">allgemeinen Regeln für Rennen des ALTTPR Racing Councils</a> durch. Bedenkt, dass die Regeln einzelner Turniere abweichen können. Im Zweifel fragt im Vorfeld nach den geltenden Regeln.',
                     ],
                 ],
                 [
-                    'header' => 'Wöchentliches Rennen des Standard Modus, Samstags um 15:00 Uhr (3pm) EST/EDT bzw. 21:00 Uhr (9pm) CET/CEST',
+                    'header' => 'ALTTPR Ladder',
                     'content' => [
-                        'Das führende Community Event, das wöchentliche Rennen hat viele Teilnehmer!',
+                        'Die <a href="https://alttprladder.com/" target="_blank">ALTTPR Ladder</a> ist eine 1v1 Elo-Rangliste, eine "A Link To the Past Randomizer"-Liga, welche komplett über Discord läuft. In diesem System werden mehere 1v1-Rennen über den Tag organisiert und gespielt. Die Rangliste basiert auf dem System der Standard Elo 32k-Gewichtung.',
                     ],
                 ],
                 [
-                    'header' => 'Wöchentliches Rennen des Offen Modus, Sonntags um 17:00 UHR (5pm) EST/EDT bzw. 23:00 Uhr (11pm) CET/CEST',
+                    'header' => 'SpeedGaming Daily Racing Series',
                     'content' => [
-                        'Trete uns Sonntag bei für ein anderes beliebtes Community Event.',
+                        '<a href="https://speedgaming.org/" target="_blank">SpeedGaming</a> veranstaltet eine Reihe von täglichen Rennen, welche auf <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a> stattfinden. Wirf einen Blick in den <a href="http://speedgaming.org/alttprdaily/" target="_blank">Zeitplan der kommenden täglichen Rennen</a>.',
                     ],
                 ],
                 [
-                    'header' => 'Das nächtliche Community Rennen, 22:00 Uhr (10pm) EST/EDT bzw. 04:00 Uhr (2am) CET/CEST',
+                    'header' => 'Overworld Glitches Weekly',
                     'content' => [
-                        'Wir haben sogar ein nächtliches Rennen für jeden, der jeden Tag spielen möchte',
+                        'Das wöchentliche Rennen mit Overworld Glitches findet jede Woche in der Nacht von Mittwoch auf Donnerstag um 04:30 Uhr Mitteleuropäischer Zeit (MEZ)  auf <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a> statt.',
                     ],
                 ],
                 [
                     'header' => 'Spontane Rennen',
                     'content' => [
-                        'Die geplannten Rennen passen nicht in dein Zeitplan? Du suchst Rennen mit eher ungenutzen Optionen? Trete einer der ungeplannten Rennen bei! Du wirst rund um die Uhr Spieler finden die gewillt sind, ein Rennen zu machen. Trete dem #race-planning Kanal bei auf unserem <a href="https://discord.gg/alttprandomizer" target="_blank" rel="noopener noreferrer">Discord</a>!',
+                        'Die ganzen geplanten Rennen passen nicht in euren Zeitplan oder ihr sucht nach einem Rennen mit ungewöhnlichen Einstellungen? Tretet einfach einem spontanen Rennen bei! Es gibt viele motivierte Mitspieler zu allen Tageszeiten. Werft einen Blick auf den #race-planning Kanal im <a href="https://discord.gg/alttprandomizer" target="_blank">internationalen Discord</a>!',
                     ],
                 ],
             ],
@@ -40,14 +41,14 @@ return [
         'watch' => [
             'header' => 'Zuschauen',
             'content' => [
-                'Mit so vielen Sachen am laufen, wird es immer ein Rennen zum schauen geben! Folge diese Netzwerken und vermisse niemals ein Rennen!',
+                'Es ist so viel los, dass es immer was zu schauen gibt! Folge diesen Netzwerken, um kein Spiel zu verpassen!',
             ],
         ],
         'network' => [
-            'header' => 'Netzwerke für Rennen',
+            'header' => 'Racing-Netzwerke',
             'content' => [
-                'Im normalfall werden Rennen auf einem Netzwerk für Rennen ausgetragen. Diese Seiten erleichtern das organisieren von Rennen, fügen eine offiziele Zeitanzeige hinzu, und erleichtern das finden von Rennen für Teilnehmer und Zuschauer.',
-                'Besuche beide Seiten <a href="http://speedrunslive.com" target="_blank" rel="noopener noreferrer">SpeedRunsLive.com</a> und <a href="http://speedracing.tv" target="_blank" rel="noopener noreferrer">SpeedRacing.tv</a> für mehr Informationen!',
+                'Rennen werden in der Regel über sogenannte Racing-Netzwerke organisiert. Diese Seiten zeigen auch einen offiziellen Timer an und machen es für Spieler und Zuschauer leichter, Rennen zu finden.',
+                'Statte auf jeden Fall <a href="http://racetime.gg" target="_blank">RaceTime.gg</a> einen Besuch ab!',
             ],
         ],
         'tournament' => [
@@ -56,15 +57,72 @@ return [
                 [
                     'header' => '',
                     'content' => [
-                        'Trete uns bei für aufregende Turniere mit großartigen Kommentar und exzellente Spielzüge!',
+                        'Tretet einem der großen Turniere bei und erlebt spannende Rennen zusammen mit den besten Spielern und erfahrenen Kommentatoren! Turniere finden das ganze Jahr über statt, auf <a href="https://discord.gg/alttprandomizer" target="_blank">Discord</a> gibt es die neuesten Informationen.',
                     ],
                 ],
                 [
-                    'header' => 'Halbjährliches geschlossenes Turnier',
+                    'header' => 'ALTTP Randomizer Main Tournament',
                     'content' => [
-                        'Werde Zeuge wenn die besten Spieler um die Trophäe kämpfen! Du denkst du hast das Zeug mit den Besten Schritt zu halten? Trede dem <a href="https://discord.gg/alttprandomizer" target="_blank" rel="noopener noreferrer">Discord</a> bei und halte Ausschau für die Qualifikationsrennen!',
-                        'Das Spring Invitational findet statt von März bis Juni.',
-                        'Das Fall Invitational findet statt von September bis Dezember.',
+                        'Erlebt hautnah, wie die besten Spieler weltweit antreten und um den Sieg des Turniers (und somit auf eine Verewigung im Spiel selbst im Houlihan-Raum) kämpfen. Seid ihr Herausforderung gewachsen, euch mit den stärksten Gegnern zu messen? Dann tretet dem <a href="https://discord.gg/B2kGXxTD6g" target="_blank">ALTTPR Turnier-Discord</a> bei und haltet nach Qualifikationsspielen Ausschau!',
+                    ],
+                ],
+                [
+                    'header' => 'Challenge Cup',
+                    'content' => [
+                        'Der <a href="https://discord.gg/982W72p" target="_blank">Challenge Cup</a> ist ein Nebenturnier des Main Tournaments für alle, welche die Qualifikation für das Hauptturnier nicht geschafft haben.',
+                    ],
+                ],
+                [
+                    'header' => 'ALTTPR League',
+                    'content' => [
+                        'Die <a href="https://alttprleague.com/" target="_blank">ALTTPR-Liga</a> ist ein teambasiertes ALTTPR-Turnier. Spieler schließen sich zu dritt zu einem Team zusammen und messen sich mit anderen Teams in verschiedenen Spiel-Einstellungen.',
+                    ],
+                ],
+                [
+                    'header' => 'Go Mode Podcast Mentor Tournament',
+                    'content' => [
+                        '<a href="https://gomodepodcast.com/" target="_blank">Go Mode Podcast</a> veranstaltet jährlich ein Turnier für Neulinge. Dabei werden die Mitspieler von einem Mentor betreut, welcher durch die Rennen begleitet. Die perfekte Vorbereitung für weitere große oder kleine Turniere.',
+                    ],
+                ],
+                [
+                    'header' => 'ALTTPR Spoiler Tournament',
+                    'content' => [
+                        'Das <a href="https://discord.gg/Jg34MuE" target="_blank">ALTTPR Spoiler-Turnier</a> findet jährlich statt und gibt den Teilnehmern vor jedem Rennen den kompletten Spoiler Log zur Vorbereitung. Hier werden besonders Spielstärke und Entscheidungsfindung gefordert!',
+                    ],
+                ],
+                [
+                    'header' => 'ALTTPR Glitched Tournaments',
+                    'content' => [
+                        'Das <a href="https://discord.gg/adac5FG" target="_blank">ALTTPR Glitched Turnier</a> richtet sich an erfahrene Spieler, welche durch "major glitches" das Spiel auf interessante und ungewöhnliche Art und Weise beenden können.',
+                    ],
+                ],
+                [
+                    'header' => 'ALTTPR Crossworld Keysanity Tournament',
+                    'content' => [
+                        'Im <a href="https://discord.gg/umCCQgr" target="_blank">ALTTPR Crossworld Keysanity Tournament</a> erwartet euch eine Mischung der Modi "Crossworld entrance shuffle" gepaart mit "Keysanity". Mit Notizen oder guten Erinnerungen werden die Spieler stark gefordert, um in diesem Gehirnjogging zu den Besten gehören zu können.',
+                    ],
+                ],
+            ],
+        ],
+        'foreign_language' => [
+            'header' => 'Language-specific Tournaments and Events',
+            'languages' => [
+                [
+                    'header' => 'Deutsch',
+                    'description' => 'Auf dem <a href="https://discord.gg/5zuANcS" target="_blank">Discord der deutschsprachigen ALTTPR-Community</a> gibt es alles, von Anfängertipps über freundschaftliche Rennen bis hin zu Turnieren.',
+                    'sections' => [
+                        [
+                            'header' => 'Deutsche ALTTPR-Turniere',
+                            'content' => [
+                                'Es wird ca. einmal im Jahr ein großes Turnier für neue und erfahrene Spieler organisiert. Dazwischen gibt es unregelmäßig kleinere und ausgefallenere Turniere. Ankündigungen und alle Informationen gibt es auf dem <a href="https://discord.gg/5zuANcS" target="_blank">Community-Discord</a>.',
+                            ],
+                        ],
+                        [
+                            'header' => 'Deutsches ALTTPR-Weekly',
+                            'content' => [
+                                'Jede Woche findet ein größeres Rennen statt, in dem man sich gegen andere Spieler aus der Community messen kann. Neben Open werden auch andere Modi gespielt, die immer durchwechseln. Auf dem <a href="https://discord.gg/5zuANcS" target="_blank">Discord</a> gibt es alle Informationen zu den nächsten Rennen und zur Teilnahme.',
+                            ],
+                        ],
                     ],
                 ],
             ],

--- a/resources/lang/de/races.php
+++ b/resources/lang/de/races.php
@@ -38,19 +38,6 @@ return [
                 ],
             ],
         ],
-        'watch' => [
-            'header' => 'Zuschauen',
-            'content' => [
-                'Es ist so viel los, dass es immer was zu schauen gibt! Folge diesen Netzwerken, um kein Spiel zu verpassen!',
-            ],
-        ],
-        'network' => [
-            'header' => 'Racing-Netzwerke',
-            'content' => [
-                'Rennen werden in der Regel über sogenannte Racing-Netzwerke organisiert. Diese Seiten zeigen auch einen offiziellen Timer an und machen es für Spieler und Zuschauer leichter, Rennen zu finden.',
-                'Statte auf jeden Fall <a href="http://racetime.gg" target="_blank">RaceTime.gg</a> einen Besuch ab!',
-            ],
-        ],
         'tournament' => [
             'header' => 'Turniere',
             'sections' => [

--- a/resources/lang/de/races.php
+++ b/resources/lang/de/races.php
@@ -50,7 +50,7 @@ return [
                 [
                     'header' => 'ALTTP Randomizer Main Tournament',
                     'content' => [
-                        'Erlebt hautnah, wie die besten Spieler weltweit antreten und um den Sieg des Turniers (und somit auf eine Verewigung im Spiel selbst im Houlihan-Raum) kämpfen. Seid ihr Herausforderung gewachsen, euch mit den stärksten Gegnern zu messen? Dann tretet dem <a href="https://discord.gg/B2kGXxTD6g" target="_blank">ALTTPR Turnier-Discord</a> bei und haltet nach Qualifikationsspielen Ausschau!',
+                        'Erlebt hautnah, wie die besten Spieler weltweit antreten und um den Sieg des Turniers (und somit auf eine Verewigung im Spiel selbst im Houlihan-Raum) kämpfen. Seid ihr der Herausforderung gewachsen, euch mit den stärksten Gegnern zu messen? Dann tretet dem <a href="https://discord.gg/B2kGXxTD6g" target="_blank">ALTTPR Turnier-Discord</a> bei und haltet nach Qualifikationsspielen Ausschau!',
                     ],
                 ],
                 [

--- a/resources/lang/de/resources.php
+++ b/resources/lang/de/resources.php
@@ -24,7 +24,7 @@ return [
                     . '<li><a href="https://alttprlinks.page.link/3vXm" target="_blank" rel="noopener noreferrer">Glossar für hilfreiche Sachen</a></li>'
                     . '<li><a href="https://alttprlinks.page.link/HVFx" target="_blank" rel="noopener noreferrer">Glitch Ressourcen</a></li>'
                     . '<li><a href="https://alttprlinks.page.link/on1o" target="_blank" rel="noopener noreferrer">Trackers / HUDs</a></li>'
-                    . '<li><a href="http://alttp.mymm1.com/srl/" target="_blank" rel="noopener noreferrer">Wie man durchstartet auf SRL</a></li>'
+                    . '<li><a href="https://racetime.gg/about/help" target="_blank" rel="noopener noreferrer">Wie man durchstartet auf RaceTime.gg</a></li>'
                 . '</ul>',
             ],
         ],

--- a/resources/lang/de/rom.php
+++ b/resources/lang/de/rom.php
@@ -57,5 +57,7 @@ return [
         'quickswap' => 'Gegenstand Schnellwechsel',
         'palette_shuffle' => 'Palette Shuffle',
         'race_warning' => 'Funktioniert nicht in einer Rom für Rennen',
+        "reduce_flashing" => "Blitzeffekte reduzieren",
+        "reduce_flashing_warning" => "Diese Option reduziert die Intensität von Blitzeffekten. Individuelle Lichtempfindlichkeitsreaktionen sind nicht ganz ausgeschlossen."
     ],
 ];

--- a/resources/lang/en/options.php
+++ b/resources/lang/en/options.php
@@ -617,6 +617,12 @@ return [
                         'Randomizes the colour palettes within the game. This means everything can look extremely bizarre. Enable with caution!',
                     ],
                 ],
+                'reduce_flashing' => [
+                    'header' => __('rom.settings.reduce_flashing'),
+                    'content' => [
+                        'Severely reduces the intensity of in-game flashing effects, or outright disables them.  Please use caution, your photosensitivity to effects may still vary.',
+                    ],
+                ],
             ],
         ],
         'item_pool' => 'Item Pool',

--- a/resources/lang/en/options.php
+++ b/resources/lang/en/options.php
@@ -602,13 +602,13 @@ return [
                 'music' => [
                     'header' => __('rom.settings.music'),
                     'content' => [
-                        'Enable or disable the original background music. You do not have to disable this if you wish to use MSU-1 packs. If left enabled and using an MSU-1 pack then the original music will act as an SPC fallback and will only play should an MSU-1 track fail (i.e. instead of silence).',
+                        'Enable or disable the background music, including MSU-1 playback.  MSU-1 users should leave this enabled.',
                     ],
                 ],
                 'quickswap' => [
                     'header' => __('rom.settings.quickswap'),
                     'content' => [
-                        'Allow items to be changed with the L and R buttons without opening the menu. This is not available for race ROMS (except when entrances are randomized).',
+                        'Allow items to be changed with the L and R buttons without opening the menu.',
                     ],
                 ],
                 'palette_shuffle' => [

--- a/resources/lang/en/races.php
+++ b/resources/lang/en/races.php
@@ -109,12 +109,12 @@ return [
             'languages' => [
                 [
                     'header' => 'Francophone',
-                    'description' => 'Something about the community here.',
+                    'description' => 'Si vous cherchez des passionnées francophone de ALTTP Randomizer, n’hésitez pas à nous rejoindre sur notre <a href="https://discord.gg/tpdpHt6" target="_blank">Discord</a>. Il y a toujours des gens prêts à vous donner un coup de main. Il y a souvent des courses amicales qui s’organisent de manière impromptue, et il y règne une bonne ambiance.',
                     'sections' => [
                         [
-                            'header' => 'Placeholder Tournament',
+                            'header' => 'Tournoi Francophone',
                             'content' => [
-                                'The <a href="https://example.com" target="_blank">Placeholder Tournament</a> is one I hope doesn’t actually exist, except in our hearts.',
+                                'Nous organisons habituellement un gros tournoi par année, ainsi qu’un micro tournoi à l’occasion. Surveillez le <a href="https://discord.gg/tpdpHt6" target="_blank">Discord</a> pour être au courant des développements',
                             ],
                         ],
                     ],

--- a/resources/lang/en/races.php
+++ b/resources/lang/en/races.php
@@ -50,7 +50,7 @@ return [
                 [
                     'header' => '',
                     'content' => [
-                        'Join us for exciting tournament action with expert commentary alongside elite play!  Tournaments are operating all the time, oin <a href="https://discord.gg/alttprandomizer" target="_blank">Discord</a> to stay up to date!',
+                        'Join us for exciting tournament action with expert commentary alongside elite play!  Tournaments are operating all the time, join <a href="https://discord.gg/alttprandomizer" target="_blank">Discord</a> to stay up to date!',
                     ],
                 ],
                 [
@@ -60,15 +60,15 @@ return [
                     ],
                 ],
                 [
-                    'header' => 'ALTTPR League',
-                    'content' => [
-                        'The <a href="https://alttprleague.com/" target="_blank">ALTTPR League</a> is a yearly team-based ALTTPR Tournament.  Players form teams of three to complete head to head with other teams using various game settings.',
-                    ],
-                ],
-                [
                     'header' => 'Challenge Cup',
                     'content' => [
                         'The <a href="https://discord.gg/982W72p" target="_blank">Challenge Cup</a> is an overflow tournament for those who did not qualify for the main tournament.',
+                    ],
+                ],
+                [
+                    'header' => 'ALTTPR League',
+                    'content' => [
+                        'The <a href="https://alttprleague.com/" target="_blank">ALTTPR League</a> is a yearly team-based ALTTPR Tournament.  Players form teams of three to complete head to head with other teams using various game settings.',
                     ],
                 ],
                 [

--- a/resources/lang/en/races.php
+++ b/resources/lang/en/races.php
@@ -92,7 +92,7 @@ return [
                 [
                     'header' => 'ALTTPR Crossworld Keysanity Tournament',
                     'content' => [
-                        'The <a href="https://discord.gg/umCCQgr" target="_blank">ALTTPR Crossworld Keysanity Tournament</a> is a Crossworld Keysanity (aka "Crosskeys") tournament where players put their note taking and memory to the test to be the top player of this mind-bending mode!',
+                        'The <a href="https://discord.gg/umCCQgr" target="_blank">ALTTPR Crossworld Keysanity Tournament</a> is a tournament that uses Crossworld entrance shuffle, plus keysanity, (aka "Crosskeys").  Players put their note taking and memory to the test to be the top player of this mind-bending mode!',
                     ],
                 ],
             ],

--- a/resources/lang/en/races.php
+++ b/resources/lang/en/races.php
@@ -8,7 +8,8 @@ return [
                 [
                     'header' => '',
                     'content' => [
-                        'Most races are done through <a href="https://racetime.gg/" target="_blank">RaceTime.gg</a>. Be sure to check them out for more info on how to get in on the action!',
+                        'Most races are done through <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a>. Be sure to check them out for more info on how to get in on the action!',
+                        'Before starting you should familiarize yourself with the <a href="http://alttp.mymm1.com/wiki/ALTTPR_Racing_Ruleset">ALTTPR Racing Council\'s General Racing Rules</a>, however individual tournaments or races may have rules that vary.  Check with the competition first to make sure your in the clear!',
                     ],
                 ],
                 [
@@ -20,13 +21,13 @@ return [
                 [
                     'header' => 'SpeedGaming Daily Racing Series',
                     'content' => [
-                        '<a href="https://speedgaming.org/" target="_blank">SpeedGaming</a> operates a daily race series, which are ran on <a href="https://racetime.gg/" target="_blank">RaceTime.gg</a>.  Check out <a href="http://speedgaming.org/alttprdaily/" target="_blank">their upcoming schedule of dailies.</a>',
+                        '<a href="https://speedgaming.org/" target="_blank">SpeedGaming</a> operates a daily race series, which are ran on <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a>.  Check out <a href="http://speedgaming.org/alttprdaily/" target="_blank">their upcoming schedule of dailies.</a>',
                     ],
                 ],
                 [
                     'header' => 'Overworld Glitches Weekly',
                     'content' => [
-                        'The Overworld Glitches Weekly runs at 10:30pm Eastern every Wednesday on <a href="https://racetime.gg/" target="_blank">RaceTime.gg</a>.',
+                        'The Overworld Glitches Weekly runs at 10:30pm Eastern every Wednesday on <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a>.',
                     ],
                 ],
                 [

--- a/resources/lang/en/races.php
+++ b/resources/lang/en/races.php
@@ -24,6 +24,12 @@ return [
                     ],
                 ],
                 [
+                    'header' => 'Overworld Glitches Weekly',
+                    'content' => [
+                        'The Overworld Glitches Weekly runs at 10:30pm Eastern every Wednesday on <a href="https://racetime.gg/" target="_blank">RaceTime.gg</a>.',
+                    ],
+                ],
+                [
                     'header' => 'Pickup Races',
                     'content' => [
                         'Scheduled races not fitting in with your schedule? Looking to race with some more uncommon options? Join a pickup race! You’ll find willing players at all hours of the day. Join the #race-planning channel in our <a href="https://discord.gg/alttprandomizer" target="_blank">Discord</a>!',

--- a/resources/lang/en/races.php
+++ b/resources/lang/en/races.php
@@ -9,7 +9,7 @@ return [
                     'header' => '',
                     'content' => [
                         'Most races are done through <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a>. Be sure to check them out for more info on how to get in on the action!',
-                        'Before starting you should familiarize yourself with the <a href="http://alttp.mymm1.com/wiki/ALTTPR_Racing_Ruleset">ALTTPR Racing Council\'s General Racing Rules</a>, however individual tournaments or races may have rules that vary.  Check with the competition first to make sure your in the clear!',
+                        'Before starting you should familiarize yourself with the <a href="http://alttp.mymm1.com/wiki/ALTTPR_Racing_Ruleset">ALTTPR Racing Council\'s General Racing Rules</a>, however individual tournaments or races may have rules that vary.  Check with the competition first to make sure you\'re in the clear!',
                     ],
                 ],
                 [

--- a/resources/lang/en/races.php
+++ b/resources/lang/en/races.php
@@ -126,13 +126,19 @@ return [
                     ],
                 ],
                 [
-                    'header' => 'German',
-                    'description' => 'Something about the community here.',
+                    'header' => 'Deutsch',
+                    'description' => 'Auf dem <a href="https://discord.gg/5zuANcS" target="_blank">Discord der deutschsprachigen ALTTPR-Community</a> gibt es alles, von Anfängertipps über freundschaftliche Rennen bis hin zu Turnieren.',
                     'sections' => [
                         [
-                            'header' => 'Placeholder Tournament',
+                            'header' => 'Deutsche ALTTPR-Turniere',
                             'content' => [
-                                'The <a href="https://example.com" target="_blank">Placeholder Tournament</a> is one I hope doesn’t actually exist, except in our hearts.',
+                                'Es wird ca. einmal im Jahr ein großes Turnier für neue und erfahrene Spieler organisiert. Dazwischen gibt es unregelmäßig kleinere und ausgefallenere Turniere. Ankündigungen und alle Informationen gibt es auf dem <a href="https://discord.gg/5zuANcS" target="_blank">Community-Discord</a>.',
+                            ],
+                        ],
+                        [
+                            'header' => 'Deutsches ALTTPR-Weekly',
+                            'content' => [
+                                'Jede Woche findet ein größeres Rennen statt, in dem man sich gegen andere Spieler aus der Community messen kann. Neben Open werden auch andere Modi gespielt, die immer durchwechseln. Auf dem <a href="https://discord.gg/5zuANcS" target="_blank">Discord</a> gibt es alle Informationen zu den nächsten Rennen und zur Teilnahme.',
                             ],
                         ],
                     ],

--- a/resources/lang/en/races.php
+++ b/resources/lang/en/races.php
@@ -3,30 +3,30 @@ return [
     'header' => 'Organized Play',
     'cards' => [
         'races' => [
-            'header' => 'Races',
+            'header' => 'Daily Races',
             'sections' => [
                 [
                     'header' => '',
                     'content' => [
-                        'Most races are done through <a href="https://speedracing.tv/" target="_blank" rel="noopener noreferrer">SpeedRacing.tv</a> or <a href="http://speedrunslive.com" target="_blank" rel="noopener noreferrer">SpeedRunsLive.com</a>. Be sure to check them out for more info on how to get in on the action!',
+                        'Most races are done through <a href="https://racetime.gg/" target="_blank">RaceTime.gg</a>. Be sure to check them out for more info on how to get in on the action!',
                     ],
                 ],
                 [
-                    'header' => 'Weekly Standard Mode Race, Saturdays at 3pm US Eastern Time',
+                    'header' => 'ALTTPR Ladder',
                     'content' => [
-                        'The premier community event, the weekly race has many competitors!',
+                        'The <a href="https://alttprladder.com/" target="_blank">ALTTPR Ladder</a> is a 1v1 Elo Ladder, "A Link To the Past Randomizer" league, running completely on Discord.  The system is designed to do several 1v1 races throughout the day, and rankings will be based on standard Elo 32k weights.',
                     ],
                 ],
                 [
-                    'header' => 'Weekly Open Mode Race, Sundays at 5:30pm US Eastern Time',
+                    'header' => 'SpeedGaming Daily Racing Series',
                     'content' => [
-                        'Join us Sundays for another popular weekly community race.',
+                        '<a href="https://speedgaming.org/" target="_blank">SpeedGaming</a> operates a daily race series, which are ran on <a href="https://racetime.gg/" target="_blank">RaceTime.gg</a>.  Check out <a href="http://speedgaming.org/alttprdaily/" target="_blank">their upcoming schedule of dailies.</a>',
                     ],
                 ],
                 [
                     'header' => 'Pickup Races',
                     'content' => [
-                        'Scheduled races not fitting in with your schedule? Looking to race with some more uncommon options? Join a pickup race! You’ll find willing players at all hours of the day. Join the #race-planning channel in our <a href="https://discord.gg/alttprandomizer" target="_blank" rel="noopener noreferrer">Discord</a>!',
+                        'Scheduled races not fitting in with your schedule? Looking to race with some more uncommon options? Join a pickup race! You’ll find willing players at all hours of the day. Join the #race-planning channel in our <a href="https://discord.gg/alttprandomizer" target="_blank">Discord</a>!',
                     ],
                 ],
             ],
@@ -41,7 +41,7 @@ return [
             'header' => 'Racing Networks',
             'content' => [
                 'Racing is typically done on a racing network. These sites facilitate in organizing races, adding an official timer, and making it easier for both racers and viewers to find races.',
-                'Be sure to check out both <a href="http://speedrunslive.com" target="_blank" rel="noopener noreferrer">SpeedRunsLive.com</a> and <a href="http://speedracing.tv" target="_blank" rel="noopener noreferrer">SpeedRacing.tv</a> for more info!',
+                'Be sure to check out <a href="http://racetime.gg" target="_blank">RaceTime.gg</a>!',
             ],
         ],
         'tournament' => [
@@ -50,13 +50,49 @@ return [
                 [
                     'header' => '',
                     'content' => [
-                        'Join us for exciting tournament action with expert commentary alongside elite play!',
+                        'Join us for exciting tournament action with expert commentary alongside elite play!  Tournaments are operating all the time, oin <a href="https://discord.gg/alttprandomizer" target="_blank">Discord</a> to stay up to date!',
                     ],
                 ],
                 [
-                    'header' => 'Annual Main Tournament',
+                    'header' => 'ALTTP Randomizer Main Tournament',
                     'content' => [
-                        'Witness the best racers compete for the trophy! Think you have what it takes to go toe-to-toe with the best? Join <a href="https://discord.gg/alttprandomizer" target="_blank" rel="noopener noreferrer">Discord</a> and keep an eye out for qualifying races!',
+                        'Witness the best racers compete for the trophy and win themselves a coveted place on the Houlihan Telepathic Tile! Think you have what it takes to go toe-to-toe with the best? Join the <a href="https://discord.gg/B2kGXxTD6g" target="_blank">ALTTPR Tournaments Discord</a> and keep an eye out for qualifying races!',
+                    ],
+                ],
+                [
+                    'header' => 'ALTTPR League',
+                    'content' => [
+                        'The <a href="https://alttprleague.com/" target="_blank">ALTTPR League</a> is a yearly team-based ALTTPR Tournament.  Players form teams of three to complete head to head with other teams using various game settings.',
+                    ],
+                ],
+                [
+                    'header' => 'Challenge Cup',
+                    'content' => [
+                        'The <a href="https://discord.gg/982W72p" target="_blank">Challenge Cup</a> is an overflow tournament for those who did not qualify for the main tournament.',
+                    ],
+                ],
+                [
+                    'header' => 'Go Mode Podcast Mentor Tournament',
+                    'content' => [
+                        '<a href="https://gomodepodcast.com/" target="_blank">Go Mode Podcast</a> operates a yearly tournament intended for brand new players.  Players have a mentor to help them with at least some of their races, with the intent to prepare players for tournaments big and small.',
+                    ],
+                ],
+                [
+                    'header' => 'ALTTPR Spoiler Tournament',
+                    'content' => [
+                        'The <a href="https://discord.gg/Jg34MuE" target="_blank">ALTTPR Spolier Tournament</a> is a yearly tournament that gives the player the spoiler log to study before the race!  This tournament is a test of execution and design making abilities!',
+                    ],
+                ],
+                [
+                    'header' => 'ALTTPR Glitched Tournaments',
+                    'content' => [
+                        '<a href="https://discord.gg/adac5FG" target="_blank">ALTTPR Glitched Tournaments</a> focuses on tournaments that involve the use of "major glitches" to beat the game in fun and unususal ways!',
+                    ],
+                ],
+                [
+                    'header' => 'ALTTPR Crossworld Keysanity Tournament',
+                    'content' => [
+                        'The <a href="https://discord.gg/umCCQgr" target="_blank">ALTTPR Crossworld Keysanity Tournament</a> is a Crossworld Keysanity (aka "Crosskeys") tournament where players put their note taking and memory to the test to be the top player of this mind-bending mode!',
                     ],
                 ],
             ],

--- a/resources/lang/en/races.php
+++ b/resources/lang/en/races.php
@@ -92,7 +92,7 @@ return [
                 [
                     'header' => 'ALTTPR Crossworld Keysanity Tournament',
                     'content' => [
-                        'The <a href="https://discord.gg/umCCQgr" target="_blank">ALTTPR Crossworld Keysanity Tournament</a> is a tournament that uses Crossworld entrance shuffle, plus keysanity, (aka "Crosskeys").  Players put their note taking and memory to the test to be the top player of this mind-bending mode!',
+                        'The <a href="https://discord.gg/umCCQgr" target="_blank">ALTTPR Crossworld Keysanity Tournament</a> is a tournament for Crossworld entrance shuffle, plus keysanity (aka "Crosskeys").  Players put their note taking and memory to the test to be the top player of this mind-bending mode!',
                     ],
                 ],
             ],

--- a/resources/lang/en/races.php
+++ b/resources/lang/en/races.php
@@ -97,5 +97,22 @@ return [
                 ],
             ],
         ],
+        'language_tournament' => [
+            'header' => 'Language-specific Tournaments',
+            'sections' => [
+                [
+                    'header' => '',
+                    'content' => [
+                        'There are several non-English communities operate their own language-specific tournaments!',
+                    ],
+                ],
+                [
+                    'header' => 'Placeholder Tournament',
+                    'content' => [
+                        'The <a href="https://example.com" target="_blank">Placeholder Tournament</a> is one I hope doesn\'t actually exist, except in our hearts.',
+                    ],
+                ],
+            ],
+        ],
     ],
 ];

--- a/resources/lang/en/races.php
+++ b/resources/lang/en/races.php
@@ -38,19 +38,6 @@ return [
                 ],
             ],
         ],
-        'watch' => [
-            'header' => 'Watch',
-            'content' => [
-                'With so much going on, there’s always a race to watch! Follow these networks and never miss a match!',
-            ],
-        ],
-        'network' => [
-            'header' => 'Racing Networks',
-            'content' => [
-                'Racing is typically done on a racing network. These sites facilitate in organizing races, adding an official timer, and making it easier for both racers and viewers to find races.',
-                'Be sure to check out <a href="http://racetime.gg" target="_blank">RaceTime.gg</a>!',
-            ],
-        ],
         'tournament' => [
             'header' => 'Tournaments',
             'sections' => [

--- a/resources/lang/en/races.php
+++ b/resources/lang/en/races.php
@@ -3,7 +3,7 @@ return [
     'header' => 'Organized Play',
     'cards' => [
         'races' => [
-            'header' => 'Daily Races',
+            'header' => 'Daily and Weekly Races',
             'sections' => [
                 [
                     'header' => '',

--- a/resources/lang/en/races.php
+++ b/resources/lang/en/races.php
@@ -109,12 +109,18 @@ return [
             'languages' => [
                 [
                     'header' => 'Francophone',
-                    'description' => 'Si vous cherchez des passionnées francophone de ALTTP Randomizer, n’hésitez pas à nous rejoindre sur notre <a href="https://discord.gg/tpdpHt6" target="_blank">Discord</a>. Il y a toujours des gens prêts à vous donner un coup de main. Il y a souvent des courses amicales qui s’organisent de manière impromptue, et il y règne une bonne ambiance.',
+                    'description' => 'Si vous cherchez des passionnées francophones de ALTTP Randomizer, n’hésitez pas à nous rejoindre sur notre <a href="https://discord.gg/tpdpHt6" target="_blank">Discord</a>. Il y a toujours des gens prêts à vous donner un coup de main. Il y a souvent des courses amicales qui s’organisent de manière impromptue, et il y règne une bonne ambiance.',
                     'sections' => [
                         [
                             'header' => 'Tournoi Francophone',
                             'content' => [
                                 'Nous organisons habituellement un gros tournoi par année, ainsi qu’un micro tournoi à l’occasion. Surveillez le <a href="https://discord.gg/tpdpHt6" target="_blank">Discord</a> pour être au courant des développements',
+                            ],
+                        ],
+						[
+                            'header' => 'Hebdomadaire Francophone',
+                            'content' => [
+                                'Chaque semaine, une course hebdomadaire entre francophones à lieu. L’horaire est voté par les joueurs sur le <a href="https://discord.gg/tpdpHt6" target="_blank">Discord de la communauté francophone</a> puis annoncé, au plaisir de tous!',
                             ],
                         ],
                     ],

--- a/resources/lang/en/races.php
+++ b/resources/lang/en/races.php
@@ -80,7 +80,7 @@ return [
                 [
                     'header' => 'ALTTPR Spoiler Tournament',
                     'content' => [
-                        'The <a href="https://discord.gg/Jg34MuE" target="_blank">ALTTPR Spolier Tournament</a> is a yearly tournament that gives the player the spoiler log to study before the race!  This tournament is a test of execution and design making abilities!',
+                        'The <a href="https://discord.gg/Jg34MuE" target="_blank">ALTTPR Spolier Tournament</a> is a yearly tournament that gives the player the spoiler log to study before the race!  This tournament is a test of execution and decision making abilities!',
                     ],
                 ],
                 [

--- a/resources/lang/en/races.php
+++ b/resources/lang/en/races.php
@@ -9,7 +9,7 @@ return [
                     'header' => '',
                     'content' => [
                         'Most races are done through <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a>. Be sure to check them out for more info on how to get in on the action!',
-                        'Before starting you should familiarize yourself with the <a href="http://alttp.mymm1.com/wiki/ALTTPR_Racing_Ruleset">ALTTPR Racing Council\'s General Racing Rules</a>, however individual tournaments or races may have rules that vary.  Check with the competition first to make sure you\'re in the clear!',
+                        'Before starting you should familiarize yourself with the <a href="http://alttp.mymm1.com/wiki/ALTTPR_Racing_Ruleset">ALTTPR Racing Council’s General Racing Rules</a>, however individual tournaments or races may have rules that vary.  Check with the competition first to make sure you’re in the clear!',
                     ],
                 ],
                 [
@@ -104,19 +104,43 @@ return [
                 ],
             ],
         ],
-        'language_tournament' => [
-            'header' => 'Language-specific Tournaments',
-            'sections' => [
+        'foreign_language' => [
+            'header' => 'Language-specific Tournaments and Events',
+            'languages' => [
                 [
-                    'header' => '',
-                    'content' => [
-                        'There are several non-English communities operate their own language-specific tournaments!',
+                    'header' => 'Francophone',
+                    'description' => 'Something about the community here.',
+                    'sections' => [
+                        [
+                            'header' => 'Placeholder Tournament',
+                            'content' => [
+                                'The <a href="https://example.com" target="_blank">Placeholder Tournament</a> is one I hope doesn’t actually exist, except in our hearts.',
+                            ],
+                        ],
                     ],
                 ],
                 [
-                    'header' => 'Placeholder Tournament',
-                    'content' => [
-                        'The <a href="https://example.com" target="_blank">Placeholder Tournament</a> is one I hope doesn\'t actually exist, except in our hearts.',
+                    'header' => 'German',
+                    'description' => 'Something about the community here.',
+                    'sections' => [
+                        [
+                            'header' => 'Placeholder Tournament',
+                            'content' => [
+                                'The <a href="https://example.com" target="_blank">Placeholder Tournament</a> is one I hope doesn’t actually exist, except in our hearts.',
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'header' => 'Spanish',
+                    'description' => 'Something about the community here.',
+                    'sections' => [
+                        [
+                            'header' => 'Placeholder Tournament',
+                            'content' => [
+                                'The <a href="https://example.com" target="_blank">Placeholder Tournament</a> is one I hope doesn’t actually exist, except in our hearts.',
+                            ],
+                        ],
                     ],
                 ],
             ],

--- a/resources/lang/en/resources.php
+++ b/resources/lang/en/resources.php
@@ -24,7 +24,7 @@ return [
                     . '<li><a href="https://alttprlinks.page.link/3vXm" target="_blank" rel="noopener noreferrer">General help glossary</a></li>'
                     . '<li><a href="https://alttprlinks.page.link/HVFx" target="_blank" rel="noopener noreferrer">Glitch Resources</a></li>'
                     . '<li><a href="https://alttprlinks.page.link/on1o" target="_blank" rel="noopener noreferrer">Trackers / HUDs</a></li>'
-                    . '<li><a href="http://alttp.mymm1.com/srl/" target="_blank" rel="noopener noreferrer">Getting started on SRL</a></li>'
+                    . '<li><a href="https://racetime.gg/about/help" target="_blank" rel="noopener noreferrer">Getting started on RaceTime.gg</a></li>'
                 . '</ul>',
             ],
         ],

--- a/resources/lang/en/rom.php
+++ b/resources/lang/en/rom.php
@@ -57,5 +57,7 @@ return [
         'quickswap' => 'Item Quickswap',
         'palette_shuffle' => 'Palette Shuffle',
         'race_warning' => 'Does not work in Race Roms',
+        'reduce_flashing' => 'Reduce Flashing',
+        'reduce_flashing_warning' => 'This option only reduces the effects of flashing, individual photosensitivity to effects may still vary.',
     ],
 ];

--- a/resources/lang/en/rom.php
+++ b/resources/lang/en/rom.php
@@ -58,6 +58,6 @@ return [
         'palette_shuffle' => 'Palette Shuffle',
         'race_warning' => 'Does not work in Race Roms',
         'reduce_flashing' => 'Reduce Flashing',
-        'reduce_flashing_warning' => 'This option only reduces the effects of flashing, individual photosensitivity to effects may still vary.',
+        'reduce_flashing_warning' => 'This option only reduces the effects of flashing. Individual photosensitivity to effects may still vary.',
     ],
 ];

--- a/resources/lang/es/options.php
+++ b/resources/lang/es/options.php
@@ -617,6 +617,12 @@ return [
                         'Randomiza las paletas de color del juego. Esto significa que todo podria verse muy extraño. ¡Actívalo con cuidado!',
                     ],
                 ],
+                'reduce_flashing' => [
+                    'header' => __('rom.settings.reduce_flashing'),
+                    'content' => [
+                        'Reduce severamente la intensidad de efectos del juego que parpadeen, o directamente los desactiva. Tener cuidado, tu sensibilidad a los efectos aun puede variar.',
+                    ],
+                ],
             ],
         ],
         'item_pool' => 'Reserva de Objetos',

--- a/resources/lang/es/options.php
+++ b/resources/lang/es/options.php
@@ -602,13 +602,13 @@ return [
                 'music' => [
                     'header' => __('rom.settings.music'),
                     'content' => [
-                        'Activa o desactiva la música de fondo original. No tienes que desactivar esto si deseas usar paquetes MSU-1. Si se deja activado y se está usando un paquete MSU-1, entonces la música originals se usará como una reserva y solo sonará si hay un error de carga del MSU-1 (en lugar de silencio).',
+                        'Activa o desactiva la música de fondo original.',
                     ],
                 ],
                 'quickswap' => [
                     'header' => __('rom.settings.quickswap'),
                     'content' => [
-                        'Permite que el objeto equipado se cambie usando los botones L y R sin abrir el menú. No está disponible para ROMs de carreras (excepto cuando las entradas estén randomizadas).',
+                        'Permite que el objeto equipado se cambie usando los botones L y R sin abrir el menú.',
                     ],
                 ],
                 'palette_shuffle' => [

--- a/resources/lang/es/races.php
+++ b/resources/lang/es/races.php
@@ -1,92 +1,92 @@
 <?php
 return [
-    'header' => 'Organized Play',
+    'header' => 'Partidas Organizadas',
     'cards' => [
         'races' => [
-            'header' => 'Daily and Weekly Races',
+            'header' => 'Carreras Semanales y Diarias',
             'sections' => [
                 [
                     'header' => '',
                     'content' => [
-                        'Most races are done through <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a>. Be sure to check them out for more info on how to get in on the action!',
-                        'Before starting you should familiarize yourself with the <a href="http://alttp.mymm1.com/wiki/ALTTPR_Racing_Ruleset">ALTTPR Racing Council’s General Racing Rules</a>, however individual tournaments or races may have rules that vary.  Check with the competition first to make sure you’re in the clear!',
+                        'La Mayoría de las carreras seran en <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a>. ¡Asegurate de pasarte por ahi para tener mas informacion de como pasar a la acción!',
+                        'Antes de empezar deberias familiarizarte con las <a href="http://alttp.mymm1.com/wiki/ALTTPR_Racing_Ruleset">Reglas Generales de Carrera del Consejo de ALTTPR</a>, sin embargo, cada torneo o carreras puede tener reglas que varíen. however individual tournaments or races may have rules that vary. ¡Comprueba con cada competición primero para asegurarte que todo esta bien!',
                     ],
                 ],
                 [
                     'header' => 'ALTTPR Ladder',
                     'content' => [
-                        'The <a href="https://alttprladder.com/" target="_blank">ALTTPR Ladder</a> is a 1v1 Elo Ladder, "A Link To the Past Randomizer" league, running completely on Discord.  The system is designed to do several 1v1 races throughout the day, and rankings will be based on standard Elo 32k weights.',
+                        '<a href="https://alttprladder.com/" target="_blank">ALTTPR Ladder</a> es un sistema de Ladder o Escalera por Elo 1v1, una liga de "A Link To the Past Randomizer", que funciona completamente por Discord. El sistema esta diseñado para que ocurran varias carreras 1v1 a lo largo del día, y los rankings se basan en pesos estandar de Elo 32K.',
                     ],
                 ],
                 [
-                    'header' => 'SpeedGaming Daily Racing Series',
+                    'header' => 'SpeedGaming Carreras Diarias',
                     'content' => [
-                        '<a href="https://speedgaming.org/" target="_blank">SpeedGaming</a> operates a daily race series, which are ran on <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a>.  Check out <a href="http://speedgaming.org/alttprdaily/" target="_blank">their upcoming schedule of dailies.</a>',
+                        '<a href="https://speedgaming.org/" target="_blank">SpeedGaming</a> opera carreras diarias, que funcionan en  <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a>.  En <a href="http://speedgaming.org/alttprdaily/" target="_blank"> podrás encontrar cuando es la siguiente carrera diaria.</a>',
                     ],
                 ],
                 [
-                    'header' => 'Overworld Glitches Weekly',
+                    'header' => 'Overworld Glitches Semanal',
                     'content' => [
-                        'The Overworld Glitches Weekly runs at 10:30pm Eastern every Wednesday on <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a>.',
+                        'La semanal de  Overworld Glitches Weekly o Glitches de Mundo Abierto es a las 10:30pm EDT cada Miercoles en <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a>.',
                     ],
                 ],
                 [
-                    'header' => 'Pickup Races',
+                    'header' => 'Carreras Improvisadas',
                     'content' => [
-                        'Scheduled races not fitting in with your schedule? Looking to race with some more uncommon options? Join a pickup race! You’ll find willing players at all hours of the day. Join the #race-planning channel in our <a href="https://discord.gg/alttprandomizer" target="_blank">Discord</a>!',
+                        '¿Las Carreras Planeadas no encajan en tu agenda? ¿Buscas alguien contra quien correr opciones menos comunes? ¡Unete a una carrera improvisada! Encontraras jugadores dispuesto a cualquier hora del dia. Unete al canal #race-planning en nuestro <a href="https://discord.gg/alttprandomizer" target="_blank">Discord</a>!',
                     ],
                 ],
             ],
         ],
         'tournament' => [
-            'header' => 'Tournaments',
+            'header' => 'Torneos',
             'sections' => [
                 [
                     'header' => '',
                     'content' => [
-                        'Join us for exciting tournament action with expert commentary alongside elite play!  Tournaments are operating all the time, join <a href="https://discord.gg/alttprandomizer" target="_blank">Discord</a> to stay up to date!',
+                        '¡Unete a nosotros en emocionante accion de torneo con comentario experto y jugadores de elite! Hay torneos operando todo el tiempo, ¡unete a <a href="https://discord.gg/alttprandomizer" target="_blank">Discord</a> para estar al dia!',
                     ],
                 ],
                 [
-                    'header' => 'ALTTP Randomizer Main Tournament',
+                    'header' => 'ALTTP Randomizer Torneo Principal',
                     'content' => [
-                        'Witness the best racers compete for the trophy and win themselves a coveted place on the Houlihan Telepathic Tile! Think you have what it takes to go toe-to-toe with the best? Join the <a href="https://discord.gg/B2kGXxTD6g" target="_blank">ALTTPR Tournaments Discord</a> and keep an eye out for qualifying races!',
+                        '¡Se testigo de los mejores corredores compitiendo por el trofeo y ganar para si mismos el preciado sitio en la Baldosa Telepatica de Houlihan! ¿Crees que tienes lo que hace falta para competir con los mejoreS? Unete a <a href="https://discord.gg/B2kGXxTD6g" target="_blank">ALTTPR Tournaments Discord</a> y estate atento a carreras clasificatorias!',
                     ],
                 ],
                 [
-                    'header' => 'Challenge Cup',
+                    'header' => 'Copa Desafio',
                     'content' => [
-                        'The <a href="https://discord.gg/982W72p" target="_blank">Challenge Cup</a> is an overflow tournament for those who did not qualify for the main tournament.',
+                        'La <a href="https://discord.gg/982W72p" target="_blank">Copa Desafio</a> es un torneo complementario para aquellos que no se clasifican para el torneo principal.',
                     ],
                 ],
                 [
-                    'header' => 'ALTTPR League',
+                    'header' => 'Liga ALTTPR',
                     'content' => [
-                        'The <a href="https://alttprleague.com/" target="_blank">ALTTPR League</a> is a yearly team-based ALTTPR Tournament.  Players form teams of three to complete head to head with other teams using various game settings.',
+                        'La <a href="https://alttprleague.com/" target="_blank">Liga ALTTPR</a> es un torneo de ALTTPR por equipos anual. Los jugadores formaran equipos de 3 y competiran otros equipos en diferentes modos de juego.',
                     ],
                 ],
                 [
-                    'header' => 'Go Mode Podcast Mentor Tournament',
+                    'header' => 'Go Mode Podcast Torneo de Mentores',
                     'content' => [
-                        '<a href="https://gomodepodcast.com/" target="_blank">Go Mode Podcast</a> operates a yearly tournament intended for brand new players.  Players have a mentor to help them with at least some of their races, with the intent to prepare players for tournaments big and small.',
+                        '<a href="https://gomodepodcast.com/" target="_blank">Go Mode Podcast</a> opera un torneo anual diseñado para jugadores noveles. Los jugadores tienen un mentor que ayudaran con algunas de sus carreras, con la intencion de preparar a los jugadores para torneos grandes o pequeños.',
                     ],
                 ],
                 [
-                    'header' => 'ALTTPR Spoiler Tournament',
+                    'header' => 'ALTTPR Torneo Spoiler',
                     'content' => [
-                        'The <a href="https://discord.gg/Jg34MuE" target="_blank">ALTTPR Spolier Tournament</a> is a yearly tournament that gives the player the spoiler log to study before the race!  This tournament is a test of execution and decision making abilities!',
+                        'El <a href="https://discord.gg/Jg34MuE" target="_blank">ALTTPR Torneo Spoiler</a> es un torneo anual que da a los jugadores el Spoiler Log para estudiar antes de la carrera. Este torneo es una prueba de ejecucion y toma de decisiones.',
                     ],
                 ],
                 [
-                    'header' => 'ALTTPR Glitched Tournaments',
+                    'header' => 'ALTTPR Torneo con Glitches',
                     'content' => [
-                        '<a href="https://discord.gg/adac5FG" target="_blank">ALTTPR Glitched Tournaments</a> focuses on tournaments that involve the use of "major glitches" to beat the game in fun and unususal ways!',
+                        '<a href="https://discord.gg/adac5FG" target="_blank">ALTTPR Glitched Tournaments</a> se centra en torneos que implican el uso de "glitches mayores" para terminar el juego en formas tan divertidas como inusuales.',
                     ],
                 ],
                 [
-                    'header' => 'ALTTPR Crossworld Keysanity Tournament',
+                    'header' => 'ALTTPR Torneo Crossworld Keysanity',
                     'content' => [
-                        'The <a href="https://discord.gg/umCCQgr" target="_blank">ALTTPR Crossworld Keysanity Tournament</a> is a tournament for Crossworld entrance shuffle, plus keysanity (aka "Crosskeys").  Players put their note taking and memory to the test to be the top player of this mind-bending mode!',
+                        'El <a href="https://discord.gg/umCCQgr" target="_blank">Torneo ALTTPR Crossworld Keysanity</a> es un torneo de Entradas Aleatorias de un mundo a otro, con Keysanity (aka"Crosskeys"). ¡Los jugadores tendran su memoria y habilidad de tomar notas puestas a prueba para ser el mejor en este alocado modo!',
                     ],
                 ],
             ],

--- a/resources/lang/es/races.php
+++ b/resources/lang/es/races.php
@@ -95,42 +95,6 @@ return [
             'header' => 'Language-specific Tournaments and Events',
             'languages' => [
                 [
-                    'header' => 'Francophone',
-                    'description' => 'Si vous cherchez des passionnées francophones de ALTTP Randomizer, n’hésitez pas à nous rejoindre sur notre <a href="https://discord.gg/tpdpHt6" target="_blank">Discord</a>. Il y a toujours des gens prêts à vous donner un coup de main. Il y a souvent des courses amicales qui s’organisent de manière impromptue, et il y règne une bonne ambiance.',
-                    'sections' => [
-                        [
-                            'header' => 'Tournoi Francophone',
-                            'content' => [
-                                'Nous organisons habituellement un gros tournoi par année, ainsi qu’un micro tournoi à l’occasion. Surveillez le <a href="https://discord.gg/tpdpHt6" target="_blank">Discord</a> pour être au courant des développements',
-                            ],
-                        ],
-						[
-                            'header' => 'Hebdomadaire Francophone',
-                            'content' => [
-                                'Chaque semaine, une course hebdomadaire entre francophones à lieu. L’horaire est voté par les joueurs sur le <a href="https://discord.gg/tpdpHt6" target="_blank">Discord de la communauté francophone</a> puis annoncé, au plaisir de tous!',
-                            ],
-                        ],
-                    ],
-                ],
-                [
-                    'header' => 'Deutsch',
-                    'description' => 'Auf dem <a href="https://discord.gg/5zuANcS" target="_blank">Discord der deutschsprachigen ALTTPR-Community</a> gibt es alles, von Anfängertipps über freundschaftliche Rennen bis hin zu Turnieren.',
-                    'sections' => [
-                        [
-                            'header' => 'Deutsche ALTTPR-Turniere',
-                            'content' => [
-                                'Es wird ca. einmal im Jahr ein großes Turnier für neue und erfahrene Spieler organisiert. Dazwischen gibt es unregelmäßig kleinere und ausgefallenere Turniere. Ankündigungen und alle Informationen gibt es auf dem <a href="https://discord.gg/5zuANcS" target="_blank">Community-Discord</a>.',
-                            ],
-                        ],
-                        [
-                            'header' => 'Deutsches ALTTPR-Weekly',
-                            'content' => [
-                                'Jede Woche findet ein größeres Rennen statt, in dem man sich gegen andere Spieler aus der Community messen kann. Neben Open werden auch andere Modi gespielt, die immer durchwechseln. Auf dem <a href="https://discord.gg/5zuANcS" target="_blank">Discord</a> gibt es alle Informationen zu den nächsten Rennen und zur Teilnahme.',
-                            ],
-                        ],
-                    ],
-                ],
-                [
                     'header' => 'Spanish',
                     'description' => 'Something about the community here.',
                     'sections' => [

--- a/resources/lang/es/races.php
+++ b/resources/lang/es/races.php
@@ -1,70 +1,145 @@
 <?php
 return [
-    'header' => 'Partidas Organizadas',
+    'header' => 'Organized Play',
     'cards' => [
         'races' => [
-            'header' => 'Carreras',
+            'header' => 'Daily and Weekly Races',
             'sections' => [
                 [
                     'header' => '',
                     'content' => [
-                        'La mayoría de carreras se hacen a través de <a href="https://speedracing.tv/" target="_blank" rel="noopener noreferrer">SpeedRacing.tv</a> o <a href="http://speedrunslive.com" target="_blank" rel="noopener noreferrer">SpeedRunsLive.com</a>. ¡No olvides entrar a ellas para informarte sobre cómo unirte a la acción!',
+                        'Most races are done through <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a>. Be sure to check them out for more info on how to get in on the action!',
+                        'Before starting you should familiarize yourself with the <a href="http://alttp.mymm1.com/wiki/ALTTPR_Racing_Ruleset">ALTTPR Racing Council’s General Racing Rules</a>, however individual tournaments or races may have rules that vary.  Check with the competition first to make sure you’re in the clear!',
                     ],
                 ],
                 [
-                    'header' => 'Carrera de Modo Estándar semanal, Sábados a las 3pm EST',
+                    'header' => 'ALTTPR Ladder',
                     'content' => [
-                        'El evento principal de la comunidad, ¡esta carrera semanal tiene muchos participantes!',
+                        'The <a href="https://alttprladder.com/" target="_blank">ALTTPR Ladder</a> is a 1v1 Elo Ladder, "A Link To the Past Randomizer" league, running completely on Discord.  The system is designed to do several 1v1 races throughout the day, and rankings will be based on standard Elo 32k weights.',
                     ],
                 ],
                 [
-                    'header' => 'Carrera de Modo Abierto semanal, Domingos a las 5pm EST',
+                    'header' => 'SpeedGaming Daily Racing Series',
                     'content' => [
-                        'Únete cada domingo para otra popular carrera semanal de la comunidad.',
+                        '<a href="https://speedgaming.org/" target="_blank">SpeedGaming</a> operates a daily race series, which are ran on <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a>.  Check out <a href="http://speedgaming.org/alttprdaily/" target="_blank">their upcoming schedule of dailies.</a>',
                     ],
                 ],
                 [
-                    'header' => 'Carrera Nocturna de la Comunidad, 10pm EST',
+                    'header' => 'Overworld Glitches Weekly',
                     'content' => [
-                        '¡También tenemos una carrera nocturna para cualquiera que quiera jugar cada día!',
+                        'The Overworld Glitches Weekly runs at 10:30pm Eastern every Wednesday on <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a>.',
                     ],
                 ],
                 [
-                    'header' => 'Carreras Espontáneas',
+                    'header' => 'Pickup Races',
                     'content' => [
-                        '¿Las carreras programadas no encajan con tu horario? ¿Buscas una carrera usando opciones poco comunes? ¡Únete a una carrera espontánea! Puedes encontrar jugadores dispuestos a cualquier hora del día. ¡Entra al canal #race-planning en nuestro <a href="https://discord.gg/alttprandomizer" target="_blank" rel="noopener noreferrer">Discord</a>!',
+                        'Scheduled races not fitting in with your schedule? Looking to race with some more uncommon options? Join a pickup race! You’ll find willing players at all hours of the day. Join the #race-planning channel in our <a href="https://discord.gg/alttprandomizer" target="_blank">Discord</a>!',
                     ],
                 ],
-            ],
-        ],
-        'watch' => [
-            'header' => 'Ver',
-            'content' => [
-                'Con todo lo que va pasando, ¡siempre hay una carrera que ver! ¡Sigue estos canales para no perderte ningún enfrentamiento!',
-            ],
-        ],
-        'network' => [
-            'header' => 'Comunidades de Carreras',
-            'content' => [
-                'Las carreras típicamente se hacen en comunidades de carreras. Estas páginas facilitan organizer carreras, añadir un temporizador oficial, y hacen encontrar carreras fácil tanto para jugadores como para espectadores.',
-                '¡No olvides mirar tanto <a href="http://speedrunslive.com" target="_blank" rel="noopener noreferrer">SpeedRunsLive.com</a> como <a href="http://speedracing.tv" target="_blank" rel="noopener noreferrer">SpeedRacing.tv</a> para más información!',
             ],
         ],
         'tournament' => [
-            'header' => 'Torneos',
+            'header' => 'Tournaments',
             'sections' => [
                 [
                     'header' => '',
                     'content' => [
-                        '¡Únete para excitante acción en torneos con comentario experto junto a juego de alto nivel!',
+                        'Join us for exciting tournament action with expert commentary alongside elite play!  Tournaments are operating all the time, join <a href="https://discord.gg/alttprandomizer" target="_blank">Discord</a> to stay up to date!',
                     ],
                 ],
                 [
-                    'header' => 'Torneo Invitacional Bianual',
+                    'header' => 'ALTTP Randomizer Main Tournament',
                     'content' => [
-                        '¡Presencia los mejores jugadores competir por el trofeo! ¿Crees que tienes lo que hay que tener para enfrentarte cara a cara con los mejores? ¡Entra a <a href="https://discord.gg/alttprandomizer" target="_blank" rel="noopener noreferrer">Discord</a> y estate atento a las carreras de calificación!',
-                        'El Invitacional de Primavera va de marzo a junio.',
-                        'El Invitacional de Otoño va de septiembre a diciembre.',
+                        'Witness the best racers compete for the trophy and win themselves a coveted place on the Houlihan Telepathic Tile! Think you have what it takes to go toe-to-toe with the best? Join the <a href="https://discord.gg/B2kGXxTD6g" target="_blank">ALTTPR Tournaments Discord</a> and keep an eye out for qualifying races!',
+                    ],
+                ],
+                [
+                    'header' => 'Challenge Cup',
+                    'content' => [
+                        'The <a href="https://discord.gg/982W72p" target="_blank">Challenge Cup</a> is an overflow tournament for those who did not qualify for the main tournament.',
+                    ],
+                ],
+                [
+                    'header' => 'ALTTPR League',
+                    'content' => [
+                        'The <a href="https://alttprleague.com/" target="_blank">ALTTPR League</a> is a yearly team-based ALTTPR Tournament.  Players form teams of three to complete head to head with other teams using various game settings.',
+                    ],
+                ],
+                [
+                    'header' => 'Go Mode Podcast Mentor Tournament',
+                    'content' => [
+                        '<a href="https://gomodepodcast.com/" target="_blank">Go Mode Podcast</a> operates a yearly tournament intended for brand new players.  Players have a mentor to help them with at least some of their races, with the intent to prepare players for tournaments big and small.',
+                    ],
+                ],
+                [
+                    'header' => 'ALTTPR Spoiler Tournament',
+                    'content' => [
+                        'The <a href="https://discord.gg/Jg34MuE" target="_blank">ALTTPR Spolier Tournament</a> is a yearly tournament that gives the player the spoiler log to study before the race!  This tournament is a test of execution and decision making abilities!',
+                    ],
+                ],
+                [
+                    'header' => 'ALTTPR Glitched Tournaments',
+                    'content' => [
+                        '<a href="https://discord.gg/adac5FG" target="_blank">ALTTPR Glitched Tournaments</a> focuses on tournaments that involve the use of "major glitches" to beat the game in fun and unususal ways!',
+                    ],
+                ],
+                [
+                    'header' => 'ALTTPR Crossworld Keysanity Tournament',
+                    'content' => [
+                        'The <a href="https://discord.gg/umCCQgr" target="_blank">ALTTPR Crossworld Keysanity Tournament</a> is a tournament for Crossworld entrance shuffle, plus keysanity (aka "Crosskeys").  Players put their note taking and memory to the test to be the top player of this mind-bending mode!',
+                    ],
+                ],
+            ],
+        ],
+        'foreign_language' => [
+            'header' => 'Language-specific Tournaments and Events',
+            'languages' => [
+                [
+                    'header' => 'Francophone',
+                    'description' => 'Si vous cherchez des passionnées francophones de ALTTP Randomizer, n’hésitez pas à nous rejoindre sur notre <a href="https://discord.gg/tpdpHt6" target="_blank">Discord</a>. Il y a toujours des gens prêts à vous donner un coup de main. Il y a souvent des courses amicales qui s’organisent de manière impromptue, et il y règne une bonne ambiance.',
+                    'sections' => [
+                        [
+                            'header' => 'Tournoi Francophone',
+                            'content' => [
+                                'Nous organisons habituellement un gros tournoi par année, ainsi qu’un micro tournoi à l’occasion. Surveillez le <a href="https://discord.gg/tpdpHt6" target="_blank">Discord</a> pour être au courant des développements',
+                            ],
+                        ],
+						[
+                            'header' => 'Hebdomadaire Francophone',
+                            'content' => [
+                                'Chaque semaine, une course hebdomadaire entre francophones à lieu. L’horaire est voté par les joueurs sur le <a href="https://discord.gg/tpdpHt6" target="_blank">Discord de la communauté francophone</a> puis annoncé, au plaisir de tous!',
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'header' => 'Deutsch',
+                    'description' => 'Auf dem <a href="https://discord.gg/5zuANcS" target="_blank">Discord der deutschsprachigen ALTTPR-Community</a> gibt es alles, von Anfängertipps über freundschaftliche Rennen bis hin zu Turnieren.',
+                    'sections' => [
+                        [
+                            'header' => 'Deutsche ALTTPR-Turniere',
+                            'content' => [
+                                'Es wird ca. einmal im Jahr ein großes Turnier für neue und erfahrene Spieler organisiert. Dazwischen gibt es unregelmäßig kleinere und ausgefallenere Turniere. Ankündigungen und alle Informationen gibt es auf dem <a href="https://discord.gg/5zuANcS" target="_blank">Community-Discord</a>.',
+                            ],
+                        ],
+                        [
+                            'header' => 'Deutsches ALTTPR-Weekly',
+                            'content' => [
+                                'Jede Woche findet ein größeres Rennen statt, in dem man sich gegen andere Spieler aus der Community messen kann. Neben Open werden auch andere Modi gespielt, die immer durchwechseln. Auf dem <a href="https://discord.gg/5zuANcS" target="_blank">Discord</a> gibt es alle Informationen zu den nächsten Rennen und zur Teilnahme.',
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'header' => 'Spanish',
+                    'description' => 'Something about the community here.',
+                    'sections' => [
+                        [
+                            'header' => 'Placeholder Tournament',
+                            'content' => [
+                                'The <a href="https://example.com" target="_blank">Placeholder Tournament</a> is one I hope doesn’t actually exist, except in our hearts.',
+                            ],
+                        ],
                     ],
                 ],
             ],

--- a/resources/lang/es/races.php
+++ b/resources/lang/es/races.php
@@ -1,3 +1,4 @@
+
 <?php
 return [
     'header' => 'Partidas Organizadas',
@@ -8,32 +9,32 @@ return [
                 [
                     'header' => '',
                     'content' => [
-                        'La Mayoría de las carreras seran en <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a>. ¡Asegurate de pasarte por ahi para tener mas informacion de como pasar a la acción!',
-                        'Antes de empezar deberias familiarizarte con las <a href="http://alttp.mymm1.com/wiki/ALTTPR_Racing_Ruleset">Reglas Generales de Carrera del Consejo de ALTTPR</a>, sin embargo, cada torneo o carreras puede tener reglas que varíen. however individual tournaments or races may have rules that vary. ¡Comprueba con cada competición primero para asegurarte que todo esta bien!',
+                        'La mayoría de las carreras se realizan a través de <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a>. ¡Asegúrate de visitar la página para tener más informacion de cómo unirse a la acción!',
+                        'Antes de empezar, deberías familiarizarte con las <a href="http://alttp.mymm1.com/wiki/ALTTPR_Racing_Ruleset">Reglas Generales de Carrera del Consejo de ALTTPR</a>. Sin embargo, ten en cuenta que las reglas quedan sujetas siempre a modificaciones y actualizaciones posteriores. Además, cada torneo o carrera particular puede que aplique sus propias variaciones de la normativa, ¡así que comprueba las reglas de cada competición con antelación para asegurarte de que todo está en orden!',
                     ],
                 ],
                 [
                     'header' => 'ALTTPR Ladder',
                     'content' => [
-                        '<a href="https://alttprladder.com/" target="_blank">ALTTPR Ladder</a> es un sistema de Ladder o Escalera por Elo 1v1, una liga de "A Link To the Past Randomizer", que funciona completamente por Discord. El sistema esta diseñado para que ocurran varias carreras 1v1 a lo largo del día, y los rankings se basan en pesos estandar de Elo 32K.',
+                        '<a href="https://alttprladder.com/" target="_blank">La Ladder de ALTTPR </a> es un sistema competitivo rankeado que utiliza el sistema de puntuación Elo. Funciona completamente por Discord. Para participar, has de unirte a la cola antes de la hora de inicio, al modo de partida que decidas y que esté disponible. Entonces serás emparejado con un rival de manera anónima en una partida 1v1. Dispondrás de un tiempo para bajarte la seed correspondiente y completarla, y al acabar marcar que has finalizado. Según ganes o pierdas, ganarás o perderás más puntos según cuál sea la diferencia de puntos entre tu oponente y tú. El sistema esta diseñado para que ocurran varias carreras 1v1 a lo largo del día, ofrenciendo una gran variedad de horas a las que poder jugar. Los rankings, una vez finalice el tiempo establecido de la temporada de la ladder, se basan en pesos estandar de Elo 32K.',
                     ],
                 ],
                 [
-                    'header' => 'SpeedGaming Carreras Diarias',
+                    'header' => 'Carreras Diarias de SpeedGaming',
                     'content' => [
-                        '<a href="https://speedgaming.org/" target="_blank">SpeedGaming</a> opera carreras diarias, que funcionan en  <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a>.  En <a href="http://speedgaming.org/alttprdaily/" target="_blank"> podrás encontrar cuando es la siguiente carrera diaria.</a>',
+                        '<a href="https://speedgaming.org/" target="_blank">SpeedGaming</a> realiza una carrera diaria oficial, en horas preestablecidas con antelación, que funcionan a través de <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a>. La normativa y ajustes de la seed varían con cada carrera, y lo único necesario para participar es unirse, como mínimo, unos minutos antes de que empiece la carrera al racetime.gg correspondiente.  <a href="http://speedgaming.org/alttprdaily/" target="_blank"> Aquí </a> podrás encontrar los horarios de las inminentes carreras diarias.',
                     ],
                 ],
                 [
-                    'header' => 'Overworld Glitches Semanal',
+                    'header' => 'Semanal de Overworld Glitches',
                     'content' => [
-                        'La semanal de  Overworld Glitches Weekly o Glitches de Mundo Abierto es a las 10:30pm EDT cada Miercoles en <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a>.',
+                        'La semanal de Overworld, o Glitches de Mundo Abierto, se lleva a cabo a las 10:30pm EDT cada miércoles en <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a>.',
                     ],
                 ],
                 [
                     'header' => 'Carreras Improvisadas',
                     'content' => [
-                        '¿Las Carreras Planeadas no encajan en tu agenda? ¿Buscas alguien contra quien correr opciones menos comunes? ¡Unete a una carrera improvisada! Encontraras jugadores dispuesto a cualquier hora del dia. Unete al canal #race-planning en nuestro <a href="https://discord.gg/alttprandomizer" target="_blank">Discord</a>!',
+                        '¿Las carreras ya planeadas no encajan en tu agenda? ¿O buscas a alguien contra quien correr con opciones o ajustes menos comunes? ¡Únete a una carrera improvisada! Encontrarás jugadores dispuestos a jugar a cualquier hora del día. Comprueba el canal #race-planning en nuestro <a href="https://discord.gg/alttprandomizer" target="_blank">Discord</a> para saber qué se está organizando.',
                     ],
                 ],
             ],
@@ -44,49 +45,49 @@ return [
                 [
                     'header' => '',
                     'content' => [
-                        '¡Unete a nosotros en emocionante accion de torneo con comentario experto y jugadores de elite! Hay torneos operando todo el tiempo, ¡unete a <a href="https://discord.gg/alttprandomizer" target="_blank">Discord</a> para estar al dia!',
+                        '¡Únete a otros jugadores en la emocionante experiencia de participar en un torneo de ALTTPR, con comentaristas expertos y jugadores de élite! Hay torneos operando todo el tiempo: únete a <a href="https://discord.gg/alttprandomizer" target="_blank">Discord</a> para estar al día.',
                     ],
                 ],
                 [
                     'header' => 'ALTTP Randomizer Torneo Principal',
                     'content' => [
-                        '¡Se testigo de los mejores corredores compitiendo por el trofeo y ganar para si mismos el preciado sitio en la Baldosa Telepatica de Houlihan! ¿Crees que tienes lo que hace falta para competir con los mejoreS? Unete a <a href="https://discord.gg/B2kGXxTD6g" target="_blank">ALTTPR Tournaments Discord</a> y estate atento a carreras clasificatorias!',
+                        '¡Sé testigo y partícipe de cómo los mejores corredores compiten en el torneo más importante del año por el trofeo, la gloria y llegar a ganar un puesto en la Baldosa Telepatica de Houlihan! ¿Crees que tienes lo que hace falta para competir con los mejores? Únete a <a href="https://discord.gg/B2kGXxTD6g" target="_blank">ALTTPR Tournaments Discord</a> y estate atento a carreras clasificatorias!',
                     ],
                 ],
                 [
-                    'header' => 'Copa Desafio',
+                    'header' => 'Copa Desafío',
                     'content' => [
-                        'La <a href="https://discord.gg/982W72p" target="_blank">Copa Desafio</a> es un torneo complementario para aquellos que no se clasifican para el torneo principal.',
+                        'La <a href="https://discord.gg/982W72p" target="_blank">Copa Desafío</a> es un torneo complementario para aquellos que no logran clasificarse para la fase de grupos del torneo principal, tras las clasificatorias. Con un menor nivel, resulta ideal para aquellos que acaban de empezar o que tienen menor habilidad y experiencia. Eso sí, las partidas son igual de emocionantes que en el torneo principal, ¡no te las pierdas!',
                     ],
                 ],
                 [
                     'header' => 'Liga ALTTPR',
                     'content' => [
-                        'La <a href="https://alttprleague.com/" target="_blank">Liga ALTTPR</a> es un torneo de ALTTPR por equipos anual. Los jugadores formaran equipos de 3 y competiran otros equipos en diferentes modos de juego.',
+                        'La <a href="https://alttprleague.com/" target="_blank">Liga ALTTPR</a> es un torneo de ALTTPR por equipos anual. Los jugadores forman equipos de 3 y compiten con otros equipos en diferentes modos de juego.',
                     ],
                 ],
                 [
-                    'header' => 'Go Mode Podcast Torneo de Mentores',
+                    'header' => 'Torneo de Mentores del Go Mode Podcast',
                     'content' => [
-                        '<a href="https://gomodepodcast.com/" target="_blank">Go Mode Podcast</a> opera un torneo anual diseñado para jugadores noveles. Los jugadores tienen un mentor que ayudaran con algunas de sus carreras, con la intencion de preparar a los jugadores para torneos grandes o pequeños.',
+                        '<a href="https://gomodepodcast.com/" target="_blank">Go Mode Podcast</a> habilita un torneo anual diseñado para jugadores noveles. A cada jugador se le asigna un mentor, que ayudará y ensenará al principante los diferentes conceptos, estrategias y trucos para afrontar las carreras de la mejor manera posible, con la intencion de preparar a los jugadores para otros torneos futuros, grandes o pequeños.',
                     ],
                 ],
                 [
-                    'header' => 'ALTTPR Torneo Spoiler',
+                    'header' => 'Torneo Spoiler de ALTTPR',
                     'content' => [
-                        'El <a href="https://discord.gg/Jg34MuE" target="_blank">ALTTPR Torneo Spoiler</a> es un torneo anual que da a los jugadores el Spoiler Log para estudiar antes de la carrera. Este torneo es una prueba de ejecucion y toma de decisiones.',
+                        'El <a href="https://discord.gg/Jg34MuE" target="_blank">Torneo Spoiler de ALTTPR</a> es un torneo anual que da a los jugadores el Spoiler Log para que puedan estudiarlo antes de la carrera. Este torneo es una prueba de ejecución y toma de decisiones, pues saber elaborar la mejor ruta para obtener los objetos necesarios es la clave de la victoria.',
                     ],
                 ],
                 [
-                    'header' => 'ALTTPR Torneo con Glitches',
+                    'header' => 'Torneo ALTTPR con Glitches',
                     'content' => [
-                        '<a href="https://discord.gg/adac5FG" target="_blank">ALTTPR Glitched Tournaments</a> se centra en torneos que implican el uso de "glitches mayores" para terminar el juego en formas tan divertidas como inusuales.',
+                        '<a href="https://discord.gg/adac5FG" target="_blank">El Torneo de ALTTPR con Glitches</a> se centra en modalidades que implican el uso de "glitches mayores" para terminar el juego en formas tan divertidas como inusuales.',
                     ],
                 ],
                 [
-                    'header' => 'ALTTPR Torneo Crossworld Keysanity',
+                    'header' => 'Torneo ALTTPR Crossworld Keysanity ',
                     'content' => [
-                        'El <a href="https://discord.gg/umCCQgr" target="_blank">Torneo ALTTPR Crossworld Keysanity</a> es un torneo de Entradas Aleatorias de un mundo a otro, con Keysanity (aka"Crosskeys"). ¡Los jugadores tendran su memoria y habilidad de tomar notas puestas a prueba para ser el mejor en este alocado modo!',
+                        'El <a href="https://discord.gg/umCCQgr" target="_blank">Torneo ALTTPR Crossworld Keysanity</a> es un torneo de con entradas aleatorizadas de un mundo a otro, con Keysanity (modalidad también conocida como "Crosskeys"). Los jugadores tendrán su memoria y su habilidad de poder tomar notas puestas a prueba para ser el mejor en este alocado modo, en el que no perderse y explorar resulta decisivo.',
                     ],
                 ],
             ],
@@ -96,7 +97,7 @@ return [
             'languages' => [
                 [
                     'header' => 'Spanish',
-                    'description' => 'Something about the community here.',
+                    'description' => 'Join the Spanish Speak.',
                     'sections' => [
                         [
                             'header' => 'Placeholder Tournament',

--- a/resources/lang/es/resources.php
+++ b/resources/lang/es/resources.php
@@ -24,7 +24,7 @@ return [
                     . '<li><a href="https://alttprlinks.page.link/3vXm" target="_blank" rel="noopener noreferrer">Glosario general de ayuda</a></li>'
                     . '<li><a href="https://alttprlinks.page.link/HVFx" target="_blank" rel="noopener noreferrer">Recursos sobre glitches</a></li>'
                     . '<li><a href="https://alttprlinks.page.link/on1o" target="_blank" rel="noopener noreferrer"><i>Trackers</i> / HUDs</a></li>'
-                    . '<li><a href="http://alttp.mymm1.com/srl/" target="_blank" rel="noopener noreferrer">Empezar en SRL</a></li>'
+                    . '<li><a href="https://racetime.gg/about/help" target="_blank" rel="noopener noreferrer">Empezar en RaceTime.gg</a></li>'
                 . '</ul>',
             ],
         ],

--- a/resources/lang/es/rom.php
+++ b/resources/lang/es/rom.php
@@ -57,5 +57,7 @@ return [
         'quickswap' => 'Cambio Rápido de Objetos',
         'palette_shuffle' => 'Paletas aleatorias',
         'race_warning' => 'No funciona en ROMs para carreras',
+        'reduce_flashing' => 'Reducir Parpadeos intermitentes',
+        'reduce_flashing_warning' => 'Esta opcion solo reduce el efecto del parpadeo, tu sensibilidad a estos efectos aun puede variar.',
     ],
 ];

--- a/resources/lang/fr/customizer.php
+++ b/resources/lang/fr/customizer.php
@@ -29,11 +29,11 @@ return [
         ],
         'canBunnySurf' => [
             'title' => 'Lapin Surfeur',
-            'description' => 'Il peut être requis de marcher sur l\'eau en tant que Lapin.',
+            'description' => 'Il peut être requis de marcher sur l’eau en tant que Lapin.',
         ],
         'canDungeonRevive' => [
             'title' => 'Résurrection en Donjon',
-            'description' => 'Il peut être requis d\'entrer dans un donjon en Lapin, et de mourir, afin de redevenir Link pour collecter des objets.',
+            'description' => 'Il peut être requis d’entrer dans un donjon en Lapin, et de mourir, afin de redevenir Link pour collecter des objets.',
         ],
         'canFakeFlipper' => [
             'title' => 'Fausses Palmes',
@@ -41,11 +41,11 @@ return [
         ],
         'canMirrorClip' => [
             'title' => 'Clip au Miroir',
-            'description' => 'Il peut être requis d\'utiliser des rebonds avec le Miroir pour se transporter hors des limites du jeu.',
+            'description' => 'Il peut être requis d’utiliser des rebonds avec le Miroir pour se transporter hors des limites du jeu.',
         ],
         'canMirrorWrap' => [
             'title' => 'Wrap au Miroir',
-            'description' => 'Il peut être requis d\utiliser le Miroir afin de défiler l\'écran à un endroit normalement inaccessible.',
+            'description' => 'Il peut être requis d\utiliser le Miroir afin de défiler l’écran à un endroit normalement inaccessible.',
         ],
         'canOneFrameClipOW' => [
             'title' => 'Clip d\Une Image (Monde extérieur)',
@@ -57,27 +57,27 @@ return [
         ],
         'canOWYBA' => [
             'title' => 'YBA (Monde extérieur)',
-            'description' => 'Il peut être requis d\'utiliser des Bocaux dans le monde extérieur afin de se rendre à un endroit normalement inaccessible.',
+            'description' => 'Il peut être requis d’utiliser des Bocaux dans le monde extérieur afin de se rendre à un endroit normalement inaccessible.',
         ],
         'canSuperBunny' => [
             'title' => 'Super Lapin',
-            'description' => 'Il peut être requis d\'activer la technique du Super Lapin pour accéder à certains endroits et objets.',
+            'description' => 'Il peut être requis d’activer la technique du Super Lapin pour accéder à certains endroits et objets.',
         ],
         'canSuperSpeed' => [
             'title' => 'Super Vitesse',
-            'description' => 'Il peut être requis d\'utiliser la Super Vitesse afin de passer à travers une barrière dans le monde extérieur.',
+            'description' => 'Il peut être requis d’utiliser la Super Vitesse afin de passer à travers une barrière dans le monde extérieur.',
         ],
         'canWaterFairyRevive' => [
-            'title' => 'Résurrection par une Fée dans l\'Eau',
-            'description' => 'Cette technique est ridicule et requiert un grand nombre d\'objets.',
+            'title' => 'Résurrection par une Fée dans l’Eau',
+            'description' => 'Cette technique est ridicule et requiert un grand nombre d’objets.',
         ],
         'canWaterWalk' => [
-            'title' => 'Marche sur l\'Eau',
-            'description' => 'Il peut être requis d\'utiliser les Bottes pour marcher sur l\eau.',
+            'title' => 'Marche sur l’Eau',
+            'description' => 'Il peut être requis d’utiliser les Bottes pour marcher sur l\eau.',
         ],
         'noLogic' => [
             'title' => 'Désactiver la Logique',
-            'description' => 'Quand ceci est activé, les dés en sont jetés, et rien d\'autre n\'importe..',
+            'description' => 'Quand ceci est activé, les dés en sont jetés, et rien d’autre n’importe..',
         ],
     ]
 ];

--- a/resources/lang/fr/options.php
+++ b/resources/lang/fr/options.php
@@ -617,6 +617,12 @@ return [
                         'Randomise les palettes de couleurs du jeu. Ceci signifie que toute peut avoir l\'air extrêmement bizarre. Utilisez avec précaution!',
                     ],
                 ],
+                'reduce_flashing' => [
+                    'header' => __('rom.settings.reduce_flashing'),
+                    'content' => [
+                        'Réduit drastiquement les effets de clignotement du jeu, ou les désactive. Svp, faire attention, votre sensibilité aux effets de clignotement peut varier.',
+                    ],
+                ],
             ],
         ],
         'item_pool' => 'Groupe d’objets',

--- a/resources/lang/fr/options.php
+++ b/resources/lang/fr/options.php
@@ -602,13 +602,13 @@ return [
                 'music' => [
                     'header' => __('rom.settings.music'),
                     'content' => [
-                        'Active ou désactive la musique originale du jeu. Vous ne devez pas désactiver ceci si vous souhaitez utiliser les packs de musique MSU-1. Si laissé activé avec un pack MSU-1, la musique originale ne jouera que en cas d\'échec du pack MSU-1 (au lieu de silence).',
+                        'Active ou désactive la musique originale du jeu.',
                     ],
                 ],
                 'quickswap' => [
                     'header' => __('rom.settings.quickswap'),
                     'content' => [
-                        'Autorise les objets à être changés avec les boutons L ou R sans ouvrir le menu. Ceci n\'est pas disponible pour les ROMs de course (sauf lorsque les entrées sont aléatoires).',
+                        'Autorise les objets à être changés avec les boutons L ou R sans ouvrir le menu.',
                     ],
                 ],
                 'palette_shuffle' => [

--- a/resources/lang/fr/options.php
+++ b/resources/lang/fr/options.php
@@ -9,7 +9,7 @@ return [
                 [
                     'header' => __('randomizer.glitches_required.options.none'),
                     'content' => [
-                        'Ce paramètre ne demande la connaissance d\'aucun glitch ou technique.',
+                        'Ce paramètre ne demande la connaissance d’aucun glitch ou technique.',
                     ],
                 ],
                 [
@@ -22,7 +22,7 @@ return [
                             . '<li>Résurrection du Lapin en donjon</li>'
                             . '<li>Super Lapin</li>'
                             . '<li>Lapin Surfeur</li>'
-                            . '<li>Marche sur l\'Eau</li>'
+                            . '<li>Marche sur l’Eau</li>'
                             . '</ul>',
                     ],
                 ],
@@ -32,21 +32,21 @@ return [
                         'Ce paramètre requiert la connaissance de glitchs plus avancés. Spécifiquement:',
                         '<ul>'
                             . '<li>Fausses flûtes (Monde Extérieur) (voir YBA)</li>'
-                            . '<li>Wraps d\'écrans (Monde Extérieur)</li>'
-                            . '<li>Clips sans Bottes (inclut Clip d\'Une Image) (Monde Extérieur et Inférieur)</li>'
+                            . '<li>Wraps d’écrans (Monde Extérieur)</li>'
+                            . '<li>Clips sans Bottes (inclut Clip d’Une Image) (Monde Extérieur et Inférieur)</li>'
                             . '</ul>',
                         'Quelques changements additionnels ont été faits:',
                         '<ul>'
                             . '<li>Les "faux mondes" existent à nouveau, comme dans le jeu original (Exemple : Mourir dans un donjon du monde des Ténèbres sans avoir défait Aganhim vous mettra dans le Faux Monde des Ténèbres)</li>'
                             . '<li>Crystals always drop regardless of pendant conflicts (QoL fix from the original)Les Cristaux vont toujours apparaître, malgré les conflits de pendantifs (correction du jeu original pour la qualité de vie)</li>'
-                            . '<li>Les niveaux d\'eau de Swamp Palace ne se re-drainent plus quand vous quittez l\'écran du Monde Extérieur (sauf la première piece)</li>'
+                            . '<li>Les niveaux d’eau de Swamp Palace ne se re-drainent plus quand vous quittez l’écran du Monde Extérieur (sauf la première piece)</li>'
                             . '</ul>',
                     ],
                 ],
                 [
                     'header' => __('randomizer.glitches_required.options.no_logic'),
                     'content' => [
-                        'Aucune logique n\'est appliquée, rien du tout. Les objets peuvent être n\'importe où. Il peut être impossible d\'obtenir des objets, mais, grâce à la force des Glitchs Majeurs, il est extrêmement rare qu\'un jeu ne puisse être battu. Ce paramètre requiert généralement un usage extensif de glitchs normalement exclus des règles des autres logiques (notamment, l\'EG, les Door Glitches et la Résurrection du Lapin en Extérieur).',
+                        'Aucune logique n’est appliquée, rien du tout. Les objets peuvent être n’importe où. Il peut être impossible d’obtenir des objets, mais, grâce à la force des Glitchs Majeurs, il est extrêmement rare qu’un jeu ne puisse être battu. Ce paramètre requiert généralement un usage extensif de glitchs normalement exclus des règles des autres logiques (notamment, l’EG, les Door Glitches et la Résurrection du Lapin en Extérieur).',
                     ],
                 ],
             ],
@@ -57,13 +57,13 @@ return [
                 [
                     'header' => __('randomizer.item_placement.options.basic'),
                     'content' => [
-                        'Ce paramètre est conçu pour des joueurs plus nouveaux, ou recherchant une expérience de détente. Il existe des restrictions de logique supplémentaires afin d\'éviter le placement d\'objets à des endroits requiérant des connaissances trop spécifiques pour être accédés (Exemple: la Bumper Cave sans le Grappin). Le jeu s\'assure également d\'éviter une exécution trop compliquée pour progresser. Par exemple, si vous devez finir un donjon du Monde des Ténèbres qui est normalement parmi les derniers, vous aurez toujours accès à des améliorations d\'épées ou de défense quelque part dans le monde.',
+                        'Ce paramètre est conçu pour des joueurs plus nouveaux, ou recherchant une expérience de détente. Il existe des restrictions de logique supplémentaires afin d’éviter le placement d’objets à des endroits requiérant des connaissances trop spécifiques pour être accédés (Exemple: la Bumper Cave sans le Grappin). Le jeu s’assure également d’éviter une exécution trop compliquée pour progresser. Par exemple, si vous devez finir un donjon du Monde des Ténèbres qui est normalement parmi les derniers, vous aurez toujours accès à des améliorations d’épées ou de défense quelque part dans le monde.',
                     ],
                 ],
                 [
                     'header' => __('randomizer.item_placement.options.advanced'),
                     'content' => [
-                        'Ce paramètre est conçu pour des joueurs plus réguliers, et les coureurs. L\'intention de ce paramètre est de maximiser les possibilités d\'objets pouvant être atteints sans glitchs. Seule une exception est faite, les pièces noires ne sont pas requises. Aucune autre exception n\'est faite regardant la possibilité d\'un objet finissant dans un endroit obscur, ou la difficulté à atteindre un emplacement. Il est attendu qu\'un joueur qui choisit ce paramètre est suffisamment familiarisé et expérimenté avec le jeu original.',
+                        'Ce paramètre est conçu pour des joueurs plus réguliers, et les coureurs. L’intention de ce paramètre est de maximiser les possibilités d’objets pouvant être atteints sans glitchs. Seule une exception est faite, les pièces noires ne sont pas requises. Aucune autre exception n’est faite regardant la possibilité d’un objet finissant dans un endroit obscur, ou la difficulté à atteindre un emplacement. Il est attendu qu’un joueur qui choisit ce paramètre est suffisamment familiarisé et expérimenté avec le jeu original.',
                     ],
                 ],
             ],
@@ -74,31 +74,31 @@ return [
                 [
                     'header' => '',
                     'content' => [
-                        'Lorsque les cartes sont déplacées hors des donjons, la carte du Monde ne renseignera plus sur les prix (cristaux/pendantifs) des donjons sans avoir la carte du donjon. Cependant, les cartes sont toujours requises par la logique, que la logique de placement des objets soit Basique ou Avancée. Notez que le boss d\'un donjon peut tenir sa propre carte.',
+                        'Lorsque les cartes sont déplacées hors des donjons, la carte du Monde ne renseignera plus sur les prix (cristaux/pendantifs) des donjons sans avoir la carte du donjon. Cependant, les cartes sont toujours requises par la logique, que la logique de placement des objets soit Basique ou Avancée. Notez que le boss d’un donjon peut tenir sa propre carte.',
                     ],
                 ],
                 [
                     'header' => __('randomizer.dungeon_items.options.standard'),
                     'content' => [
-                        'Les objets propres aux donjons sont randomisés, mais toujours dans leur donjon d\'origine.',
+                        'Les objets propres aux donjons sont randomisés, mais toujours dans leur donjon d’origine.',
                     ],
                 ],
                 [
                     'header' => __('randomizer.dungeon_items.options.mc'),
                     'content' => [
-                        'Seules les clefs restent randomisées à l\'intérieur de leurs donjons spécifiques. Les cartes et boussoles peuvent finir n\'importe où, y compris parfois dans leur donjon d\'origine.',
+                        'Seules les clefs restent randomisées à l’intérieur de leurs donjons spécifiques. Les cartes et boussoles peuvent finir n’importe où, y compris parfois dans leur donjon d’origine.',
                     ],
                 ],
                 [
                     'header' => __('randomizer.dungeon_items.options.mcs'),
                     'content' => [
-                        'Seules les grandes clefs restent randomisées à l\'intérieur de leurs donjons spécifiques. Les petites clefs, cartes et boussoles peuvent finir n\'importe où, y compris parfois dans leur donjon d\'origine.',
+                        'Seules les grandes clefs restent randomisées à l’intérieur de leurs donjons spécifiques. Les petites clefs, cartes et boussoles peuvent finir n’importe où, y compris parfois dans leur donjon d’origine.',
                     ],
                 ],
                 [
                     'header' => __('randomizer.dungeon_items.options.full'),
                     'content' => [
-                        'Les cartes, boussoles, petites et grandes clefs peuvent se retrouver n\'importe où dans le monde L\'aléatoire peut décider malgré tout de placer l\'une ou l\'autre dans son donjon d\'origine.',
+                        'Les cartes, boussoles, petites et grandes clefs peuvent se retrouver n’importe où dans le monde L’aléatoire peut décider malgré tout de placer l’une ou l’autre dans son donjon d’origine.',
                     ],
                 ],
             ],
@@ -109,19 +109,19 @@ return [
                 [
                     'header' => __('randomizer.accessibility.options.items'),
                     'content' => [
-                        'Ce paramètre s\'assure que tous les objets de l\'inventaire peuvent être obtenus, mais peut décider d\'enfermer l\'une ou l\'autre clef. Par exemple, des grandes clefs non requises peuvent être dans le grand coffre, ou certaines petites clefs peuvent être derrière des portes à clefs (que vous pourriez accéder, ou pas, selon votre usage personnel). En pratique, quasi l\'entièreté du monde devrait être accessible, avec ce paramètre.',
+                        'Ce paramètre s’assure que tous les objets de l’inventaire peuvent être obtenus, mais peut décider d’enfermer l’une ou l’autre clef. Par exemple, des grandes clefs non requises peuvent être dans le grand coffre, ou certaines petites clefs peuvent être derrière des portes à clefs (que vous pourriez accéder, ou pas, selon votre usage personnel). En pratique, quasi l’entièreté du monde devrait être accessible, avec ce paramètre.',
                     ],
                 ],
                 [
                     'header' => __('randomizer.accessibility.options.locations'),
                     'content' => [
-                        'Ce paramètre s\'assure que vous puissiez toujours atteindre les 216 emplacements du jeu, peu importe si les clefs sont usées de façon non efficace dans les donjons. Plus spécifiquement, les grandes clefs ne seront jamais dans leur propre grand coffre, et certains coffres derrière des portes à clefs ne contiendront pas de petite clef.',
+                        'Ce paramètre s’assure que vous puissiez toujours atteindre les 216 emplacements du jeu, peu importe si les clefs sont usées de façon non efficace dans les donjons. Plus spécifiquement, les grandes clefs ne seront jamais dans leur propre grand coffre, et certains coffres derrière des portes à clefs ne contiendront pas de petite clef.',
                     ],
                 ],
                 [
                     'header' => __('randomizer.accessibility.options.none'),
                     'content' => [
-                        'Ce paramètre s\'assure seulement de la complétion du jeu. Vous pouvez ne pas être capable de trouver un objet non requis (par exemple, la Baguette de Feu si elle n\'est pas requise) ou d\'entrer un donjon non requis.',
+                        'Ce paramètre s’assure seulement de la complétion du jeu. Vous pouvez ne pas être capable de trouver un objet non requis (par exemple, la Baguette de Feu si elle n’est pas requise) ou d’entrer un donjon non requis.',
                     ],
                 ],
             ],
@@ -132,19 +132,19 @@ return [
                 [
                     'header' => __('randomizer.goal.options.ganon'),
                     'content' => [
-                        'Ce paramètre requiert la complétion de la Tour de Ganon en plus de défaire Ganon. Le nombre de cristaux requis pour la Tour de Ganon dépend d\'un autre paramètre.',
+                        'Ce paramètre requiert la complétion de la Tour de Ganon en plus de défaire Ganon. Le nombre de cristaux requis pour la Tour de Ganon dépend d’un autre paramètre.',
                     ],
                 ],
                 [
                     'header' => __('randomizer.goal.options.fast_ganon'),
                     'content' => [
-                        'Ce paramètre demande seulement de défaire Ganon, sans la complétion de la Tour de Ganon. Pour que cela fonctionne, le trou au sommet de la Pyramide existe toujours (sauf si vous jouez un Randomiseur d\'Entrées). Le nombre de cristaux requis pour battre Ganon dépend d\'un autre paramètre.',
+                        'Ce paramètre demande seulement de défaire Ganon, sans la complétion de la Tour de Ganon. Pour que cela fonctionne, le trou au sommet de la Pyramide existe toujours (sauf si vous jouez un Randomiseur d’Entrées). Le nombre de cristaux requis pour battre Ganon dépend d’un autre paramètre.',
                     ],
                 ],
                 [
                     'header' => __('randomizer.goal.options.dungeons'),
                     'content' => [
-                        'Ce paramètre requiert la complétion de tous les donjons. Ceci inclut les 3 donjons du Monde de la Lumière, les 7 du Monde des Ténèbres, la Tour d\'Aganhim et la Tour de Ganon.',
+                        'Ce paramètre requiert la complétion de tous les donjons. Ceci inclut les 3 donjons du Monde de la Lumière, les 7 du Monde des Ténèbres, la Tour d’Aganhim et la Tour de Ganon.',
                     ],
                 ],
                 [
@@ -156,7 +156,7 @@ return [
                 [
                     'header' => __('randomizer.goal.options.triforce-hunt'),
                     'content' => [
-                        'La Triforce a été brisée en 30 morceaux, éparpillés à travers Hyrule! Vous devez retrouver 20 des 30 pièces, et les emmener à Murahdhala pour recevoir la Triforce. Qui est ce Murahdahla, me direz-vous? Mais enfin, il est évidemment le petit frère de Sahasrahla et Aginah! De retour de ses vacances à Lorule, vous le trouverez dans la cour du Château d\'Hyrule.',
+                        'La Triforce a été brisée en 30 morceaux, éparpillés à travers Hyrule! Vous devez retrouver 20 des 30 pièces, et les emmener à Murahdhala pour recevoir la Triforce. Qui est ce Murahdahla, me direz-vous? Mais enfin, il est évidemment le petit frère de Sahasrahla et Aginah! De retour de ses vacances à Lorule, vous le trouverez dans la cour du Château d’Hyrule.',
                     ],
                 ],
             ],
@@ -164,13 +164,13 @@ return [
         'tower_open' => [
             'header' => __('randomizer.tower_open.title'),
             'content' => [
-                'Ce paramètre vous laisse choisir le nombre de cristaux requis pour ouvrir la Tour de Ganon. Si vous choisissez 0, alors la Tour est accessible sans rien. Si vous choisissez "Aléatoire", alors il y aura un panneau devant la Tour vous indiquant combien de cristaux sont requis. En mode Inversé, le panneau sera en dehors du Château d\'Hyrule, en toute accordance.',
+                'Ce paramètre vous laisse choisir le nombre de cristaux requis pour ouvrir la Tour de Ganon. Si vous choisissez 0, alors la Tour est accessible sans rien. Si vous choisissez "Aléatoire", alors il y aura un panneau devant la Tour vous indiquant combien de cristaux sont requis. En mode Inversé, le panneau sera en dehors du Château d’Hyrule, en toute accordance.',
             ],
         ],
         'ganon_open' => [
             'header' => __('randomizer.ganon_open.title'),
             'content' => [
-                'Ce paramètre vous laisse choisir le nombre de cristaux requis pour que Ganon soit vulnérable à vos attaques! Si vous choisissez 0, alors il peut être battu dès que vous le trouvez. Si Aléatoire est choisi, alors un panneau vous informera du nombre requis sur la Pyramide. En mode Inversé, ce panneau se trouvera au Château d\'Hyrule, en toute accordance.',
+                'Ce paramètre vous laisse choisir le nombre de cristaux requis pour que Ganon soit vulnérable à vos attaques! Si vous choisissez 0, alors il peut être battu dès que vous le trouvez. Si Aléatoire est choisi, alors un panneau vous informera du nombre requis sur la Pyramide. En mode Inversé, ce panneau se trouvera au Château d’Hyrule, en toute accordance.',
             ],
         ],
         'world_state' => [
@@ -179,13 +179,13 @@ return [
                 [
                     'header' => __('randomizer.world_state.options.standard'),
                     'content' => [
-                        'Ce paramètre est le plus semblable au jeu original. Il maintient le prologue original, le sauvetage de Zelda dans le Château d\'Hyrule, et votre parcours avec elle jusqu\'au Sanctuaire. Ceci doit être fait afin de gagner votre accès au reste de Hyrule. Votre oncle vous donnera toujours un objet pour vaincre les ennemis du château (mais pas forcément une épée). Les égouts seront éclairés par Zelda jusqu\'au sanctuaire, mais toute visite plus tard dans le jeu demandera la Lampe pour voir dans le noir, et ceci inclut les Egouts.',
+                        'Ce paramètre est le plus semblable au jeu original. Il maintient le prologue original, le sauvetage de Zelda dans le Château d’Hyrule, et votre parcours avec elle jusqu’au Sanctuaire. Ceci doit être fait afin de gagner votre accès au reste de Hyrule. Votre oncle vous donnera toujours un objet pour vaincre les ennemis du château (mais pas forcément une épée). Les égouts seront éclairés par Zelda jusqu’au sanctuaire, mais toute visite plus tard dans le jeu demandera la Lampe pour voir dans le noir, et ceci inclut les Egouts.',
                     ],
                 ],
                 [
                     'header' => __('randomizer.world_state.options.open'),
                     'content' => [
-                        'Ce paramètre démarre le jeu comme si le prologue a déjà été accompli. Zelda est déjà sauvée, et vous pouvez démarrer à la maison de Link ou au Sanctuaire. Aucun coffre de Hyrule n\'est ouvert, à vous de décider lesquels visiter, et à quel moment.',
+                        'Ce paramètre démarre le jeu comme si le prologue a déjà été accompli. Zelda est déjà sauvée, et vous pouvez démarrer à la maison de Link ou au Sanctuaire. Aucun coffre de Hyrule n’est ouvert, à vous de décider lesquels visiter, et à quel moment.',
                     ],
                 ],
                 [
@@ -193,25 +193,25 @@ return [
                     'content' => [
                         'Ce paramètre place Link dans le Monde des Ténèbres dès le début, vous devrez trouver Ganon dans le Monde de la Lumière! Plusieurs changements ont été faits pour que ce mode fonctionne mieux:',
                         '<ul>'
-                            . '<li>Les Tours de Ganon et d\'Aganhim ont échangé de place.</li>'
-                            . '<li>Ganon a abandonné la Pyramide, et vit sous le Château d\'Hyrule.</li>'
+                            . '<li>Les Tours de Ganon et d’Aganhim ont échangé de place.</li>'
+                            . '<li>Ganon a abandonné la Pyramide, et vit sous le Château d’Hyrule.</li>'
                             . '<li>Les portails vous emmènent désormais, depuis le Monde des Ténèbres, vers le Monde de la Lumière.</li>'
-                            . '<li>Link sera un Lapin dans le Monde de la Lumière s\'il n\'a pas la Perle de Lune.</li>'
+                            . '<li>Link sera un Lapin dans le Monde de la Lumière s’il n’a pas la Perle de Lune.</li>'
                             . '<li>Le Miroir Magique vous emmène désormais, depuis le Monde de la Lumière, vers le Monde des Ténèbres.</li>'
-                            . '<li>Les cristaux ouvrent désormais la porte menant à la Tour d\'Aganhim. La Tour de Ganon est ouverte.</li>'
+                            . '<li>Les cristaux ouvrent désormais la porte menant à la Tour d’Aganhim. La Tour de Ganon est ouverte.</li>'
                             . '</ul>',
                         'Quelques autres modifications ont été faites afin que le jeu fonctionne proprement:',
                         '<ul>'
                             . '<li>La maison de Link et le marchand de bombes ont échangé de place.</li>'
-                            . '<li>La flûte ne fonctionne que dans le Monde des Ténèbres. Elle s\'active toujours à son emplacement original.</li>'
-                            . '<li>Beaucoup d\'emplacements dans le Monde de la Lumière ont été retravaillés afin de leur donner un accès, puisqu\'ils ne peuvent plus être accédés avec le Miroir.</li>'
+                            . '<li>La flûte ne fonctionne que dans le Monde des Ténèbres. Elle s’active toujours à son emplacement original.</li>'
+                            . '<li>Beaucoup d’emplacements dans le Monde de la Lumière ont été retravaillés afin de leur donner un accès, puisqu’ils ne peuvent plus être accédés avec le Miroir.</li>'
                             . '<li>Les grottes de la Montagne de la Mort ont été changées. Vous pouvez désormais accéder la Montagne de la Mort des Ténèbres depuis le reste du Monde des Ténèbres. </li>'
-                            . '<li>Le Vieil Homme de la Montagne de la Mort est dans le Monde des Ténèbres. Vous devrez l\'emmener à sa maison dans le Monde de la Lumière.</li>'
+                            . '<li>Le Vieil Homme de la Montagne de la Mort est dans le Monde des Ténèbres. Vous devrez l’emmener à sa maison dans le Monde de la Lumière.</li>'
                             . '<li>La Montagne de la Mort des Ténèbres a quelques escaliers supplémentaires pour accéder la Tour de Ganon et à sa section est.</li>'
                             . '<li>Les murs de Ice Palace ont fondu, laissant un accès libre depuis le Monde des Ténèbres.</li>'
                             . '<li>Vous pouvez monter sur Turtle Rock en sautant sur sa queue!</li>'
                             . '</ul>',
-                        'Gardez à l\'esprit que Link le Lapin peut utiliser le Libre de Mudora, parler à des PNJs, et ramasser des objets simplement sur le sol. Les jeux inversés peuvent être <strong>vraiment difficiles</strong>, et ne sont donc pas une recommandation pour une première fois.',
+                        'Gardez à l’esprit que Link le Lapin peut utiliser le Libre de Mudora, parler à des PNJs, et ramasser des objets simplement sur le sol. Les jeux inversés peuvent être <strong>vraiment difficiles</strong>, et ne sont donc pas une recommandation pour une première fois.',
                     ],
                 ],
                 [
@@ -222,31 +222,31 @@ return [
                             'header' => 'Arc à Rubis',
                             'content' => [
                                 '<ul>'
-                                    . '<li>L\'Arc n\'use plus de flèches, mais des rubis!!</li>'
+                                    . '<li>L’Arc n’use plus de flèches, mais des rubis!!</li>'
                                     . '<li>Le premier Arc progressif ne tire que des flèches en bois.</li>'
                                     . '<li>Le second Arc progressif peut tirer des flèches en bois ou en argent.</li>'
-                                    . '<li>Cependant, aucun arc ne peut être utilisé avant d\'acheter un Carquois à Rubis.</li>'
+                                    . '<li>Cependant, aucun arc ne peut être utilisé avant d’acheter un Carquois à Rubis.</li>'
                                     . '<li>Le Carquois à Rubis apparaît dans un magasin aléatoire, pour la modique somme de 80 rubis!</li>'
-                                    . '<li>Chaque flèche en bois coûte 10 rubis, tandis qu\'une flèche d\'argent coûte 50 rubis..</li>'
+                                    . '<li>Chaque flèche en bois coûte 10 rubis, tandis qu’une flèche d’argent coûte 50 rubis..</li>'
                                     . '</ul>',
                             ],
                         ],
                         [
                             'header' => 'Magasins',
                             'content' => [
-                                'Cinq des neufs magasins du jeu sont choisis pour avoir de nouveaux objets. Ceci n\'inclut pas le Magasin de Bombes ni celui de Potions. L\'un deux contiendra le Carquois à Rubis pour 80 rubis. Additionnellement, plusieurs magasins vendront des petites clefs pour le prix de 100 rubis, sans limite d\'achat.',
+                                'Cinq des neufs magasins du jeu sont choisis pour avoir de nouveaux objets. Ceci n’inclut pas le Magasin de Bombes ni celui de Potions. L’un deux contiendra le Carquois à Rubis pour 80 rubis. Additionnellement, plusieurs magasins vendront des petites clefs pour le prix de 100 rubis, sans limite d’achat.',
                             ],
                         ],
                         [
                             'header' => 'Petites Clefs',
                             'content' => [
-                                'Les petites clefs deviennent génériques : Elles ne sont plus attachées à un donjon, elles peuvent être utilisées n\'importe où. Elles pevent également être trouvées n\'importe où (par exemple, dans le monde extérieur). Les clefs sous les pots et tenues par des ennemis sont inchangées. Dix clefs sont retirées, relativement à la quantité normale (15 clefs si vous jouez en Difficile ou plus). Les grandes clefs, cartes, boussoles sont toujours dans leur donjon de base.',
+                                'Les petites clefs deviennent génériques : Elles ne sont plus attachées à un donjon, elles peuvent être utilisées n’importe où. Elles pevent également être trouvées n’importe où (par exemple, dans le monde extérieur). Les clefs sous les pots et tenues par des ennemis sont inchangées. Dix clefs sont retirées, relativement à la quantité normale (15 clefs si vous jouez en Difficile ou plus). Les grandes clefs, cartes, boussoles sont toujours dans leur donjon de base.',
                             ],
                         ],
                         [
                             'header' => 'Grottes à Choix',
                             'content' => [
-                                'Cinq grottes ne menant nulle part (une seule entrée et aucun objet à l\'intérieur) sont désormais des Grottes à Choix. Quatre de ces grottes proposent un Réceptacle de Cœur ou une potion bleue, et la cinquième possède une amélioration d\'épée (qui ne sera pas disponible ailleurs). Cela signifie qu\'il n\'y aura que trois épées parmi les objets randomisés. Les Réceptacles de Cœur, au contraire, sont ajoutés en bonus, mais vous êtes toujours limité à 20 cœurs maximum. La potion bleue requiert une bouteille vide.',
+                                'Cinq grottes ne menant nulle part (une seule entrée et aucun objet à l’intérieur) sont désormais des Grottes à Choix. Quatre de ces grottes proposent un Réceptacle de Cœur ou une potion bleue, et la cinquième possède une amélioration d’épée (qui ne sera pas disponible ailleurs). Cela signifie qu’il n’y aura que trois épées parmi les objets randomisés. Les Réceptacles de Cœur, au contraire, sont ajoutés en bonus, mais vous êtes toujours limité à 20 cœurs maximum. La potion bleue requiert une bouteille vide.',
                             ],
                         ],
                     ],
@@ -256,25 +256,25 @@ return [
         'entrance_shuffle' => [
             'header' => __('randomizer.entrance_shuffle.title'),
             'subheader' => [
-                'Ce paramètre randomise les endroits auxquels les entrées mènent. Par exemple, entrer dans le magasin de Kakariko, peut vous emmener dans une fontaine de fées, ou autre chose. Différents types d\'entrées sont groupés ensemble, et chaque groupe est ensuite randomisé. La façon dont ces groupes sont sélectionnées dépend du paramètre choisi. Les transitions dans le monde extérieur ne sont jamais aléatoires.',
+                'Ce paramètre randomise les endroits auxquels les entrées mènent. Par exemple, entrer dans le magasin de Kakariko, peut vous emmener dans une fontaine de fées, ou autre chose. Différents types d’entrées sont groupés ensemble, et chaque groupe est ensuite randomisé. La façon dont ces groupes sont sélectionnées dépend du paramètre choisi. Les transitions dans le monde extérieur ne sont jamais aléatoires.',
                 'Les grottes/donjons avec plusieurs entrées ont un comportement spécifique, sauf contre-indication:',
                 '<ul>'
-                    . '<li>Toutes les entrées restent groupées. Cela signifie que sortir d\'une grotte ou un donjon vous ramènera à l\'emplacement d\'entrée.</li>'
+                    . '<li>Toutes les entrées restent groupées. Cela signifie que sortir d’une grotte ou un donjon vous ramènera à l’emplacement d’entrée.</li>'
                     . '<li>Toutes les entrées pour une grotte ou un donjon qui a plusieurs entrées apparaîtront dans le même monde. (Une grotte ou un donjon ne reliera pas Monde de la Lumière et Monde des Ténèbres).</li>'
                     . '</ul>',
-                'La Maison de Link et l\'arrière du bar ne sont pas aléatoires. Notez toutefois que si vous jouez en ' . __('randomizer.world_state.options.inverted') . ' ' . __('randomizer.world_state.title') . ', la Maison de Link (dans le monde des Ténèbres) et le magasin de bombes (dans le monde de la Lumière) seront randomisés.',
+                'La Maison de Link et l’arrière du bar ne sont pas aléatoires. Notez toutefois que si vous jouez en ' . __('randomizer.world_state.options.inverted') . ' ' . __('randomizer.world_state.title') . ', la Maison de Link (dans le monde des Ténèbres) et le magasin de bombes (dans le monde de la Lumière) seront randomisés.',
             ],
             'sections' => [
                 'none' => [
                     'header' => __('randomizer.entrance_shuffle.options.none'),
                     'content' => [
-                        'Aucune entrée n\'est randomisée. Chaque entrée mènera à l\'endroit normal.',
+                        'Aucune entrée n’est randomisée. Chaque entrée mènera à l’endroit normal.',
                     ],
                 ],
                 'simple' => [
                     'header' => __('randomizer.entrance_shuffle.options.simple'),
                     'content' => [
-                        'Ce paramètre utilise le plus grand nombre de groupements de types d\'entrées. Ceci réduit énormément la randomisation, ce qui permet de garder les choses simples.',
+                        'Ce paramètre utilise le plus grand nombre de groupements de types d’entrées. Ceci réduit énormément la randomisation, ce qui permet de garder les choses simples.',
                         [
                             'header' => 'Donjons à Une Entrée',
                             'content' => [
@@ -284,7 +284,7 @@ return [
                         [
                             'header' => 'Donjons à Plusieurs Entrées (sauf Skull Woods)',
                             'content' => [
-                                'Chacune des 4 entrées du Château d\'Hyrule, de Desert palace et de Turtle Rock restent groupées ensemble. Chaque groupe de 4 est randomisé avec les autres en gardant les mêmes positions. Par exemple, si le Château d\'Hyrule et Desert Palace sont inversés, l\'entrée principale du Château d\'Hyrule sera l\'entrée principale de Desert Palace, l\'entrée gauche de Desert Palace mènera à l\'entrée gauche du Château d\'Hyrule, etc. Notez que la Tour d\{Aganhim n\'est pas randomisée en ' . __('randomizer.world_state.options.standard') . ' ' . __('randomizer.world_state.title') . '.',
+                                'Chacune des 4 entrées du Château d’Hyrule, de Desert palace et de Turtle Rock restent groupées ensemble. Chaque groupe de 4 est randomisé avec les autres en gardant les mêmes positions. Par exemple, si le Château d’Hyrule et Desert Palace sont inversés, l’entrée principale du Château d’Hyrule sera l’entrée principale de Desert Palace, l’entrée gauche de Desert Palace mènera à l’entrée gauche du Château d’Hyrule, etc. Notez que la Tour d\{Aganhim n’est pas randomisée en ' . __('randomizer.world_state.options.standard') . ' ' . __('randomizer.world_state.title') . '.',
                             ],
                         ],
                         [
@@ -296,19 +296,19 @@ return [
                         [
                             'header' => 'Grottes à Une Entrée',
                             'content' => [
-                                'Toutes les entrées sont groupées et mélangées ensemble. Ceci n\'inclut pas la Montagne de la Mort du Monde de la Lumière. (Exemple : Maisons).',
+                                'Toutes les entrées sont groupées et mélangées ensemble. Ceci n’inclut pas la Montagne de la Mort du Monde de la Lumière. (Exemple : Maisons).',
                             ],
                         ],
                         [
                             'header' => 'Grottes à Plusieurs Entrées',
                             'content' => [
-                                'Toutes les entrées sont groupées et mélangées ensemble. Les emplacements qui ont normalement 2 entrées resteront connectées ensemble avec une grotte à deux entrées (exemple : la maison de l\'Ancien dans Kakariko). Ceci n\'inclut pas la Montagne de la Mort du Monde de la Lumière.',
+                                'Toutes les entrées sont groupées et mélangées ensemble. Les emplacements qui ont normalement 2 entrées resteront connectées ensemble avec une grotte à deux entrées (exemple : la maison de l’Ancien dans Kakariko). Ceci n’inclut pas la Montagne de la Mort du Monde de la Lumière.',
                             ],
                         ],
                         [
                             'header' => 'Montagne de la Mort du Monde de la Lumière',
                             'content' => [
-                                'Toutes les entrées restent dans la région de la Montagne de la Mort de la Lumière et sont mélangées ensemble. Veuillez noter que l\{accès à la Montagne (où le vieil homme est perdu) n\'est pas randomisée non plus.',
+                                'Toutes les entrées restent dans la région de la Montagne de la Mort de la Lumière et sont mélangées ensemble. Veuillez noter que l\{accès à la Montagne (où le vieil homme est perdu) n’est pas randomisée non plus.',
                             ],
                         ],
                         [
@@ -322,7 +322,7 @@ return [
                 'restricted' => [
                     'header' => __('randomizer.entrance_shuffle.options.restricted'),
                     'content' => [
-                        'Similaire à ' . __('randomizer.entrance_shuffle.options.simple') . ', sauf que toutes les entrées qui ne sont pas des donjons (grottes à une ou plusieurs entrées, et la Montagne de la Mort de la Lumière) sont groupées et mélangées ensemble. Ceci inclut l\'accès à la Montagne de la Mort.',
+                        'Similaire à ' . __('randomizer.entrance_shuffle.options.simple') . ', sauf que toutes les entrées qui ne sont pas des donjons (grottes à une ou plusieurs entrées, et la Montagne de la Mort de la Lumière) sont groupées et mélangées ensemble. Ceci inclut l’accès à la Montagne de la Mort.',
                     ],
                 ],
                 'full' => [
@@ -334,7 +334,7 @@ return [
                 'crossed' => [
                     'header' => __('randomizer.entrance_shuffle.options.crossed'),
                     'content' => [
-                        'Smilaire à  ' . __('randomizer.entrance_shuffle.options.full') . ', sauf que les grottes et donjons avec plusieurs entrées ne sont plus limitées à un seul monde. Cela signifie que ceux-ci peuvent servir d\'accès entre les Mondes de la Lumière et des Ténèbres.',
+                        'Smilaire à  ' . __('randomizer.entrance_shuffle.options.full') . ', sauf que les grottes et donjons avec plusieurs entrées ne sont plus limitées à un seul monde. Cela signifie que ceux-ci peuvent servir d’accès entre les Mondes de la Lumière et des Ténèbres.',
                     ],
                 ],
                 'insanity' => [
@@ -388,8 +388,8 @@ return [
                     'content' => [
                         'Tous les ennemis sont aléatoires, mais il faut noter quelques points:',
                         '<ul>'
-                            . '<li>N\'importe quel ennemi ne peut pas apparaître n\'importe où, à cause des limitations du jeu.</li>'
-                            . '<li>Les pièces où il est requis de tuer des ennemis ne vont jamais demander une arme spécifique (par exemple des Mimiques requérant l\'Arc n\'apparaîtront pas dans ces pièces.</li>'
+                            . '<li>N’importe quel ennemi ne peut pas apparaître n’importe où, à cause des limitations du jeu.</li>'
+                            . '<li>Les pièces où il est requis de tuer des ennemis ne vont jamais demander une arme spécifique (par exemple des Mimiques requérant l’Arc n’apparaîtront pas dans ces pièces.</li>'
                             . '<li>Les Voleurs peuvent maintenant être tués.</li>'
                             . '<li>Les pièces à Tuiles Volantes ne sont pas aléatoires.</li>'
                             . '<li>Les ennemis sous des buissons ne sont pas aléatoires.</li>'
@@ -399,7 +399,7 @@ return [
                 [
                     'header' => __('randomizer.enemy_shuffle.options.random'),
                     'content' => [
-                        'Similaire à ' . __('randomizer.enemy_shuffle.options.shuffled') . ', sauf que les ennemis sous les buissons, ainsi que leur chance d\'apparaître, sont désormais aléatoires. Ceci n\'a pas l\'air de grand chose, mais peut drastiquement changer l\'expérience. En addition, les pièces à Tuiles Volantes ont un dessin aléatoire, et les Voleurs ont 50% de chance d\'être tuables ou invincibles.',
+                        'Similaire à ' . __('randomizer.enemy_shuffle.options.shuffled') . ', sauf que les ennemis sous les buissons, ainsi que leur chance d’apparaître, sont désormais aléatoires. Ceci n’a pas l’air de grand chose, mais peut drastiquement changer l’expérience. En addition, les pièces à Tuiles Volantes ont un dessin aléatoire, et les Voleurs ont 50% de chance d’être tuables ou invincibles.',
                     ],
                 ],
             ],
@@ -407,7 +407,7 @@ return [
         'hints' => [
             'header' => __('randomizer.hints.title'),
             'content' => [
-                'Active ou désactive la possibilité d\'avoir des indices sur les Tuiles Télépathiques à travers le monde.',
+                'Active ou désactive la possibilité d’avoir des indices sur les Tuiles Télépathiques à travers le monde.',
             ],
         ],
         'difficulty' => [
@@ -472,7 +472,7 @@ return [
                 [
                     'header' => __('randomizer.weapons.options.randomized'),
                     'content' => [
-                        'Les quatre Épées Progressives sont randomisées dans le jeu. Si ce paramètre est combiné avec ' . __('randomizer.world_state.options.standard') . ' ' . __('randomizer.world_state.title') . ', alors votre Oncle aura toujours l\'un des objets suivants:',
+                        'Les quatre Épées Progressives sont randomisées dans le jeu. Si ce paramètre est combiné avec ' . __('randomizer.world_state.options.standard') . ' ' . __('randomizer.world_state.title') . ', alors votre Oncle aura toujours l’un des objets suivants:',
                         '<ul>'
                             . '<li>Épée (oui, c’est possible !)</li>'
                             . '<li>Marteau</li>'
@@ -494,9 +494,9 @@ return [
                 [
                     'header' => __('randomizer.weapons.options.vanilla'),
                     'content' => [
-                        'Les quatre épées sont à leur emplacement d\'origine, c\'est-à-dire :',
+                        'Les quatre épées sont à leur emplacement d’origine, c’est-à-dire :',
                         '<ul>'
-                            . '<li>L\'oncle de Link</li>'
+                            . '<li>L’oncle de Link</li>'
                             . '<li>Le Piédestal de la Master Sword</li>'
                             . '<li>Le Forgeron</li>'
                             . '<li>La Fée de la Pyramide</li>'
@@ -526,25 +526,25 @@ return [
                 [
                     'header' => __('randomizer.enemy_health.options.default'),
                     'content' => [
-                        'La vie des ennemis n\'est pas aléatoire.',
+                        'La vie des ennemis n’est pas aléatoire.',
                     ],
                 ],
                 [
                     'header' => __('randomizer.enemy_health.options.easy'),
                     'content' => [
-                        'Tous les ennemis auront de 1 à 4 points de vie (1 ou deux coups d\'Épée du Combattant).',
+                        'Tous les ennemis auront de 1 à 4 points de vie (1 ou deux coups d’Épée du Combattant).',
                     ],
                 ],
                 [
                     'header' => __('randomizer.enemy_health.options.hard'),
                     'content' => [
-                        'Tous les ennemis auront de 2 à 15 points de vie (1 à 8 coups d\'Épée du Combattant). Notez que en moyenne, ceci donne plus de vie aux ennemis que le jeu original.',
+                        'Tous les ennemis auront de 2 à 15 points de vie (1 à 8 coups d’Épée du Combattant). Notez que en moyenne, ceci donne plus de vie aux ennemis que le jeu original.',
                     ],
                 ],
                 [
                     'header' => __('randomizer.enemy_health.options.expert'),
                     'content' => [
-                        'Tous les ennemis auront de 2 à 30 points de vie (1 à 15 coups d\'Épée du Combattant). Presque tous les ennemis auront beaucoup plus de vie que la normale.',
+                        'Tous les ennemis auront de 2 à 30 points de vie (1 à 15 coups d’Épée du Combattant). Presque tous les ennemis auront beaucoup plus de vie que la normale.',
                     ],
                 ],
             ],
@@ -561,13 +561,13 @@ return [
                 [
                     'header' => __('randomizer.enemy_damage.options.shuffled'),
                     'content' => [
-                        'Les dégâts infligés par les ennemis sont randomisés selon les types d\'ennemis. Par exemple, les dégâts des Octoroks et de Ganon peuvent être échangés, causant les Octorok à infliger 8 cœurs de dégâts, tandis que Ganon ne fera que 1 cœur. Les améliorations d\'armure fonctionnent toujours normalement.',
+                        'Les dégâts infligés par les ennemis sont randomisés selon les types d’ennemis. Par exemple, les dégâts des Octoroks et de Ganon peuvent être échangés, causant les Octorok à infliger 8 cœurs de dégâts, tandis que Ganon ne fera que 1 cœur. Les améliorations d’armure fonctionnent toujours normalement.',
                     ],
                 ],
                 [
                     'header' => __('randomizer.enemy_damage.options.random'),
                     'content' => [
-                        'Les dégâts des ennemis sont complètement aléatoires. Une valeur est choisie pour chaque armure. Les armures ne réduisent donc plus forcément les dégâts. Il n\'y a aucune relation entre différents ennemis. Tous les ennemis pourraient faire des dégâts massifs.',
+                        'Les dégâts des ennemis sont complètement aléatoires. Une valeur est choisie pour chaque armure. Les armures ne réduisent donc plus forcément les dégâts. Il n’y a aucune relation entre différents ennemis. Tous les ennemis pourraient faire des dégâts massifs.',
                     ],
                 ],
             ],
@@ -578,7 +578,7 @@ return [
                 'heart_speed' => [
                     'header' => __('rom.settings.heart_speed'),
                     'content' => [
-                        'Change la vitesse de l\'alarme quand la vie de Link est faible.',
+                        'Change la vitesse de l’alarme quand la vie de Link est faible.',
                     ],
                 ],
                 'play_as' => [
@@ -590,7 +590,7 @@ return [
                 'menu_speed' => [
                     'header' => __('rom.settings.menu_speed'),
                     'content' => [
-                        'Change la vitesse d\'ouverture et de fermeture du menu. Ceci n\'est pas disponible pour les ROMs de course.',
+                        'Change la vitesse d’ouverture et de fermeture du menu. Ceci n’est pas disponible pour les ROMs de course.',
                     ],
                 ],
                 'heart_color' => [
@@ -614,7 +614,7 @@ return [
                 'palette_shuffle' => [
                     'header' => __('rom.settings.palette_shuffle'),
                     'content' => [
-                        'Randomise les palettes de couleurs du jeu. Ceci signifie que toute peut avoir l\'air extrêmement bizarre. Utilisez avec précaution!',
+                        'Randomise les palettes de couleurs du jeu. Ceci signifie que toute peut avoir l’air extrêmement bizarre. Utilisez avec précaution!',
                     ],
                 ],
                 'reduce_flashing' => [

--- a/resources/lang/fr/races.php
+++ b/resources/lang/fr/races.php
@@ -38,19 +38,6 @@ return [
                 ],
             ],
         ],
-        'watch' => [
-            'header' => 'Regarder',
-            'content' => [
-                'Il y a toujours une course à regarder! Suivez ces serveurs et ne manquez jamais un match',
-            ],
-        ],
-        'network' => [
-            'header' => 'Serveur de course',
-            'content' => [
-                'Les courses se font typiquement sur une plate-forme de course qui permet d’organiser des courses officielles ou non officielles, et d’avoir un chonomètre commun. Il est ainsi plus facile pour les coureurs et spectateurs de trouver des courses.',
-                'Visitez <a href="http://racetime.gg" target="_blank">RaceTime.gg</a> pour plus de détails!',
-            ],
-        ],
         'tournament' => [
             'header' => 'Tournois',
             'sections' => [

--- a/resources/lang/fr/races.php
+++ b/resources/lang/fr/races.php
@@ -9,13 +9,13 @@ return [
                     'header' => '',
                     'content' => [
                         'La plupart des courses se font à l’aide de la plate-forme <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a>. Vous pouvez vous créer un compte, et vous connecter sur le site pour plus d’information sur le fonctionnement de la plate-forme!',
-                        'Avant de commencer à faire des courses, vous devriez vous familiariser avec les <a href="http://alttp.mymm1.com/wiki/ALTTPR_Racing_Ruleset">règles de course de ALTTPR</a>. Veuillez noter que certains tounois ou évènements peuvent utiliser des règles différentes. Validez avec les organisateurs pour savoir s’il y a des variations!',
+                        'Avant de commencer à faire des courses, vous devriez vous familiariser avec les <a href="http://alttp.mymm1.com/wiki/ALTTPR_Racing_Ruleset">règles de course d’ALTTPR</a>. Veuillez noter que certains tounois ou évènements peuvent utiliser des règles différentes. Validez avec les organisateurs pour savoir s’il y a des variations!',
                     ],
                 ],
                 [
                     'header' => 'Ladder ALTTPR',
                     'content' => [
-                        'Le <a href="https://alttprladder.com/" target="_blank">Ladder de ALTTPR</a> est une ligue de ALTTPR qui fonctionne selon l’échelle Elo. Les courses se font entièrement sur un serveur Discord. Plusieurs courses se déroulent chaque jour, en rotation, et en utilisant différents paramètres du randomiseur. Le système de pointage fonctionne selon le standard Elo 32k.',
+                        'Le <a href="https://alttprladder.com/" target="_blank">Ladder ALTTPR</a> est une ligue d’ALTTPR qui fonctionne selon l’échelle Elo. Les courses se font entièrement sur un serveur Discord. Plusieurs courses se déroulent chaque jour, en rotation, et en utilisant différents paramètres du randomiseur. Le système de pointage fonctionne selon le standard Elo 32k.',
                     ],
                 ],
                 [
@@ -33,7 +33,7 @@ return [
                 [
                     'header' => 'Votre propre course',
                     'content' => [
-                        'Les courses organisées ne fonctionnent pas avec votre horaire ? Vous voulez faire une course avec des paramètres plus exotiques ? Organisez votre propre course! Vous trouverez des joueurs prêts à jouer à toute heure du jour ou de la nuit. Visitez #race-planning dans le <a href="https://discord.gg/alttprandomizer" target="_blank">discord principal de ALTTPR.</a>!',
+                        'Les courses organisées ne fonctionnent pas avec votre horaire? Vous voulez faire une course avec des paramètres plus exotiques? Organisez votre propre course! Vous trouverez des joueurs prêts à jouer à toute heure du jour ou de la nuit. Visitez #race-planning dans le <a href="https://discord.gg/alttprandomizer" target="_blank">Discord principal d’ALTTPR.</a>!',
                     ],
                 ],
             ],
@@ -57,11 +57,11 @@ return [
                 [
                     'header' => '',
                     'content' => [
-                        'Vous voulez voir des courses de tournoi commentées, et courus par des joueurs de haut niveau ? Des tournois ont souvent lieu au cours de l’année. Joignez notre <a href="https://discord.gg/alttprandomizer" target="_blank">Discord</a> pour être au courant du calendrier!',
+                        'Vous voulez voir des courses de tournoi commentées, et courues par des joueurs de haut niveau ? Des tournois ont souvent lieu au cours de l’année. Joignez notre <a href="https://discord.gg/alttprandomizer" target="_blank">Discord</a> pour être au courant du calendrier!',
                     ],
                 ],
                 [
-                    'header' => 'Tournoi principal de ALTTP Randomizer',
+                    'header' => 'Tournoi principal d’ALTTP Randomizer',
                     'content' => [
                         'Voyez les meilleurs joueurs compétitionner pour le trophée et la chance d’avoir leur nom sur la tuile télépathique de la salle Houlihan! Vous croyez avoir ce qu’il faut pour vous mesurer aux meilleurs ? Joignez le <a href="https://discord.gg/B2kGXxTD6g" target="_blank">Discord du tournoi ALTTPR</a> et surveillez les courses de qualification!',
                     ],
@@ -69,13 +69,13 @@ return [
                 [
                     'header' => 'Challenge Cup',
                     'content' => [
-                        'The <a href="https://discord.gg/982W72p" target="_blank">Challenge Cup</a> is an overflow tournament for those who did not qualify for the main tournament.',
+                        'La <a href="https://discord.gg/982W72p" target="_blank">Challenge Cup</a> est un tournoi destiné aux joueurs qui n’ont pas pu se qualifier dans le tournoi principal.',
                     ],
                 ],
                 [
                     'header' => 'Ligue ALTTPR',
                     'content' => [
-                        'La <a href="https://alttprleague.com/" target="_blank">Lighe de ALTTPR</a> est un tournoi annuel en équipe. Les joueurs forment des équipes de trois personnes, et s’affrontent en solo ou en équipe dans des courses avec des modes variés.',
+                        'La <a href="https://alttprleague.com/" target="_blank">Ligue ALTTPR</a> est un tournoi annuel en équipe. Les joueurs forment des équipes de trois personnes, et s’affrontent en solo ou en équipe dans des courses avec des modes variés.',
                     ],
                 ],
                 [
@@ -93,13 +93,13 @@ return [
                 [
                     'header' => 'Tournois ALTTPR avec des Glitches',
                     'content' => [
-                        'Les <a href="https://discord.gg/adac5FG" target="_blank">tournois de ALTTPR Glitchés</a> impliquent l’utilisation de glitches majeurs pour briser et battre le jeu, souvent de manière innatendue.',
+                        'Les <a href="https://discord.gg/adac5FG" target="_blank">tournois de ALTTPR Glitchés</a> impliquent l’utilisation de glitchs majeurs pour briser et battre le jeu, souvent de manière inattendue.',
                     ],
                 ],
                 [
-                    'header' => 'Le tournois Croise-clés ALTTPR',
+                    'header' => 'Tournoi croise-clés ALTTPR',
                     'content' => [
-                        'Le <a href="https://discord.gg/umCCQgr" target="_blank">tournoi de croise-clés de ALTTPR</a>, communément appelé "Crosskeys" est un tournoi qui teste la capacité des joueurs à naviguer le monde d’Hyrule avec les entrées et les clés mélangées. Les joueurs devront faire appel à leur mémoire et leurs notes pour trouver la solution de ce mode renversant!',
+                        'Le <a href="https://discord.gg/umCCQgr" target="_blank">tournoi croise-clés d’ALTTPR</a>, communément appelé "Crosskeys" est un tournoi qui teste la capacité des joueurs à naviguer le monde d’Hyrule avec les entrées et les clés mélangées. Les joueurs devront faire appel à leur mémoire et leurs notes pour trouver la solution de ce mode renversant!',
                     ],
                 ],
             ],
@@ -109,12 +109,18 @@ return [
             'languages' => [
                 [
                     'header' => 'Francophone',
-                    'description' => 'Si vous cherchez des passionnées francophone de ALTTP Randomizer, n’hésitez pas à nous rejoindre sur notre <a href="https://discord.gg/tpdpHt6" target="_blank">Discord</a>. Il y a toujours des gens prêts à vous donner un coup de main. Il y a souvent des courses amicales qui s’organisent de manière impromptue, et il y règne une bonne ambiance.',
+                    'description' => 'Si vous cherchez des passionnées francophones de ALTTP Randomizer, n’hésitez pas à nous rejoindre sur notre <a href="https://discord.gg/tpdpHt6" target="_blank">Discord</a>. Il y a toujours des gens prêts à vous donner un coup de main. Il y a souvent des courses amicales qui s’organisent de manière impromptue, et il y règne une bonne ambiance.',
                     'sections' => [
                         [
                             'header' => 'Tournoi Francophone',
                             'content' => [
                                 'Nous organisons habituellement un gros tournoi par année, ainsi qu’un micro tournoi à l’occasion. Surveillez le <a href="https://discord.gg/tpdpHt6" target="_blank">Discord</a> pour être au courant des développements',
+                            ],
+                        ],
+						[
+                            'header' => 'Hebdomadaire Francophone',
+                            'content' => [
+                                'Chaque semaine, une course hebdomadaire entre francophones à lieu. L’horaire est voté par les joueurs sur le <a href="https://discord.gg/tpdpHt6" target="_blank">Discord de la communauté francophone</a> puis annoncé, au plaisir de tous!',
                             ],
                         ],
                     ],

--- a/resources/lang/fr/races.php
+++ b/resources/lang/fr/races.php
@@ -1,38 +1,39 @@
 <?php
 return [
-    'header' => 'Parties organisées',
+    'header' => 'Courses organisées',
     'cards' => [
         'races' => [
-            'header' => 'Courses',
+            'header' => 'Courses quotidiennes et hebdomadaires',
             'sections' => [
                 [
                     'header' => '',
                     'content' => [
-                        'La plupart des courses sont faites au travers de <a href="https://speedracing.tv/" target="_blank" rel="noopener noreferrer">SpeedRacing.tv</a> ou <a href="http://speedrunslive.com" target="_blank" rel="noopener noreferrer">SpeedRunsLive.com</a>. Vous y trouverez toutes les informations nécessaires pour profiter de l’action !',
+                        'La plupart des courses se font à l’aide de la plate-forme <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a>. Vous pouvez vous créer un compte, et vous connecter sur le site pour plus d’information sur le fonctionnement de la plate-forme!',
+                        'Avant de commencer à faire des courses, vous devriez vous familiariser avec les <a href="http://alttp.mymm1.com/wiki/ALTTPR_Racing_Ruleset">règles de course de ALTTPR</a>. Veuillez noter que certains tounois ou évènements peuvent utiliser des règles différentes. Validez avec les organisateurs pour savoir s’il y a des variations!',
                     ],
                 ],
                 [
-                    'header' => 'Courses Hebdomadaires en Mode Standard, le Samedi à 15h, heure de l’Est Américain',
+                    'header' => 'Ladder ALTTPR',
                     'content' => [
-                        'Événement principal de la communauté, cette course hebdomadaire compte beaucoup de compétiteurs !',
+                        'Le <a href="https://alttprladder.com/" target="_blank">Ladder de ALTTPR</a> est une ligue de ALTTPR qui fonctionne selon l’échelle Elo. Les courses se font entièrement sur un serveur Discord. Plusieurs courses se déroulent chaque jour, en rotation, et en utilisant différents paramètres du randomiseur. Le système de pointage fonctionne selon le standard Elo 32k.',
                     ],
                 ],
                 [
-                    'header' => 'Courses Hebdomadaires en Mode Ouvert, le Dimanche à 17h, heure de l’Est Américain',
+                    'header' => 'Courses quotidiennes de SpeedGaming',
                     'content' => [
-                        'Rejoignez-nous tous les Dimanches pour une autre course hebdomadaire populaire dans la communauté.',
+                        '<a href="https://speedgaming.org/" target="_blank">SpeedGaming</a> organise des courses quotidiennes qui se font sur la plate-forme <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a>.  N’hésitez pas à aller voir la <a href="http://speedgaming.org/alttprdaily/" target="_blank">planification des courses.</a>',
                     ],
                 ],
                 [
-                    'header' => 'La Course Communautaire Nocturne, 22h, heure de l’Est Américain',
+                    'header' => 'Course hebdomadaire des glitches du monde extérieur',
                     'content' => [
-                        'Nous faisons aussi des courses nocturnes pour ceux qui cherchent à jouer tous les jours !',
+                        'La course hebdomadaire des glitches du monde extérieur a lieu tous les mercredis à 22h30 sur <a href="https://racetime.gg/alttpr" target="_blank">RaceTime.gg</a>.',
                     ],
                 ],
                 [
-                    'header' => 'Courses Ponctuelles',
+                    'header' => 'Votre propre course',
                     'content' => [
-                        'Les courses planifiées ne correspondent pas avec vos horaires ? Vous cherchez une course avec des options exotiques ? Rejoignez une course ponctuelle ! Vous trouverez des joueurs à toute heure de la journée. Rejoignez le canal #race-planning sur notre <a href="https://discord.gg/alttprandomizer" target="_blank" rel="noopener noreferrer">serveur Discord</a>!',
+                        'Les courses organisées ne fonctionnent pas avec votre horaire ? Vous voulez faire une course avec des paramètres plus exotiques ? Organisez votre propre course! Vous trouverez des joueurs prêts à jouer à toute heure du jour ou de la nuit. Visitez #race-planning dans le <a href="https://discord.gg/alttprandomizer" target="_blank">discord principal de ALTTPR.</a>!',
                     ],
                 ],
             ],
@@ -40,14 +41,14 @@ return [
         'watch' => [
             'header' => 'Regarder',
             'content' => [
-                'Avec autant d’événements, il y a toujours une course à regarder ! Suivez ces réseaux et ne manquez aucun match !',
+                'Il y a toujours une course à regarder! Suivez ces serveurs et ne manquez jamais un match',
             ],
         ],
         'network' => [
-            'header' => 'Réseaux de Courses',
+            'header' => 'Serveur de course',
             'content' => [
-                'Les courses sont habituellement organisées au sein d’un réseau de course. Ces sites facilitent l’organisation, ajoutent un chronomètre officiel et permettent autant aux coureurs qu’aux spectateurs de trouver plus facilement des courses.',
-                'Soyez surs de jeter un oeil aux sites <a href="http://speedrunslive.com" target="_blank" rel="noopener noreferrer">SpeedRunsLive.com</a> et <a href="http://speedracing.tv" target="_blank" rel="noopener noreferrer">SpeedRacing.tv</a> pour plus d’informations !',
+                'Les courses se font typiquement sur une plate-forme de course qui permet d’organiser des courses officielles ou non officielles, et d’avoir un chonomètre commun. Il est ainsi plus facile pour les coureurs et spectateurs de trouver des courses.',
+                'Visitez <a href="http://racetime.gg" target="_blank">RaceTime.gg</a> pour plus de détails!',
             ],
         ],
         'tournament' => [
@@ -56,15 +57,66 @@ return [
                 [
                     'header' => '',
                     'content' => [
-                        'Rejoignez-nous pour de l’action au cours de tournois avec des commentateurs experts au côté de joueurs d’élite !',
+                        'Vous voulez voir des courses de tournoi commentées, et courus par des joueurs de haut niveau ? Des tournois ont souvent lieu au cours de l’année. Joignez notre <a href="https://discord.gg/alttprandomizer" target="_blank">Discord</a> pour être au courant du calendrier!',
                     ],
                 ],
                 [
-                    'header' => 'Tournois bi-annuels sur invitation',
+                    'header' => 'Tournoi principal de ALTTP Randomizer',
                     'content' => [
-                        'Soyez témoins des meilleurs coureurs en compétition pour le Trophée ! Vous pensez avoir ce qu’il faut pour être au coude à coude avec les meilleurs ? Rejoignez notre <a href="https://discord.gg/alttprandomizer" target="_blank" rel="noopener noreferrer">serveur Discord</a> et gardez un oeil sur les qualifications !',
-                        'Le tournoi du Printemps sur invitation dure de Mars à Juin.',
-                        'Le tournoi d’Automne sur invitation dure de Septembre à Décembre.',
+                        'Voyez les meilleurs joueurs compétitionner pour le trophée et la chance d’avoir leur nom sur la tuile télépathique de la salle Houlihan! Vous croyez avoir ce qu’il faut pour vous mesurer aux meilleurs ? Joignez le <a href="https://discord.gg/B2kGXxTD6g" target="_blank">Discord du tournoi ALTTPR</a> et surveillez les courses de qualification!',
+                    ],
+                ],
+                [
+                    'header' => 'Challenge Cup',
+                    'content' => [
+                        'The <a href="https://discord.gg/982W72p" target="_blank">Challenge Cup</a> is an overflow tournament for those who did not qualify for the main tournament.',
+                    ],
+                ],
+                [
+                    'header' => 'Ligue ALTTPR',
+                    'content' => [
+                        'La <a href="https://alttprleague.com/" target="_blank">Lighe de ALTTPR</a> est un tournoi annuel en équipe. Les joueurs forment des équipes de trois personnes, et s’affrontent en solo ou en équipe dans des courses avec des modes variés.',
+                    ],
+                ],
+                [
+                    'header' => 'Tournoi mentor Go Mode Podcast',
+                    'content' => [
+                        '<a href="https://gomodepodcast.com/" target="_blank">Go Mode Podcast</a> organise un tournoi annuel destiné aux nouveaux joueurs. Les apprentis ont un mentor pour les aider dans certaines courses. Le but est de préparer les joueurs pour compétitionner dans d’autres tournois, petits ou grands.',
+                    ],
+                ],
+                [
+                    'header' => 'Tournoi ALTTPR Spoiler',
+                    'content' => [
+                        'Le <a href="https://discord.gg/Jg34MuE" target="_blank">tournoi ALTTPR Spoiler</a> est un tournoi annuel dont le but est d’étudier le spoiler de la course pendant 15 minutes, planifier la course, et ensuite faire la course. Ce tournoi teste l’habileté des joueurs à joueur rapidement, efficacement, et souvent avec peu de protection.',
+                    ],
+                ],
+                [
+                    'header' => 'Tournois ALTTPR avec des Glitches',
+                    'content' => [
+                        'Les <a href="https://discord.gg/adac5FG" target="_blank">tournois de ALTTPR Glitchés</a> impliquent l’utilisation de glitches majeurs pour briser et battre le jeu, souvent de manière innatendue.',
+                    ],
+                ],
+                [
+                    'header' => 'Le tournois Croise-clés ALTTPR',
+                    'content' => [
+                        'Le <a href="https://discord.gg/umCCQgr" target="_blank">tournoi de croise-clés de ALTTPR</a>, communément appelé "Crosskeys" est un tournoi qui teste la capacité des joueurs à naviguer le monde d’Hyrule avec les entrées et les clés mélangées. Les joueurs devront faire appel à leur mémoire et leurs notes pour trouver la solution de ce mode renversant!',
+                    ],
+                ],
+            ],
+        ],
+        'foreign_language' => [
+            'header' => 'Language-specific Tournaments and Events',
+            'languages' => [
+                [
+                    'header' => 'Francophone',
+                    'description' => 'Si vous cherchez des passionnées francophone de ALTTP Randomizer, n’hésitez pas à nous rejoindre sur notre <a href="https://discord.gg/tpdpHt6" target="_blank">Discord</a>. Il y a toujours des gens prêts à vous donner un coup de main. Il y a souvent des courses amicales qui s’organisent de manière impromptue, et il y règne une bonne ambiance.',
+                    'sections' => [
+                        [
+                            'header' => 'Tournoi Francophone',
+                            'content' => [
+                                'Nous organisons habituellement un gros tournoi par année, ainsi qu’un micro tournoi à l’occasion. Surveillez le <a href="https://discord.gg/tpdpHt6" target="_blank">Discord</a> pour être au courant des développements',
+                            ],
+                        ],
                     ],
                 ],
             ],

--- a/resources/lang/fr/randomizer.php
+++ b/resources/lang/fr/randomizer.php
@@ -103,7 +103,7 @@ return [
         ],
     ],
     "entrance_shuffle" => [
-        'title' => 'Mélangeur d\'Entrées',
+        'title' => 'Mélangeur d’Entrées',
         'options' => [
             'none' => 'Désactivé',
             'simple' => 'Simple',
@@ -123,7 +123,7 @@ return [
         ],
     ],
     "enemy_shuffle" => [
-        'title' => 'Mélangeur d\'Ennemis',
+        'title' => 'Mélangeur d’Ennemis',
         'options' => [
             'none' => 'Désactivé',
             'shuffled' => 'Intervertis',
@@ -155,7 +155,7 @@ return [
             'expert' => 'Expert',
             'crowd_control' => 'Crowd Control',
         ],
-        'crowd_control_warning' => '<sup>*</sup> Ce paramètre est prévu pour être utilisé avec l\'extension Twitch Crowd Control. En savoir plus: <a href="https://crowdcontrol.live/" target="_blank" rel=”noopener noreferrer”>https://crowdcontrol.live/</a>',
+        'crowd_control_warning' => '<sup>*</sup> Ce paramètre est prévu pour être utilisé avec l’extension Twitch Crowd Control. En savoir plus: <a href="https://crowdcontrol.live/" target="_blank" rel=”noopener noreferrer”>https://crowdcontrol.live/</a>',
     ],
     'item_functionality' => [
         'title' => 'Fonctionnalité des Objets',

--- a/resources/lang/fr/resources.php
+++ b/resources/lang/fr/resources.php
@@ -24,7 +24,7 @@ return [
                     . '<li><a href="https://alttprlinks.page.link/3vXm" target="_blank" rel="noopener noreferrer">Glossaire d’aide</a></li>'
                     . '<li><a href="https://alttprlinks.page.link/HVFx" target="_blank" rel="noopener noreferrer">Ressources pour les glitchs</a></li>'
                     . '<li><a href="https://alttprlinks.page.link/on1o" target="_blank" rel="noopener noreferrer">Trackers / HUDs</a></li>'
-                    . '<li><a href="http://alttp.mymm1.com/srl/" target="_blank" rel="noopener noreferrer">Débuter sur SRL</a></li>'
+                    . '<li><a href="https://racetime.gg/about/help" target="_blank" rel="noopener noreferrer">Débuter sur RaceTime.gg</a></li>'
                 . '</ul>',
             ],
         ],

--- a/resources/lang/fr/rom.php
+++ b/resources/lang/fr/rom.php
@@ -57,5 +57,7 @@ return [
         'quickswap' => 'Changement rapide d’objets',
         'palette_shuffle' => 'Mélange des Couleurs de Palettes',
         'race_warning' => 'Ne fonctionne pas dans les ROMs de course',
+        "reduce_flashing" => "Réduit le clignotement",
+        "reduce_flashing_warning" => "Cette option réduit l'effet de clignotement. Votre sensibilité aux effets de clignotement peut varier."
     ],
 ];

--- a/resources/sass/_sprites.scss
+++ b/resources/sass/_sprites.scss
@@ -3,1038 +3,1110 @@
   width: 16px;
   height: 24px;
   vertical-align: bottom;
-  background-image: url("https://alttpr.s3.us-east-2.amazonaws.com/sprites.31.0.8.png");
+  background-image: url("https://alttpr.s3.us-east-2.amazonaws.com/sprites.31.0.9.png");
 }
 
 .icon-custom-Random {
   background-position: 0 0;
 }
 .icon-custom-Link {
-  background-position: percentage((1 - 344)/ 343) 0;
+  background-position: percentage((1 - 368)/ 367) 0;
 }
 .icon-custom-FourSwordsLink {
-  background-position: percentage((2 - 344)/ 343) 0;
+  background-position: percentage((2 - 368)/ 367) 0;
 }
 .icon-custom-Abigail {
-  background-position: percentage((3 - 344)/ 343) 0;
+  background-position: percentage((3 - 368)/ 367) 0;
 }
 .icon-custom-Adol {
-  background-position: percentage((4 - 344)/ 343) 0;
+  background-position: percentage((4 - 368)/ 367) 0;
+}
+.icon-custom-Adventure2600 {
+  background-position: percentage((5 - 368)/ 367) 0;
 }
 .icon-custom-Aggretsuko {
-  background-position: percentage((5 - 344)/ 343) 0;
+  background-position: percentage((6 - 368)/ 367) 0;
 }
 .icon-custom-Alice {
-  background-position: percentage((6 - 344)/ 343) 0;
+  background-position: percentage((7 - 368)/ 367) 0;
 }
 .icon-custom-AngryVideoGameNerd {
-  background-position: percentage((7 - 344)/ 343) 0;
+  background-position: percentage((8 - 368)/ 367) 0;
 }
 .icon-custom-Arcane {
-  background-position: percentage((8 - 344)/ 343) 0;
+  background-position: percentage((9 - 368)/ 367) 0;
+}
+.icon-custom-Aria {
+  background-position: percentage((10 - 368)/ 367) 0;
 }
 .icon-custom-ArkNoCape {
-  background-position: percentage((9 - 344)/ 343) 0;
+  background-position: percentage((11 - 368)/ 367) 0;
 }
 .icon-custom-ArkCape {
-  background-position: percentage((10 - 344)/ 343) 0;
+  background-position: percentage((12 - 368)/ 367) 0;
 }
 .icon-custom-Arrghus {
-  background-position: percentage((11 - 344)/ 343) 0;
+  background-position: percentage((13 - 368)/ 367) 0;
 }
 .icon-custom-Astronaut {
-  background-position: percentage((12 - 344)/ 343) 0;
+  background-position: percentage((14 - 368)/ 367) 0;
 }
 .icon-custom-Asuna {
-  background-position: percentage((13 - 344)/ 343) 0;
+  background-position: percentage((15 - 368)/ 367) 0;
 }
 .icon-custom-Badeline {
-  background-position: percentage((14 - 344)/ 343) 0;
+  background-position: percentage((16 - 368)/ 367) 0;
 }
 .icon-custom-BananasInPyjamas {
-  background-position: percentage((15 - 344)/ 343) 0;
+  background-position: percentage((17 - 368)/ 367) 0;
 }
 .icon-custom-Bandit {
-  background-position: percentage((16 - 344)/ 343) 0;
+  background-position: percentage((18 - 368)/ 367) 0;
 }
 .icon-custom-Batman {
-  background-position: percentage((17 - 344)/ 343) 0;
+  background-position: percentage((19 - 368)/ 367) 0;
 }
 .icon-custom-Beau {
-  background-position: percentage((18 - 344)/ 343) 0;
+  background-position: percentage((20 - 368)/ 367) 0;
+}
+.icon-custom-Bee {
+  background-position: percentage((21 - 368)/ 367) 0;
 }
 .icon-custom-Bewp {
-  background-position: percentage((19 - 344)/ 343) 0;
+  background-position: percentage((22 - 368)/ 367) 0;
 }
 .icon-custom-BigKey {
-  background-position: percentage((20 - 344)/ 343) 0;
+  background-position: percentage((23 - 368)/ 367) 0;
 }
 .icon-custom-Birb {
-  background-position: percentage((21 - 344)/ 343) 0;
+  background-position: percentage((24 - 368)/ 367) 0;
 }
 .icon-custom-Birdo {
-  background-position: percentage((22 - 344)/ 343) 0;
+  background-position: percentage((25 - 368)/ 367) 0;
 }
 .icon-custom-BlackMage {
-  background-position: percentage((23 - 344)/ 343) 0;
+  background-position: percentage((26 - 368)/ 367) 0;
 }
 .icon-custom-BlacksmithLink {
-  background-position: percentage((24 - 344)/ 343) 0;
+  background-position: percentage((27 - 368)/ 367) 0;
 }
 .icon-custom-Blazer {
-  background-position: percentage((25 - 344)/ 343) 0;
+  background-position: percentage((28 - 368)/ 367) 0;
 }
 .icon-custom-Blossom {
-  background-position: percentage((26 - 344)/ 343) 0;
+  background-position: percentage((29 - 368)/ 367) 0;
 }
 .icon-custom-Bob {
-  background-position: percentage((27 - 344)/ 343) 0;
+  background-position: percentage((30 - 368)/ 367) 0;
 }
 .icon-custom-BobRoss {
-  background-position: percentage((28 - 344)/ 343) 0;
+  background-position: percentage((31 - 368)/ 367) 0;
 }
 .icon-custom-BocotheChocobo {
-  background-position: percentage((29 - 344)/ 343) 0;
+  background-position: percentage((32 - 368)/ 367) 0;
 }
 .icon-custom-Boo2 {
-  background-position: percentage((30 - 344)/ 343) 0;
+  background-position: percentage((33 - 368)/ 367) 0;
 }
 .icon-custom-Boo {
-  background-position: percentage((31 - 344)/ 343) 0;
+  background-position: percentage((34 - 368)/ 367) 0;
 }
 .icon-custom-BottleoGoo {
-  background-position: percentage((32 - 344)/ 343) 0;
+  background-position: percentage((35 - 368)/ 367) 0;
 }
 .icon-custom-BotWLink {
-  background-position: percentage((33 - 344)/ 343) 0;
+  background-position: percentage((36 - 368)/ 367) 0;
 }
 .icon-custom-BotWZelda {
-  background-position: percentage((34 - 344)/ 343) 0;
+  background-position: percentage((37 - 368)/ 367) 0;
 }
 .icon-custom-Bowser {
-  background-position: percentage((35 - 344)/ 343) 0;
+  background-position: percentage((38 - 368)/ 367) 0;
 }
 .icon-custom-BowsetteRed {
-  background-position: percentage((36 - 344)/ 343) 0;
+  background-position: percentage((39 - 368)/ 367) 0;
 }
 .icon-custom-Bowsette {
-  background-position: percentage((37 - 344)/ 343) 0;
+  background-position: percentage((40 - 368)/ 367) 0;
 }
 .icon-custom-Branch {
-  background-position: percentage((38 - 344)/ 343) 0;
+  background-position: percentage((41 - 368)/ 367) 0;
 }
 .icon-custom-Brian {
-  background-position: percentage((39 - 344)/ 343) 0;
+  background-position: percentage((42 - 368)/ 367) 0;
 }
 .icon-custom-Broccoli {
-  background-position: percentage((40 - 344)/ 343) 0;
+  background-position: percentage((43 - 368)/ 367) 0;
 }
 .icon-custom-Bronzor {
-  background-position: percentage((41 - 344)/ 343) 0;
+  background-position: percentage((44 - 368)/ 367) 0;
 }
 .icon-custom-BSBoy {
-  background-position: percentage((42 - 344)/ 343) 0;
+  background-position: percentage((45 - 368)/ 367) 0;
 }
 .icon-custom-BSGirl {
-  background-position: percentage((43 - 344)/ 343) 0;
+  background-position: percentage((46 - 368)/ 367) 0;
 }
 .icon-custom-Bubbles {
-  background-position: percentage((44 - 344)/ 343) 0;
+  background-position: percentage((47 - 368)/ 367) 0;
 }
 .icon-custom-BulletBill {
-  background-position: percentage((45 - 344)/ 343) 0;
+  background-position: percentage((48 - 368)/ 367) 0;
 }
 .icon-custom-Buttercup {
-  background-position: percentage((46 - 344)/ 343) 0;
+  background-position: percentage((49 - 368)/ 367) 0;
 }
 .icon-custom-Cactuar {
-  background-position: percentage((47 - 344)/ 343) 0;
+  background-position: percentage((50 - 368)/ 367) 0;
 }
 .icon-custom-Cadence {
-  background-position: percentage((48 - 344)/ 343) 0;
+  background-position: percentage((51 - 368)/ 367) 0;
 }
 .icon-custom-CarlSagan42 {
-  background-position: percentage((49 - 344)/ 343) 0;
+  background-position: percentage((52 - 368)/ 367) 0;
 }
 .icon-custom-CasualZelda {
-  background-position: percentage((50 - 344)/ 343) 0;
+  background-position: percentage((53 - 368)/ 367) 0;
 }
 .icon-custom-MarvintheCat {
-  background-position: percentage((51 - 344)/ 343) 0;
+  background-position: percentage((54 - 368)/ 367) 0;
 }
 .icon-custom-CatBoo {
-  background-position: percentage((52 - 344)/ 343) 0;
+  background-position: percentage((55 - 368)/ 367) 0;
+}
+.icon-custom-CatgirlHidari {
+  background-position: percentage((56 - 368)/ 367) 0;
 }
 .icon-custom-CD-iLink {
-  background-position: percentage((53 - 344)/ 343) 0;
+  background-position: percentage((57 - 368)/ 367) 0;
 }
 .icon-custom-Celes {
-  background-position: percentage((54 - 344)/ 343) 0;
+  background-position: percentage((58 - 368)/ 367) 0;
+}
+.icon-custom-CentaurEnos {
+  background-position: percentage((59 - 368)/ 367) 0;
 }
 .icon-custom-Charizard {
-  background-position: percentage((55 - 344)/ 343) 0;
+  background-position: percentage((60 - 368)/ 367) 0;
 }
 .icon-custom-CheepCheep {
-  background-position: percentage((56 - 344)/ 343) 0;
+  background-position: percentage((61 - 368)/ 367) 0;
 }
 .icon-custom-Chibity {
-  background-position: percentage((57 - 344)/ 343) 0;
+  background-position: percentage((62 - 368)/ 367) 0;
 }
 .icon-custom-Chrizzz {
-  background-position: percentage((58 - 344)/ 343) 0;
+  background-position: percentage((63 - 368)/ 367) 0;
 }
 .icon-custom-Cinna {
-  background-position: percentage((59 - 344)/ 343) 0;
+  background-position: percentage((64 - 368)/ 367) 0;
 }
 .icon-custom-Cirno {
-  background-position: percentage((60 - 344)/ 343) 0;
+  background-position: percentage((65 - 368)/ 367) 0;
 }
 .icon-custom-Clifford {
-  background-position: percentage((61 - 344)/ 343) 0;
+  background-position: percentage((66 - 368)/ 367) 0;
+}
+.icon-custom-Clippy {
+  background-position: percentage((67 - 368)/ 367) 0;
+}
+.icon-custom-Cloud {
+  background-position: percentage((68 - 368)/ 367) 0;
 }
 .icon-custom-Clyde {
-  background-position: percentage((62 - 344)/ 343) 0;
+  background-position: percentage((69 - 368)/ 367) 0;
 }
 .icon-custom-Conker {
-  background-position: percentage((63 - 344)/ 343) 0;
+  background-position: percentage((70 - 368)/ 367) 0;
 }
 .icon-custom-Cornelius {
-  background-position: percentage((64 - 344)/ 343) 0;
+  background-position: percentage((71 - 368)/ 367) 0;
 }
 .icon-custom-Corona {
-  background-position: percentage((65 - 344)/ 343) 0;
+  background-position: percentage((72 - 368)/ 367) 0;
 }
 .icon-custom-Crewmate {
-  background-position: percentage((66 - 344)/ 343) 0;
+  background-position: percentage((73 - 368)/ 367) 0;
 }
 .icon-custom-Cucco {
-  background-position: percentage((67 - 344)/ 343) 0;
+  background-position: percentage((74 - 368)/ 367) 0;
 }
 .icon-custom-Cursor {
-  background-position: percentage((68 - 344)/ 343) 0;
+  background-position: percentage((75 - 368)/ 367) 0;
 }
 .icon-custom-DOwls {
-  background-position: percentage((69 - 344)/ 343) 0;
+  background-position: percentage((76 - 368)/ 367) 0;
 }
 .icon-custom-DarkPanda {
-  background-position: percentage((70 - 344)/ 343) 0;
+  background-position: percentage((77 - 368)/ 367) 0;
 }
 .icon-custom-DarkBoy {
-  background-position: percentage((71 - 344)/ 343) 0;
+  background-position: percentage((78 - 368)/ 367) 0;
 }
 .icon-custom-DarkGirl {
-  background-position: percentage((72 - 344)/ 343) 0;
+  background-position: percentage((79 - 368)/ 367) 0;
 }
 .icon-custom-DarkLinkTunic {
-  background-position: percentage((73 - 344)/ 343) 0;
+  background-position: percentage((80 - 368)/ 367) 0;
 }
 .icon-custom-DarkLink {
-  background-position: percentage((74 - 344)/ 343) 0;
+  background-position: percentage((81 - 368)/ 367) 0;
 }
 .icon-custom-DarkSwatchy {
-  background-position: percentage((75 - 344)/ 343) 0;
+  background-position: percentage((82 - 368)/ 367) 0;
 }
 .icon-custom-DarkZelda {
-  background-position: percentage((76 - 344)/ 343) 0;
+  background-position: percentage((83 - 368)/ 367) 0;
 }
 .icon-custom-DarkZora {
-  background-position: percentage((77 - 344)/ 343) 0;
+  background-position: percentage((84 - 368)/ 367) 0;
 }
 .icon-custom-DeadpoolMythic {
-  background-position: percentage((78 - 344)/ 343) 0;
+  background-position: percentage((85 - 368)/ 367) 0;
 }
 .icon-custom-DeadpoolSirCzah {
-  background-position: percentage((79 - 344)/ 343) 0;
+  background-position: percentage((86 - 368)/ 367) 0;
 }
 .icon-custom-Deadrock {
-  background-position: percentage((80 - 344)/ 343) 0;
+  background-position: percentage((87 - 368)/ 367) 0;
 }
 .icon-custom-Decidueye {
-  background-position: percentage((81 - 344)/ 343) 0;
+  background-position: percentage((88 - 368)/ 367) 0;
 }
 .icon-custom-Dekar {
-  background-position: percentage((82 - 344)/ 343) 0;
+  background-position: percentage((89 - 368)/ 367) 0;
 }
 .icon-custom-DemonLink {
-  background-position: percentage((83 - 344)/ 343) 0;
+  background-position: percentage((90 - 368)/ 367) 0;
+}
+.icon-custom-Dennsen86 {
+  background-position: percentage((91 - 368)/ 367) 0;
+}
+.icon-custom-DigDug {
+  background-position: percentage((92 - 368)/ 367) 0;
 }
 .icon-custom-Dipper {
-  background-position: percentage((84 - 344)/ 343) 0;
+  background-position: percentage((93 - 368)/ 367) 0;
+}
+.icon-custom-Discord {
+  background-position: percentage((94 - 368)/ 367) 0;
 }
 .icon-custom-Dragonite {
-  background-position: percentage((85 - 344)/ 343) 0;
+  background-position: percentage((95 - 368)/ 367) 0;
 }
 .icon-custom-DrakeTheDragon {
-  background-position: percentage((86 - 344)/ 343) 0;
+  background-position: percentage((96 - 368)/ 367) 0;
 }
 .icon-custom-Eggplant {
-  background-position: percentage((87 - 344)/ 343) 0;
+  background-position: percentage((97 - 368)/ 367) 0;
 }
 .icon-custom-EmaSkye {
-  background-position: percentage((88 - 344)/ 343) 0;
+  background-position: percentage((98 - 368)/ 367) 0;
 }
 .icon-custom-EmoSaru {
-  background-position: percentage((89 - 344)/ 343) 0;
+  background-position: percentage((99 - 368)/ 367) 0;
 }
 .icon-custom-Ezlo {
-  background-position: percentage((90 - 344)/ 343) 0;
+  background-position: percentage((100 - 368)/ 367) 0;
+}
+.icon-custom-Fi {
+  background-position: percentage((101 - 368)/ 367) 0;
 }
 .icon-custom-FierceDeityLink {
-  background-position: percentage((91 - 344)/ 343) 0;
+  background-position: percentage((102 - 368)/ 367) 0;
 }
 .icon-custom-FinnMerten {
-  background-position: percentage((92 - 344)/ 343) 0;
+  background-position: percentage((103 - 368)/ 367) 0;
 }
 .icon-custom-FinnyBear {
-  background-position: percentage((93 - 344)/ 343) 0;
+  background-position: percentage((104 - 368)/ 367) 0;
 }
 .icon-custom-FloodgateFish {
-  background-position: percentage((94 - 344)/ 343) 0;
+  background-position: percentage((105 - 368)/ 367) 0;
 }
 .icon-custom-FlavorGuy {
-  background-position: percentage((95 - 344)/ 343) 0;
+  background-position: percentage((106 - 368)/ 367) 0;
 }
 .icon-custom-FoxLink {
-  background-position: percentage((96 - 344)/ 343) 0;
+  background-position: percentage((107 - 368)/ 367) 0;
 }
 .icon-custom-FreyaCrescent {
-  background-position: percentage((97 - 344)/ 343) 0;
+  background-position: percentage((108 - 368)/ 367) 0;
 }
 .icon-custom-Frisk {
-  background-position: percentage((98 - 344)/ 343) 0;
+  background-position: percentage((109 - 368)/ 367) 0;
 }
 .icon-custom-FrogLink {
-  background-position: percentage((99 - 344)/ 343) 0;
+  background-position: percentage((110 - 368)/ 367) 0;
 }
 .icon-custom-Fujin {
-  background-position: percentage((100 - 344)/ 343) 0;
+  background-position: percentage((111 - 368)/ 367) 0;
 }
 .icon-custom-FutureTrunks {
-  background-position: percentage((101 - 344)/ 343) 0;
+  background-position: percentage((112 - 368)/ 367) 0;
 }
 .icon-custom-Gamer {
-  background-position: percentage((102 - 344)/ 343) 0;
+  background-position: percentage((113 - 368)/ 367) 0;
 }
 .icon-custom-MiniGanon {
-  background-position: percentage((103 - 344)/ 343) 0;
+  background-position: percentage((114 - 368)/ 367) 0;
 }
 .icon-custom-Ganondorf {
-  background-position: percentage((104 - 344)/ 343) 0;
+  background-position: percentage((115 - 368)/ 367) 0;
 }
 .icon-custom-Garfield {
-  background-position: percentage((105 - 344)/ 343) 0;
+  background-position: percentage((116 - 368)/ 367) 0;
 }
 .icon-custom-Garnet {
-  background-position: percentage((106 - 344)/ 343) 0;
+  background-position: percentage((117 - 368)/ 367) 0;
 }
 .icon-custom-GaroMaster {
-  background-position: percentage((107 - 344)/ 343) 0;
+  background-position: percentage((118 - 368)/ 367) 0;
 }
 .icon-custom-GBCLink {
-  background-position: percentage((108 - 344)/ 343) 0;
+  background-position: percentage((119 - 368)/ 367) 0;
 }
 .icon-custom-Geno {
-  background-position: percentage((109 - 344)/ 343) 0;
+  background-position: percentage((120 - 368)/ 367) 0;
 }
 .icon-custom-GliitchWiitch {
-  background-position: percentage((110 - 344)/ 343) 0;
+  background-position: percentage((121 - 368)/ 367) 0;
 }
 .icon-custom-Gobli {
-  background-position: percentage((111 - 344)/ 343) 0;
+  background-position: percentage((122 - 368)/ 367) 0;
 }
 .icon-custom-Gooey {
-  background-position: percentage((112 - 344)/ 343) 0;
+  background-position: percentage((123 - 368)/ 367) 0;
 }
 .icon-custom-Goomba {
-  background-position: percentage((113 - 344)/ 343) 0;
+  background-position: percentage((124 - 368)/ 367) 0;
 }
 .icon-custom-Goose {
-  background-position: percentage((114 - 344)/ 343) 0;
+  background-position: percentage((125 - 368)/ 367) 0;
+}
+.icon-custom-GraalianNoob {
+  background-position: percentage((126 - 368)/ 367) 0;
 }
 .icon-custom-GrandPOOBear {
-  background-position: percentage((115 - 344)/ 343) 0;
+  background-position: percentage((127 - 368)/ 367) 0;
 }
 .icon-custom-Gretis {
-  background-position: percentage((116 - 344)/ 343) 0;
+  background-position: percentage((128 - 368)/ 367) 0;
 }
 .icon-custom-GruncleStan {
-  background-position: percentage((117 - 344)/ 343) 0;
+  background-position: percentage((129 - 368)/ 367) 0;
 }
 .icon-custom-Guiz {
-  background-position: percentage((118 - 344)/ 343) 0;
+  background-position: percentage((130 - 368)/ 367) 0;
 }
 .icon-custom-Hanna {
-  background-position: percentage((119 - 344)/ 343) 0;
+  background-position: percentage((131 - 368)/ 367) 0;
 }
 .icon-custom-HardhatBeetle {
-  background-position: percentage((120 - 344)/ 343) 0;
+  background-position: percentage((132 - 368)/ 367) 0;
 }
 .icon-custom-HatKid {
-  background-position: percentage((121 - 344)/ 343) 0;
+  background-position: percentage((133 - 368)/ 367) 0;
+}
+.icon-custom-HeadLink {
+  background-position: percentage((134 - 368)/ 367) 0;
 }
 .icon-custom-HeadlessLink {
-  background-position: percentage((122 - 344)/ 343) 0;
+  background-position: percentage((135 - 368)/ 367) 0;
 }
 .icon-custom-HelloKitty {
-  background-position: percentage((123 - 344)/ 343) 0;
+  background-position: percentage((136 - 368)/ 367) 0;
 }
 .icon-custom-HeroofAwakening {
-  background-position: percentage((124 - 344)/ 343) 0;
+  background-position: percentage((137 - 368)/ 367) 0;
 }
 .icon-custom-HeroofHyrule {
-  background-position: percentage((125 - 344)/ 343) 0;
-}
-.icon-custom-Hidari {
-  background-position: percentage((126 - 344)/ 343) 0;
+  background-position: percentage((138 - 368)/ 367) 0;
 }
 .icon-custom-HintTile {
-  background-position: percentage((127 - 344)/ 343) 0;
+  background-position: percentage((139 - 368)/ 367) 0;
 }
 .icon-custom-HoarderBush {
-  background-position: percentage((128 - 344)/ 343) 0;
+  background-position: percentage((140 - 368)/ 367) 0;
 }
 .icon-custom-HoarderPot {
-  background-position: percentage((129 - 344)/ 343) 0;
+  background-position: percentage((141 - 368)/ 367) 0;
 }
 .icon-custom-HoarderRock {
-  background-position: percentage((130 - 344)/ 343) 0;
+  background-position: percentage((142 - 368)/ 367) 0;
 }
 .icon-custom-HollowKnightMalmoWinter {
-  background-position: percentage((131 - 344)/ 343) 0;
+  background-position: percentage((143 - 368)/ 367) 0;
 }
 .icon-custom-HollowKnight {
-  background-position: percentage((132 - 344)/ 343) 0;
+  background-position: percentage((144 - 368)/ 367) 0;
 }
 .icon-custom-HomerSimpson {
-  background-position: percentage((133 - 344)/ 343) 0;
+  background-position: percentage((145 - 368)/ 367) 0;
+}
+.icon-custom-Hornet {
+  background-position: percentage((146 - 368)/ 367) 0;
 }
 .icon-custom-Hotdog {
-  background-position: percentage((134 - 344)/ 343) 0;
+  background-position: percentage((147 - 368)/ 367) 0;
 }
 .icon-custom-HyruleKnight {
-  background-position: percentage((135 - 344)/ 343) 0;
+  background-position: percentage((148 - 368)/ 367) 0;
 }
 .icon-custom-iBazly {
-  background-position: percentage((136 - 344)/ 343) 0;
+  background-position: percentage((149 - 368)/ 367) 0;
 }
 .icon-custom-Ignignokt {
-  background-position: percentage((137 - 344)/ 343) 0;
+  background-position: percentage((150 - 368)/ 367) 0;
 }
 .icon-custom-InformantWoman {
-  background-position: percentage((138 - 344)/ 343) 0;
+  background-position: percentage((151 - 368)/ 367) 0;
 }
 .icon-custom-Inkling {
-  background-position: percentage((139 - 344)/ 343) 0;
+  background-position: percentage((152 - 368)/ 367) 0;
 }
 .icon-custom-InvisibleLink {
-  background-position: percentage((140 - 344)/ 343) 0;
+  background-position: percentage((153 - 368)/ 367) 0;
 }
 .icon-custom-JackFrost {
-  background-position: percentage((141 - 344)/ 343) 0;
+  background-position: percentage((154 - 368)/ 367) 0;
 }
 .icon-custom-JasonFrudnick {
-  background-position: percentage((142 - 344)/ 343) 0;
+  background-position: percentage((155 - 368)/ 367) 0;
 }
 .icon-custom-Jasp {
-  background-position: percentage((143 - 344)/ 343) 0;
+  background-position: percentage((156 - 368)/ 367) 0;
 }
 .icon-custom-Jogurt {
-  background-position: percentage((144 - 344)/ 343) 0;
+  background-position: percentage((157 - 368)/ 367) 0;
 }
 .icon-custom-Kain {
-  background-position: percentage((145 - 344)/ 343) 0;
+  background-position: percentage((158 - 368)/ 367) 0;
 }
 .icon-custom-Katsura {
-  background-position: percentage((146 - 344)/ 343) 0;
+  background-position: percentage((159 - 368)/ 367) 0;
 }
 .icon-custom-Kecleon {
-  background-position: percentage((147 - 344)/ 343) 0;
+  background-position: percentage((160 - 368)/ 367) 0;
 }
 .icon-custom-Kefka {
-  background-position: percentage((148 - 344)/ 343) 0;
+  background-position: percentage((161 - 368)/ 367) 0;
 }
 .icon-custom-KennyMcCormick {
-  background-position: percentage((149 - 344)/ 343) 0;
+  background-position: percentage((162 - 368)/ 367) 0;
 }
 .icon-custom-Ketchup {
-  background-position: percentage((150 - 344)/ 343) 0;
+  background-position: percentage((163 - 368)/ 367) 0;
 }
 .icon-custom-Kholdstare {
-  background-position: percentage((151 - 344)/ 343) 0;
+  background-position: percentage((164 - 368)/ 367) 0;
 }
 .icon-custom-KingGothalion {
-  background-position: percentage((152 - 344)/ 343) 0;
+  background-position: percentage((165 - 368)/ 367) 0;
 }
 .icon-custom-KingGraham {
-  background-position: percentage((153 - 344)/ 343) 0;
+  background-position: percentage((166 - 368)/ 367) 0;
 }
 .icon-custom-Kinu {
-  background-position: percentage((154 - 344)/ 343) 0;
+  background-position: percentage((167 - 368)/ 367) 0;
 }
 .icon-custom-KirbyDreamland3 {
-  background-position: percentage((155 - 344)/ 343) 0;
+  background-position: percentage((168 - 368)/ 367) 0;
 }
 .icon-custom-Kirby {
-  background-position: percentage((156 - 344)/ 343) 0;
+  background-position: percentage((169 - 368)/ 367) 0;
 }
 .icon-custom-Kore8 {
-  background-position: percentage((157 - 344)/ 343) 0;
+  background-position: percentage((170 - 368)/ 367) 0;
 }
 .icon-custom-Korok {
-  background-position: percentage((158 - 344)/ 343) 0;
+  background-position: percentage((171 - 368)/ 367) 0;
 }
 .icon-custom-Kriv {
-  background-position: percentage((159 - 344)/ 343) 0;
+  background-position: percentage((172 - 368)/ 367) 0;
 }
 .icon-custom-Lakitu {
-  background-position: percentage((160 - 344)/ 343) 0;
+  background-position: percentage((173 - 368)/ 367) 0;
 }
 .icon-custom-Lapras {
-  background-position: percentage((161 - 344)/ 343) 0;
+  background-position: percentage((174 - 368)/ 367) 0;
 }
 .icon-custom-Lest {
-  background-position: percentage((162 - 344)/ 343) 0;
+  background-position: percentage((175 - 368)/ 367) 0;
+}
+.icon-custom-Lestat {
+  background-position: percentage((176 - 368)/ 367) 0;
 }
 .icon-custom-Lily {
-  background-position: percentage((163 - 344)/ 343) 0;
+  background-position: percentage((177 - 368)/ 367) 0;
 }
 .icon-custom-Linja {
-  background-position: percentage((164 - 344)/ 343) 0;
+  background-position: percentage((178 - 368)/ 367) 0;
 }
 .icon-custom-LinkRedrawn {
-  background-position: percentage((165 - 344)/ 343) 0;
+  background-position: percentage((179 - 368)/ 367) 0;
 }
 .icon-custom-HatColorLink {
-  background-position: percentage((166 - 344)/ 343) 0;
+  background-position: percentage((180 - 368)/ 367) 0;
 }
 .icon-custom-TunicColorLink {
-  background-position: percentage((167 - 344)/ 343) 0;
+  background-position: percentage((181 - 368)/ 367) 0;
 }
 .icon-custom-LittleHylian {
-  background-position: percentage((168 - 344)/ 343) 0;
+  background-position: percentage((182 - 368)/ 367) 0;
 }
 .icon-custom-Pony {
-  background-position: percentage((169 - 344)/ 343) 0;
+  background-position: percentage((183 - 368)/ 367) 0;
 }
 .icon-custom-Locke {
-  background-position: percentage((170 - 344)/ 343) 0;
+  background-position: percentage((184 - 368)/ 367) 0;
 }
 .icon-custom-FigaroMerchant {
-  background-position: percentage((171 - 344)/ 343) 0;
+  background-position: percentage((185 - 368)/ 367) 0;
 }
 .icon-custom-Lucario {
-  background-position: percentage((172 - 344)/ 343) 0;
+  background-position: percentage((186 - 368)/ 367) 0;
 }
 .icon-custom-Luffy {
-  background-position: percentage((173 - 344)/ 343) 0;
+  background-position: percentage((187 - 368)/ 367) 0;
 }
 .icon-custom-Luigi {
-  background-position: percentage((174 - 344)/ 343) 0;
+  background-position: percentage((188 - 368)/ 367) 0;
 }
 .icon-custom-LunaMaindo {
-  background-position: percentage((175 - 344)/ 343) 0;
+  background-position: percentage((189 - 368)/ 367) 0;
 }
 .icon-custom-LynelBotW {
-  background-position: percentage((176 - 344)/ 343) 0;
+  background-position: percentage((190 - 368)/ 367) 0;
 }
 .icon-custom-Madeline {
-  background-position: percentage((177 - 344)/ 343) 0;
+  background-position: percentage((191 - 368)/ 367) 0;
 }
 .icon-custom-Magus {
-  background-position: percentage((178 - 344)/ 343) 0;
+  background-position: percentage((192 - 368)/ 367) 0;
 }
 .icon-custom-Maiden {
-  background-position: percentage((179 - 344)/ 343) 0;
+  background-position: percentage((193 - 368)/ 367) 0;
+}
+.icon-custom-MajorasMask {
+  background-position: percentage((194 - 368)/ 367) 0;
 }
 .icon-custom-MallowCat {
-  background-position: percentage((180 - 344)/ 343) 0;
+  background-position: percentage((195 - 368)/ 367) 0;
 }
 .icon-custom-MangaLink {
-  background-position: percentage((181 - 344)/ 343) 0;
+  background-position: percentage((196 - 368)/ 367) 0;
 }
 .icon-custom-MapleQueen {
-  background-position: percentage((182 - 344)/ 343) 0;
+  background-position: percentage((197 - 368)/ 367) 0;
 }
 .icon-custom-Marin {
-  background-position: percentage((183 - 344)/ 343) 0;
+  background-position: percentage((198 - 368)/ 367) 0;
 }
 .icon-custom-MarioClassic {
-  background-position: percentage((184 - 344)/ 343) 0;
+  background-position: percentage((199 - 368)/ 367) 0;
 }
 .icon-custom-TanookiMario {
-  background-position: percentage((185 - 344)/ 343) 0;
+  background-position: percentage((200 - 368)/ 367) 0;
 }
 .icon-custom-MarioandCappy {
-  background-position: percentage((186 - 344)/ 343) 0;
+  background-position: percentage((201 - 368)/ 367) 0;
 }
 .icon-custom-MarisaKirisame {
-  background-position: percentage((187 - 344)/ 343) 0;
+  background-position: percentage((202 - 368)/ 367) 0;
 }
 .icon-custom-Matthias {
-  background-position: percentage((188 - 344)/ 343) 0;
+  background-position: percentage((203 - 368)/ 367) 0;
 }
 .icon-custom-Meatwad {
-  background-position: percentage((189 - 344)/ 343) 0;
+  background-position: percentage((204 - 368)/ 367) 0;
 }
 .icon-custom-Medallions {
-  background-position: percentage((190 - 344)/ 343) 0;
+  background-position: percentage((205 - 368)/ 367) 0;
 }
 .icon-custom-Medli {
-  background-position: percentage((191 - 344)/ 343) 0;
+  background-position: percentage((206 - 368)/ 367) 0;
 }
 .icon-custom-MegamanX {
-  background-position: percentage((192 - 344)/ 343) 0;
+  background-position: percentage((207 - 368)/ 367) 0;
+}
+.icon-custom-MegamanX2 {
+  background-position: percentage((208 - 368)/ 367) 0;
+}
+.icon-custom-MegaManClassic {
+  background-position: percentage((209 - 368)/ 367) 0;
 }
 .icon-custom-BabyMetroid {
-  background-position: percentage((193 - 344)/ 343) 0;
+  background-position: percentage((210 - 368)/ 367) 0;
 }
 .icon-custom-MewLp {
-  background-position: percentage((194 - 344)/ 343) 0;
+  background-position: percentage((211 - 368)/ 367) 0;
 }
 .icon-custom-MikeJones {
-  background-position: percentage((195 - 344)/ 343) 0;
+  background-position: percentage((212 - 368)/ 367) 0;
+}
+.icon-custom-Mimic {
+  background-position: percentage((213 - 368)/ 367) 0;
 }
 .icon-custom-MinishLink {
-  background-position: percentage((196 - 344)/ 343) 0;
+  background-position: percentage((214 - 368)/ 367) 0;
 }
 .icon-custom-MinishCapLink {
-  background-position: percentage((197 - 344)/ 343) 0;
+  background-position: percentage((215 - 368)/ 367) 0;
+}
+.icon-custom-Mipha {
+  background-position: percentage((216 - 368)/ 367) 0;
 }
 .icon-custom-missingno {
-  background-position: percentage((198 - 344)/ 343) 0;
+  background-position: percentage((217 - 368)/ 367) 0;
 }
 .icon-custom-Moblin {
-  background-position: percentage((199 - 344)/ 343) 0;
+  background-position: percentage((218 - 368)/ 367) 0;
 }
 .icon-custom-ModernLink {
-  background-position: percentage((200 - 344)/ 343) 0;
+  background-position: percentage((219 - 368)/ 367) 0;
 }
 .icon-custom-Mog {
-  background-position: percentage((201 - 344)/ 343) 0;
+  background-position: percentage((220 - 368)/ 367) 0;
 }
 .icon-custom-MomijiInubashiri {
-  background-position: percentage((202 - 344)/ 343) 0;
+  background-position: percentage((221 - 368)/ 367) 0;
 }
 .icon-custom-Moosh {
-  background-position: percentage((203 - 344)/ 343) 0;
+  background-position: percentage((222 - 368)/ 367) 0;
 }
 .icon-custom-Mouse {
-  background-position: percentage((204 - 344)/ 343) 0;
+  background-position: percentage((223 - 368)/ 367) 0;
 }
 .icon-custom-MsPaintDog {
-  background-position: percentage((205 - 344)/ 343) 0;
+  background-position: percentage((224 - 368)/ 367) 0;
 }
 .icon-custom-PowerUpwithPrideMushroom {
-  background-position: percentage((206 - 344)/ 343) 0;
+  background-position: percentage((225 - 368)/ 367) 0;
 }
 .icon-custom-NatureLink {
-  background-position: percentage((207 - 344)/ 343) 0;
+  background-position: percentage((226 - 368)/ 367) 0;
 }
 .icon-custom-Navi {
-  background-position: percentage((208 - 344)/ 343) 0;
+  background-position: percentage((227 - 368)/ 367) 0;
 }
 .icon-custom-Navirou {
-  background-position: percentage((209 - 344)/ 343) 0;
+  background-position: percentage((228 - 368)/ 367) 0;
 }
 .icon-custom-NedFlanders {
-  background-position: percentage((210 - 344)/ 343) 0;
+  background-position: percentage((229 - 368)/ 367) 0;
 }
 .icon-custom-NegativeLink {
-  background-position: percentage((211 - 344)/ 343) 0;
+  background-position: percentage((230 - 368)/ 367) 0;
 }
 .icon-custom-Neosad {
-  background-position: percentage((212 - 344)/ 343) 0;
+  background-position: percentage((231 - 368)/ 367) 0;
 }
 .icon-custom-NESLink {
-  background-position: percentage((213 - 344)/ 343) 0;
+  background-position: percentage((232 - 368)/ 367) 0;
 }
 .icon-custom-Ness {
-  background-position: percentage((214 - 344)/ 343) 0;
+  background-position: percentage((233 - 368)/ 367) 0;
 }
 .icon-custom-Nia {
-  background-position: percentage((215 - 344)/ 343) 0;
+  background-position: percentage((234 - 368)/ 367) 0;
 }
 .icon-custom-Niddraig {
-  background-position: percentage((216 - 344)/ 343) 0;
+  background-position: percentage((235 - 368)/ 367) 0;
 }
 .icon-custom-Niko {
-  background-position: percentage((217 - 344)/ 343) 0;
+  background-position: percentage((236 - 368)/ 367) 0;
 }
 .icon-custom-OldMan {
-  background-position: percentage((218 - 344)/ 343) 0;
+  background-position: percentage((237 - 368)/ 367) 0;
 }
 .icon-custom-Ori {
-  background-position: percentage((219 - 344)/ 343) 0;
+  background-position: percentage((238 - 368)/ 367) 0;
 }
 .icon-custom-OutlineLink {
-  background-position: percentage((220 - 344)/ 343) 0;
+  background-position: percentage((239 - 368)/ 367) 0;
 }
 .icon-custom-ParallelWorldsLink {
-  background-position: percentage((221 - 344)/ 343) 0;
+  background-position: percentage((240 - 368)/ 367) 0;
 }
 .icon-custom-Paula {
-  background-position: percentage((222 - 344)/ 343) 0;
+  background-position: percentage((241 - 368)/ 367) 0;
 }
 .icon-custom-PrincessPeach {
-  background-position: percentage((223 - 344)/ 343) 0;
+  background-position: percentage((242 - 368)/ 367) 0;
 }
 .icon-custom-PenguinLink {
-  background-position: percentage((224 - 344)/ 343) 0;
+  background-position: percentage((243 - 368)/ 367) 0;
 }
 .icon-custom-Pete {
-  background-position: percentage((225 - 344)/ 343) 0;
+  background-position: percentage((244 - 368)/ 367) 0;
 }
 .icon-custom-PhoenixWright {
-  background-position: percentage((226 - 344)/ 343) 0;
+  background-position: percentage((245 - 368)/ 367) 0;
 }
 .icon-custom-Pikachu {
-  background-position: percentage((227 - 344)/ 343) 0;
+  background-position: percentage((246 - 368)/ 367) 0;
 }
 .icon-custom-PinkRibbonLink {
-  background-position: percentage((228 - 344)/ 343) 0;
+  background-position: percentage((247 - 368)/ 367) 0;
 }
 .icon-custom-PiranhaPlant {
-  background-position: percentage((229 - 344)/ 343) 0;
+  background-position: percentage((248 - 368)/ 367) 0;
 }
 .icon-custom-PlagueKnight {
-  background-position: percentage((230 - 344)/ 343) 0;
+  background-position: percentage((249 - 368)/ 367) 0;
+}
+.icon-custom-Plouni {
+  background-position: percentage((250 - 368)/ 367) 0;
+}
+.icon-custom-Pokeysubtle {
+  background-position: percentage((251 - 368)/ 367) 0;
 }
 .icon-custom-Pokey {
-  background-position: percentage((231 - 344)/ 343) 0;
+  background-position: percentage((252 - 368)/ 367) 0;
 }
 .icon-custom-Popoi {
-  background-position: percentage((232 - 344)/ 343) 0;
+  background-position: percentage((253 - 368)/ 367) 0;
 }
 .icon-custom-Poppy {
-  background-position: percentage((233 - 344)/ 343) 0;
+  background-position: percentage((254 - 368)/ 367) 0;
 }
 .icon-custom-PorgKnight {
-  background-position: percentage((234 - 344)/ 343) 0;
+  background-position: percentage((255 - 368)/ 367) 0;
 }
 .icon-custom-PowerRanger {
-  background-position: percentage((235 - 344)/ 343) 0;
+  background-position: percentage((256 - 368)/ 367) 0;
 }
 .icon-custom-PowerpuffGirl {
-  background-position: percentage((236 - 344)/ 343) 0;
+  background-position: percentage((257 - 368)/ 367) 0;
 }
 .icon-custom-PrideLink {
-  background-position: percentage((237 - 344)/ 343) 0;
+  background-position: percentage((258 - 368)/ 367) 0;
 }
 .icon-custom-Primm {
-  background-position: percentage((238 - 344)/ 343) 0;
+  background-position: percentage((259 - 368)/ 367) 0;
 }
 .icon-custom-PrincessBubblegum {
-  background-position: percentage((239 - 344)/ 343) 0;
+  background-position: percentage((260 - 368)/ 367) 0;
+}
+.icon-custom-ProfRendererGrizzleton {
+  background-position: percentage((261 - 368)/ 367) 0;
 }
 .icon-custom-TheProfessor {
-  background-position: percentage((240 - 344)/ 343) 0;
+  background-position: percentage((262 - 368)/ 367) 0;
 }
 .icon-custom-Psyduck {
-  background-position: percentage((241 - 344)/ 343) 0;
+  background-position: percentage((263 - 368)/ 367) 0;
 }
 .icon-custom-ThePug {
-  background-position: percentage((242 - 344)/ 343) 0;
+  background-position: percentage((264 - 368)/ 367) 0;
 }
 .icon-custom-PurpleChest {
-  background-position: percentage((243 - 344)/ 343) 0;
+  background-position: percentage((265 - 368)/ 367) 0;
 }
 .icon-custom-Pyro {
-  background-position: percentage((244 - 344)/ 343) 0;
+  background-position: percentage((266 - 368)/ 367) 0;
 }
 .icon-custom-QuadBanger {
-  background-position: percentage((245 - 344)/ 343) 0;
+  background-position: percentage((267 - 368)/ 367) 0;
 }
 .icon-custom-RainbowLink {
-  background-position: percentage((246 - 344)/ 343) 0;
+  background-position: percentage((268 - 368)/ 367) 0;
 }
 .icon-custom-Rat {
-  background-position: percentage((247 - 344)/ 343) 0;
+  background-position: percentage((269 - 368)/ 367) 0;
 }
 .icon-custom-RedMage {
-  background-position: percentage((248 - 344)/ 343) 0;
+  background-position: percentage((270 - 368)/ 367) 0;
 }
 .icon-custom-Remeer {
-  background-position: percentage((249 - 344)/ 343) 0;
+  background-position: percentage((271 - 368)/ 367) 0;
 }
 .icon-custom-RemusRBlack {
-  background-position: percentage((250 - 344)/ 343) 0;
+  background-position: percentage((272 - 368)/ 367) 0;
 }
 .icon-custom-Rick {
-  background-position: percentage((251 - 344)/ 343) 0;
+  background-position: percentage((273 - 368)/ 367) 0;
 }
 .icon-custom-Robo-Link9000 {
-  background-position: percentage((252 - 344)/ 343) 0;
+  background-position: percentage((274 - 368)/ 367) 0;
 }
 .icon-custom-Rocko {
-  background-position: percentage((253 - 344)/ 343) 0;
+  background-position: percentage((275 - 368)/ 367) 0;
 }
 .icon-custom-Rottytops {
-  background-position: percentage((254 - 344)/ 343) 0;
+  background-position: percentage((276 - 368)/ 367) 0;
 }
 .icon-custom-Rover {
-  background-position: percentage((255 - 344)/ 343) 0;
+  background-position: percentage((277 - 368)/ 367) 0;
 }
 .icon-custom-RoyKoopa {
-  background-position: percentage((256 - 344)/ 343) 0;
+  background-position: percentage((278 - 368)/ 367) 0;
 }
 .icon-custom-Rumia {
-  background-position: percentage((257 - 344)/ 343) 0;
+  background-position: percentage((279 - 368)/ 367) 0;
 }
 .icon-custom-Rydia {
-  background-position: percentage((258 - 344)/ 343) 0;
+  background-position: percentage((280 - 368)/ 367) 0;
 }
 .icon-custom-Ryu {
-  background-position: percentage((259 - 344)/ 343) 0;
+  background-position: percentage((281 - 368)/ 367) 0;
 }
 .icon-custom-SailorMoon {
-  background-position: percentage((260 - 344)/ 343) 0;
+  background-position: percentage((282 - 368)/ 367) 0;
 }
 .icon-custom-Saitama {
-  background-position: percentage((261 - 344)/ 343) 0;
+  background-position: percentage((283 - 368)/ 367) 0;
 }
 .icon-custom-SamusSuperMetroid {
-  background-position: percentage((262 - 344)/ 343) 0;
+  background-position: percentage((284 - 368)/ 367) 0;
 }
 .icon-custom-Samus {
-  background-position: percentage((263 - 344)/ 343) 0;
+  background-position: percentage((285 - 368)/ 367) 0;
 }
 .icon-custom-SamusClassic {
-  background-position: percentage((264 - 344)/ 343) 0;
+  background-position: percentage((286 - 368)/ 367) 0;
 }
 .icon-custom-SantaHatLink {
-  background-position: percentage((265 - 344)/ 343) 0;
+  background-position: percentage((287 - 368)/ 367) 0;
 }
 .icon-custom-SantaLink {
-  background-position: percentage((266 - 344)/ 343) 0;
+  background-position: percentage((288 - 368)/ 367) 0;
 }
 .icon-custom-Scholar {
-  background-position: percentage((267 - 344)/ 343) 0;
+  background-position: percentage((289 - 368)/ 367) 0;
 }
 .icon-custom-Selan {
-  background-position: percentage((268 - 344)/ 343) 0;
+  background-position: percentage((290 - 368)/ 367) 0;
 }
 .icon-custom-SevenS1ns {
-  background-position: percentage((269 - 344)/ 343) 0;
+  background-position: percentage((291 - 368)/ 367) 0;
 }
 .icon-custom-Shadow {
-  background-position: percentage((270 - 344)/ 343) 0;
+  background-position: percentage((292 - 368)/ 367) 0;
 }
 .icon-custom-ShadowSakura {
-  background-position: percentage((271 - 344)/ 343) 0;
+  background-position: percentage((293 - 368)/ 367) 0;
 }
 .icon-custom-Shantae {
-  background-position: percentage((272 - 344)/ 343) 0;
+  background-position: percentage((294 - 368)/ 367) 0;
 }
 .icon-custom-Shuppet {
-  background-position: percentage((273 - 344)/ 343) 0;
+  background-position: percentage((295 - 368)/ 367) 0;
 }
 .icon-custom-ShyGal {
-  background-position: percentage((274 - 344)/ 343) 0;
+  background-position: percentage((296 - 368)/ 367) 0;
 }
 .icon-custom-ShyGuy {
-  background-position: percentage((275 - 344)/ 343) 0;
+  background-position: percentage((297 - 368)/ 367) 0;
 }
 .icon-custom-SighnWaive {
-  background-position: percentage((276 - 344)/ 343) 0;
+  background-position: percentage((298 - 368)/ 367) 0;
 }
 .icon-custom-Skunk {
-  background-position: percentage((277 - 344)/ 343) 0;
+  background-position: percentage((299 - 368)/ 367) 0;
 }
 .icon-custom-Slime {
-  background-position: percentage((278 - 344)/ 343) 0;
+  background-position: percentage((300 - 368)/ 367) 0;
 }
 .icon-custom-Slowpoke {
-  background-position: percentage((279 - 344)/ 343) 0;
+  background-position: percentage((301 - 368)/ 367) 0;
 }
 .icon-custom-SNESController {
-  background-position: percentage((280 - 344)/ 343) 0;
+  background-position: percentage((302 - 368)/ 367) 0;
 }
 .icon-custom-SodaCan {
-  background-position: percentage((281 - 344)/ 343) 0;
+  background-position: percentage((303 - 368)/ 367) 0;
 }
 .icon-custom-SolaireofAstora {
-  background-position: percentage((282 - 344)/ 343) 0;
+  background-position: percentage((304 - 368)/ 367) 0;
 }
 .icon-custom-HyruleSoldier {
-  background-position: percentage((283 - 344)/ 343) 0;
+  background-position: percentage((305 - 368)/ 367) 0;
 }
 .icon-custom-SonictheHedgehog {
-  background-position: percentage((284 - 344)/ 343) 0;
+  background-position: percentage((306 - 368)/ 367) 0;
 }
 .icon-custom-Sora {
-  background-position: percentage((285 - 344)/ 343) 0;
+  background-position: percentage((307 - 368)/ 367) 0;
 }
 .icon-custom-SoraKH1 {
-  background-position: percentage((286 - 344)/ 343) 0;
+  background-position: percentage((308 - 368)/ 367) 0;
+}
+.icon-custom-SpikedRoller {
+  background-position: percentage((309 - 368)/ 367) 0;
 }
 .icon-custom-SpongebobSquarepants {
-  background-position: percentage((287 - 344)/ 343) 0;
+  background-position: percentage((310 - 368)/ 367) 0;
 }
 .icon-custom-Squall {
-  background-position: percentage((288 - 344)/ 343) 0;
+  background-position: percentage((311 - 368)/ 367) 0;
 }
 .icon-custom-Squirrel {
-  background-position: percentage((289 - 344)/ 343) 0;
+  background-position: percentage((312 - 368)/ 367) 0;
 }
 .icon-custom-Squirtle {
-  background-position: percentage((290 - 344)/ 343) 0;
+  background-position: percentage((313 - 368)/ 367) 0;
 }
 .icon-custom-Stalfos {
-  background-position: percentage((291 - 344)/ 343) 0;
+  background-position: percentage((314 - 368)/ 367) 0;
 }
 .icon-custom-Stan {
-  background-position: percentage((292 - 344)/ 343) 0;
+  background-position: percentage((315 - 368)/ 367) 0;
 }
 .icon-custom-StaticLink {
-  background-position: percentage((293 - 344)/ 343) 0;
+  background-position: percentage((316 - 368)/ 367) 0;
 }
 .icon-custom-SteamedHams {
-  background-position: percentage((294 - 344)/ 343) 0;
+  background-position: percentage((317 - 368)/ 367) 0;
 }
 .icon-custom-StickMan {
-  background-position: percentage((295 - 344)/ 343) 0;
+  background-position: percentage((318 - 368)/ 367) 0;
 }
 .icon-custom-SuperBomb {
-  background-position: percentage((296 - 344)/ 343) 0;
+  background-position: percentage((319 - 368)/ 367) 0;
 }
 .icon-custom-SuperBunny {
-  background-position: percentage((297 - 344)/ 343) 0;
+  background-position: percentage((320 - 368)/ 367) 0;
 }
 .icon-custom-SuperMeatBoy {
-  background-position: percentage((298 - 344)/ 343) 0;
+  background-position: percentage((321 - 368)/ 367) 0;
 }
 .icon-custom-Susie {
-  background-position: percentage((299 - 344)/ 343) 0;
+  background-position: percentage((322 - 368)/ 367) 0;
 }
 .icon-custom-Swatchy {
-  background-position: percentage((300 - 344)/ 343) 0;
+  background-position: percentage((323 - 368)/ 367) 0;
+}
+.icon-custom-Swiper {
+  background-position: percentage((324 - 368)/ 367) 0;
 }
 .icon-custom-TASBot {
-  background-position: percentage((301 - 344)/ 343) 0;
+  background-position: percentage((325 - 368)/ 367) 0;
 }
 .icon-custom-TeaTime {
-  background-position: percentage((302 - 344)/ 343) 0;
+  background-position: percentage((326 - 368)/ 367) 0;
 }
 .icon-custom-TerraEsper {
-  background-position: percentage((303 - 344)/ 343) 0;
+  background-position: percentage((327 - 368)/ 367) 0;
 }
 .icon-custom-TerryContactDS {
-  background-position: percentage((304 - 344)/ 343) 0;
+  background-position: percentage((328 - 368)/ 367) 0;
 }
 .icon-custom-Tetra {
-  background-position: percentage((305 - 344)/ 343) 0;
+  background-position: percentage((329 - 368)/ 367) 0;
 }
 .icon-custom-TGH {
-  background-position: percentage((306 - 344)/ 343) 0;
+  background-position: percentage((330 - 368)/ 367) 0;
 }
 .icon-custom-Thief {
-  background-position: percentage((307 - 344)/ 343) 0;
+  background-position: percentage((331 - 368)/ 367) 0;
 }
 .icon-custom-ThinkDorm {
-  background-position: percentage((308 - 344)/ 343) 0;
+  background-position: percentage((332 - 368)/ 367) 0;
 }
 .icon-custom-Thomcrow {
-  background-position: percentage((309 - 344)/ 343) 0;
+  background-position: percentage((333 - 368)/ 367) 0;
 }
 .icon-custom-Tile {
-  background-position: percentage((310 - 344)/ 343) 0;
+  background-position: percentage((334 - 368)/ 367) 0;
 }
 .icon-custom-Tingle {
-  background-position: percentage((311 - 344)/ 343) 0;
+  background-position: percentage((335 - 368)/ 367) 0;
 }
 .icon-custom-TMNT {
-  background-position: percentage((312 - 344)/ 343) 0;
+  background-position: percentage((336 - 368)/ 367) 0;
 }
 .icon-custom-Toad {
-  background-position: percentage((313 - 344)/ 343) 0;
+  background-position: percentage((337 - 368)/ 367) 0;
 }
 .icon-custom-Toadette {
-  background-position: percentage((314 - 344)/ 343) 0;
+  background-position: percentage((338 - 368)/ 367) 0;
 }
 .icon-custom-CaptainToadette {
-  background-position: percentage((315 - 344)/ 343) 0;
+  background-position: percentage((339 - 368)/ 367) 0;
 }
 .icon-custom-TotemLinks {
-  background-position: percentage((316 - 344)/ 343) 0;
+  background-position: percentage((340 - 368)/ 367) 0;
 }
 .icon-custom-TrogdortheBurninator {
-  background-position: percentage((317 - 344)/ 343) 0;
+  background-position: percentage((341 - 368)/ 367) 0;
 }
 .icon-custom-TPZelda {
-  background-position: percentage((318 - 344)/ 343) 0;
+  background-position: percentage((342 - 368)/ 367) 0;
 }
 .icon-custom-TwoFaced {
-  background-position: percentage((319 - 344)/ 343) 0;
+  background-position: percentage((343 - 368)/ 367) 0;
 }
 .icon-custom-TytheTasmanianTiger {
-  background-position: percentage((320 - 344)/ 343) 0;
+  background-position: percentage((344 - 368)/ 367) 0;
 }
 .icon-custom-Ultros {
-  background-position: percentage((321 - 344)/ 343) 0;
+  background-position: percentage((345 - 368)/ 367) 0;
 }
 .icon-custom-Valeera {
-  background-position: percentage((322 - 344)/ 343) 0;
+  background-position: percentage((346 - 368)/ 367) 0;
 }
 .icon-custom-VanillaLink {
-  background-position: percentage((323 - 344)/ 343) 0;
+  background-position: percentage((347 - 368)/ 367) 0;
 }
 .icon-custom-Vaporeon {
-  background-position: percentage((324 - 344)/ 343) 0;
+  background-position: percentage((348 - 368)/ 367) 0;
 }
 .icon-custom-Vegeta {
-  background-position: percentage((325 - 344)/ 343) 0;
+  background-position: percentage((349 - 368)/ 367) 0;
 }
 .icon-custom-Vera {
-  background-position: percentage((326 - 344)/ 343) 0;
+  background-position: percentage((350 - 368)/ 367) 0;
 }
 .icon-custom-Vitreous {
-  background-position: percentage((327 - 344)/ 343) 0;
+  background-position: percentage((351 - 368)/ 367) 0;
 }
 .icon-custom-Vivi {
-  background-position: percentage((328 - 344)/ 343) 0;
+  background-position: percentage((352 - 368)/ 367) 0;
 }
 .icon-custom-Vivian {
-  background-position: percentage((329 - 344)/ 343) 0;
+  background-position: percentage((353 - 368)/ 367) 0;
 }
 .icon-custom-Wario {
-  background-position: percentage((330 - 344)/ 343) 0;
+  background-position: percentage((354 - 368)/ 367) 0;
 }
 .icon-custom-WhiteMage {
-  background-position: percentage((331 - 344)/ 343) 0;
+  background-position: percentage((355 - 368)/ 367) 0;
 }
 .icon-custom-Will {
-  background-position: percentage((332 - 344)/ 343) 0;
+  background-position: percentage((356 - 368)/ 367) 0;
 }
 .icon-custom-Wizzrobe {
-  background-position: percentage((333 - 344)/ 343) 0;
+  background-position: percentage((357 - 368)/ 367) 0;
 }
 .icon-custom-WolfLinkFestive {
-  background-position: percentage((334 - 344)/ 343) 0;
+  background-position: percentage((358 - 368)/ 367) 0;
 }
 .icon-custom-WolfLinkTP {
-  background-position: percentage((335 - 344)/ 343) 0;
+  background-position: percentage((359 - 368)/ 367) 0;
 }
 .icon-custom-Yoshi {
-  background-position: percentage((336 - 344)/ 343) 0;
+  background-position: percentage((360 - 368)/ 367) 0;
 }
 .icon-custom-YunicaTovah {
-  background-position: percentage((337 - 344)/ 343) 0;
+  background-position: percentage((361 - 368)/ 367) 0;
 }
 .icon-custom-Zandra {
-  background-position: percentage((338 - 344)/ 343) 0;
+  background-position: percentage((362 - 368)/ 367) 0;
 }
 .icon-custom-ZebraUnicorn {
-  background-position: percentage((339 - 344)/ 343) 0;
+  background-position: percentage((363 - 368)/ 367) 0;
 }
 .icon-custom-Zeckemyro {
-  background-position: percentage((340 - 344)/ 343) 0;
+  background-position: percentage((364 - 368)/ 367) 0;
 }
 .icon-custom-Zelda {
-  background-position: percentage((341 - 344)/ 343) 0;
+  background-position: percentage((365 - 368)/ 367) 0;
 }
 .icon-custom-ZeroSuitSamus {
-  background-position: percentage((342 - 344)/ 343) 0;
+  background-position: percentage((366 - 368)/ 367) 0;
 }
 .icon-custom-Zora {
-  background-position: percentage((343 - 344)/ 343) 0;
+  background-position: percentage((367 - 368)/ 367) 0;
 }

--- a/resources/views/about.blade.php
+++ b/resources/views/about.blade.php
@@ -18,15 +18,4 @@
         <p>{!! $block !!}</p>
     @endforeach
 </div>
-
-<div class="card card-body bg-light">
-    <iframe class="mx-auto"
-        allow="encrypted-media"
-        allowfullscreen
-        frameborder="0"
-        gesture="media"
-        height="315"
-        src="https://www.youtube.com/embed/YaEypVa3kx4?rel=0"
-        width="560"></iframe>
-</div>
 @overwrite

--- a/resources/views/contribute.blade.php
+++ b/resources/views/contribute.blade.php
@@ -18,17 +18,6 @@
 
     <div class="card border-info mt-4">
         <div class="card-header bg-info">
-            <h3 class="card-title text-white">{{ __('contribute.cards.live.header') }}</h3>
-        </div>
-        <div class="card-body">
-            @foreach (__('contribute.cards.live.content') as $block)
-                <p>{!! $block !!}</p>
-            @endforeach
-        </div>
-    </div>
-
-    <div class="card border-info mt-4">
-        <div class="card-header bg-info">
             <h3 class="card-title text-white">{{ __('contribute.cards.other.header') }}</h3>
         </div>
         <div class="card-body">

--- a/resources/views/options.blade.php
+++ b/resources/views/options.blade.php
@@ -363,7 +363,7 @@
             <div class="row">
                 <div class="col-md-6">
                     <ul>
-                        <li>10x Big Key</li>
+                        <li>11x Big Key</li>
                         <li>1x Bombos</li>
                         <li>1x Book Of Mudora</li>
                         <li>1x Boomerang</li>
@@ -382,7 +382,7 @@
                         <li>11x Heart Container</li>
                         <li>1x Hookshot</li>
                         <li>1x Ice Rod</li>
-                        <li>28x Small Key</li>
+                        <li>29x Small Key</li>
                         <li>1x Lamp</li>
                         <li>1x Magic Cape</li>
                         <li>1x Magic Mirror</li>

--- a/resources/views/races.blade.php
+++ b/resources/views/races.blade.php
@@ -30,5 +30,19 @@
             @endforeach
         </div>
     </div>
+
+    <div class="card border-info mt-4">
+        <div class="card-header bg-info">
+            <h3 class="card-title text-white">{{ __('races.cards.language_tournament.header') }}</h3>
+        </div>
+        <div class="card-body">
+            @foreach (__('races.cards.language_tournament.sections') as $section)
+            <h4>{{ $section['header'] }}</h4>
+                @foreach ($section['content'] as $block)
+                    <p>{!! $block !!}</p>
+                @endforeach
+            @endforeach
+        </div>
+    </div>
 </div>
 @overwrite

--- a/resources/views/races.blade.php
+++ b/resources/views/races.blade.php
@@ -33,13 +33,17 @@
 
     <div class="card border-info mt-4">
         <div class="card-header bg-info">
-            <h3 class="card-title text-white">{{ __('races.cards.language_tournament.header') }}</h3>
+            <h3 class="card-title text-white">{{ __('races.cards.foreign_language.header') }}</h3>
         </div>
         <div class="card-body">
-            @foreach (__('races.cards.language_tournament.sections') as $section)
-            <h4>{{ $section['header'] }}</h4>
-                @foreach ($section['content'] as $block)
-                    <p>{!! $block !!}</p>
+            @foreach (__('races.cards.foreign_language.languages') as $language)
+                <h3>{{ $language['header'] }}</h3>
+                <p>{{ $language['description'] }}</p>
+                @foreach ($language['sections'] as $section)
+                <h4>{{ $section['header'] }}</h4>
+                    @foreach ($section['content'] as $block)
+                        <p>{!! $block !!}</p>
+                    @endforeach
                 @endforeach
             @endforeach
         </div>

--- a/resources/views/races.blade.php
+++ b/resources/views/races.blade.php
@@ -31,22 +31,21 @@
         </div>
     </div>
 
+    @foreach (__('races.cards.foreign_language.languages') as $language)
     <div class="card border-info mt-4">
         <div class="card-header bg-info">
-            <h3 class="card-title text-white">{{ __('races.cards.foreign_language.header') }}</h3>
+            <h3 class="card-title text-white">{{ $language['header'] }}</h3>
         </div>
         <div class="card-body">
-            @foreach (__('races.cards.foreign_language.languages') as $language)
-                <h3>{{ $language['header'] }}</h3>
-                <p>{!! $language['description'] !!}</p>
-                @foreach ($language['sections'] as $section)
+            <p>{!! $language['description'] !!}</p>
+            @foreach ($language['sections'] as $section)
                 <h4>{{ $section['header'] }}</h4>
                     @foreach ($section['content'] as $block)
                         <p>{!! $block !!}</p>
                     @endforeach
-                @endforeach
             @endforeach
         </div>
     </div>
+    @endforeach
 </div>
 @overwrite

--- a/resources/views/races.blade.php
+++ b/resources/views/races.blade.php
@@ -38,7 +38,7 @@
         <div class="card-body">
             @foreach (__('races.cards.foreign_language.languages') as $language)
                 <h3>{{ $language['header'] }}</h3>
-                <p>{{!! $language['description'] !!}}</p>
+                <p>{!! $language['description'] !!}</p>
                 @foreach ($language['sections'] as $section)
                 <h4>{{ $section['header'] }}</h4>
                     @foreach ($section['content'] as $block)

--- a/resources/views/races.blade.php
+++ b/resources/views/races.blade.php
@@ -38,7 +38,7 @@
         <div class="card-body">
             @foreach (__('races.cards.foreign_language.languages') as $language)
                 <h3>{{ $language['header'] }}</h3>
-                <p>{{ $language['description'] }}</p>
+                <p>{{!! $language['description'] !!}}</p>
                 @foreach ($language['sections'] as $section)
                 <h4>{{ $section['header'] }}</h4>
                     @foreach ($section['content'] as $block)

--- a/resources/views/races.blade.php
+++ b/resources/views/races.blade.php
@@ -19,17 +19,6 @@
 
     <div class="card border-info mt-4">
         <div class="card-header bg-info">
-            <h3 class="card-title text-white">{{ __('races.cards.network.header') }}</h3>
-        </div>
-        <div class="card-body">
-            @foreach (__('races.cards.network.content') as $block)
-                <p>{!! $block !!}</p>
-            @endforeach
-        </div>
-    </div>
-
-    <div class="card border-info mt-4">
-        <div class="card-header bg-info">
             <h3 class="card-title text-white">{{ __('races.cards.tournament.header') }}</h3>
         </div>
         <div class="card-body">

--- a/resources/views/resources.blade.php
+++ b/resources/views/resources.blade.php
@@ -16,17 +16,6 @@
 
     <div class="card border-info mt-4">
         <div class="card-header bg-info">
-            <h3 class="card-title text-white">{{ __('resources.cards.learn.header') }}</h3>
-        </div>
-        <div class="card-body">
-            @foreach (__('resources.cards.learn.content') as $block)
-                <p>{!! $block !!}</p>
-            @endforeach
-        </div>
-    </div>
-
-    <div class="card border-info mt-4">
-        <div class="card-header bg-info">
             <h3 class="card-title text-white">{{ __('resources.cards.external.header') }}</h3>
         </div>
         <div class="card-body">

--- a/resources/views/updates.blade.php
+++ b/resources/views/updates.blade.php
@@ -14,6 +14,7 @@
         <li>Finding a map in Hyrule Castle will now properly show the map on your item menu while in the Sewers section of Hyrule Castle.</li>
         <li>Enemizer: Firebars will now only damage the player if the firebar is on the same layer as Link.</li>
         <li>Customizer: Will now default to enabling spoilers on generated games.  This can still be set to Disabled, On Generate, or Mystery as needed.</li>
+        <li>Miscellaneous website updates.</li>
         <li>Added new player options<br />
             <img src="https://alttpr.s3.us-east-2.amazonaws.com/sprites.31.0.9.lg.png"
                 alt="Link sprite options" style="width:50%" /></li>

--- a/resources/views/updates.blade.php
+++ b/resources/views/updates.blade.php
@@ -2,6 +2,22 @@
 
 @section('content')
 
+<h2>v31.0.9</h2>
+<div class="card card-body bg-light mb-3">
+    <ul>
+        <li>New post-generation option called "Reduce Flashing" has been added.  Thanks Cassidymoen!</li>
+        <li>The credits have been updated to include additional individuals we want to recognize for their contributions to this project.</li>
+        <li>The author of the sprite you're using will now appear in the end credits.</li>
+        <li>When underworld clips are enabled, a new line will appear in the menu indicating what bosses have been defeated.</li>
+        <li>The bottles now work like other items that share an inventory space when using Quickswap.  Press L+R to swap bottles.</li>
+        <li>Finding a map in Hyrule Castle will now properly show the map on your item menu while in the Sewers section of Hyrule Castle.</li>
+        <li>Enemizer: Firebars will now only damage the player if the firebar is on the same layer as Link.</li>
+        <li>Added new player options<br />
+            <img src="https://alttpr.s3.us-east-2.amazonaws.com/sprites.31.0.9.lg.png"
+                alt="Link sprite options" style="width:50%" /></li>
+    </ul>
+</div>
+
 <h2>v31.0.8</h2>
 <div class="card card-body bg-light mb-3">
     <ul>

--- a/resources/views/updates.blade.php
+++ b/resources/views/updates.blade.php
@@ -14,6 +14,10 @@
         <li>Finding a map in Hyrule Castle will now properly show the map on your item menu while in the Sewers section of Hyrule Castle.</li>
         <li>Enemizer: Firebars will now only damage the player if the firebar is on the same layer as Link.</li>
         <li>Customizer: Will now default to enabling spoilers on generated games.  This can still be set to Disabled, On Generate, or Mystery as needed.</li>
+        <li>Overworld YBA now puts Moon Pearl-less access to Ganon in logic</li>
+        <li>Bot authors may now specify a game name and notes in API requests to /api/randomizer</li>
+        <li>A new "Random" option was added for the heart color.  Thanks Doctor Blue!</li>
+        <li>Ganon will now say something New and Unique™ when Silver Arrows are unavailable.</li>
         <li>Miscellaneous website updates.</li>
         <li>Added new player options<br />
             <img src="https://alttpr.s3.us-east-2.amazonaws.com/sprites.31.0.9.lg.png"

--- a/resources/views/updates.blade.php
+++ b/resources/views/updates.blade.php
@@ -10,8 +10,10 @@
         <li>The author of the sprite you're using will now appear in the end credits.</li>
         <li>When underworld clips are enabled, a new line will appear in the menu indicating what bosses have been defeated.</li>
         <li>The bottles now work like other items that share an inventory space when using Quickswap.  Press L+R to swap bottles.</li>
+        <li>The website will now, by default, generate games where Quickswap is allowed.  This can still be disabled via the API.</li>
         <li>Finding a map in Hyrule Castle will now properly show the map on your item menu while in the Sewers section of Hyrule Castle.</li>
         <li>Enemizer: Firebars will now only damage the player if the firebar is on the same layer as Link.</li>
+        <li>Customizer: Will now default to enabling spoilers on generated games.  This can still be set to Disabled, On Generate, or Mystery as needed.</li>
         <li>Added new player options<br />
             <img src="https://alttpr.s3.us-east-2.amazonaws.com/sprites.31.0.9.lg.png"
                 alt="Link sprite options" style="width:50%" /></li>

--- a/routes/console.php
+++ b/routes/console.php
@@ -45,7 +45,7 @@ Artisan::command('alttp:dailies {days=7}', function ($days) {
                 'none' => 'NoGlitches',
                 'overworld_glitches' => 'OverworldGlitches',
                 'major_glitches' => 'MajorGlitches',
-                'no_logic' => 'None',
+                'no_logic' => 'NoLogic',
             ][getWeighted('glitches_required')];
 
             $world = World::factory(getWeighted('world_state'), [

--- a/strings/ganon_phase_3_no_silvers.txt
+++ b/strings/ganon_phase_3_no_silvers.txt
@@ -79,7 +79,8 @@ Did you find
 the arrows in
 Recycle Bin?
 -
-Arrows?
+Silver Arrows?
+
 LUL
 -
 Imagine
@@ -112,8 +113,8 @@ DID YOU FIND
 THE ARROWS IN
 LEVEL 9?
 -
-SILVER IS SO
-v30 ANYWAY
+Silver Arrows
+are so v30
 -
 OH, NO, THEY
 ACTUALLY SAID
@@ -138,8 +139,4 @@ Like A Record
 SILLY HERO,
 SILVER IS FOR
 WEREWOLVES!
--
-Did you find
-The arrows in
-Gensokyo?
 -

--- a/strings/ganon_phase_3_no_silvers.txt
+++ b/strings/ganon_phase_3_no_silvers.txt
@@ -17,7 +17,7 @@ The Moon?
 -
 Did you find
 The arrows
-In /dev/null?
+In dev null?
 -
 I have sold
 The arrows for
@@ -27,7 +27,7 @@ Did you find
 The arrows in
 Count Dracula?
 -
-Error 404:
+Error 404
 Silver arrows
 not found.
 -
@@ -47,17 +47,9 @@ Did you find
 the arrows in
 Jabu's belly?
 -
-Did you find
-the arrows in
-you, all along
--
 Silver is not
 an appropriate
 arrow material
--
-Did you find
-the arrows on
-Thor's throne?
 -
 Did you find
 the arrows in
@@ -69,11 +61,7 @@ To win?
 -
 DID YOU FIND
 THE ARROWS IN
-KEFKAS TOWER
--
-Did you find
-the arrows in
-shadow realm?
+KEFKA'S TOWER
 -
 Did you find
 the arrows in
@@ -95,23 +83,13 @@ Did you find
 The arrows in
 *mumblemumble*
 -
+
 Spin To Win!
--
-did you find
-the arrows on
-the ladder?
+
 -
 did you find
 the arrows in
 the hourglass?
--
-DID YOU FIND
-THE ARROWS ON
-THE MOON?
--
-DID YOU FIND
-THE ARROWS IN
-LEVEL 9?
 -
 Silver Arrows
 are so v30
@@ -128,10 +106,6 @@ Did you find
 the arrows in
 World 4-2?
 -
-Did you find
-The arrows in
-Another pool?
--
 You Spin Me
 Right Round
 Like A Record
@@ -139,4 +113,8 @@ Like A Record
 SILLY HERO,
 SILVER IS FOR
 WEREWOLVES!
+-
+Did you find
+the silvers in
+ganti's ears
 -

--- a/strings/ganon_phase_3_no_silvers.txt
+++ b/strings/ganon_phase_3_no_silvers.txt
@@ -1,0 +1,145 @@
+-
+Did you find
+the arrows on
+Planet Zebes?
+-
+Did you find
+the arrows?
+I think not.
+-
+Silver arrows?
+I have never
+heard of them
+-
+Did you find
+The arrows on
+The Moon?
+-
+Did you find
+The arrows
+In /dev/null?
+-
+I have sold
+The arrows for
+A green big 20
+-
+Did you find
+The arrows in
+Count Dracula?
+-
+Error 404:
+Silver arrows
+not found.
+-
+No arrows for
+You today,
+Sorry
+-
+No arrows?
+Check your
+junk mail.
+-
+Careful, all
+that spinning
+makes me dizzy
+-
+Did you find
+the arrows in
+Jabu's belly?
+-
+Did you find
+the arrows in
+you, all along
+-
+Silver is not
+an appropriate
+arrow material
+-
+Did you find
+the arrows on
+Thor's throne?
+-
+Did you find
+the arrows in
+Narnia?
+-
+Are you ready
+To spin
+To win?
+-
+DID YOU FIND
+THE ARROWS IN
+KEFKAS TOWER
+-
+Did you find
+the arrows in
+shadow realm?
+-
+Did you find
+the arrows in
+Recycle Bin?
+-
+Arrows?
+LUL
+-
+Imagine
+finding the
+arrows
+-
+Did you find
+silvers in
+scenic Ohio?
+-
+Did you find
+The arrows in
+*mumblemumble*
+-
+Spin To Win!
+-
+did you find
+the arrows on
+the ladder?
+-
+did you find
+the arrows in
+the hourglass?
+-
+DID YOU FIND
+THE ARROWS ON
+THE MOON?
+-
+DID YOU FIND
+THE ARROWS IN
+LEVEL 9?
+-
+SILVER IS SO
+v30 ANYWAY
+-
+OH, NO, THEY
+ACTUALLY SAID
+SILVER MARROW
+-
+SURELY THE
+LEFTMOST TILES
+WILL STAY UP
+-
+Did you find
+the arrows in
+World 4-2?
+-
+Did you find
+The arrows in
+Another pool?
+-
+You Spin Me
+Right Round
+Like A Record
+-
+SILLY HERO,
+SILVER IS FOR
+WEREWOLVES!
+-
+Did you find
+The arrows in
+Gensokyo?
+-

--- a/tests/MajorGlitches/DarkWorld/NorthEastTest.php
+++ b/tests/MajorGlitches/DarkWorld/NorthEastTest.php
@@ -124,7 +124,6 @@ class NorthEastTest extends TestCase
             ["Pyramid Fairy - Right", true, ['Crystal5', 'Crystal6', 'BottleWithGoldBee']],
 
             ["Ganon", false, []],
-            ["Ganon", false, [], ['MoonPearl']],
             ["Ganon", false, [], ['DefeatAgahnim2']],
         ];
     }


### PR DESCRIPTION
Draft PR for updates to v31.0.9.

We may want to squash merge this at this point, as the rebase totally screwed the branch I was working on.  Thanks git.

Updates base rom template
Adds @cassidoxa flash reduction to the frontend as a post-gen option (still need to work out the i18n)
Adds @spannerisms dynamic text line stuff to the credits too
Enables the bosses defeated menu when using No Logic or Major Glitches logic, or when canOneFrameClipUW is enabled
Adds a texts section for customizer API requests to override game text set by the randomizer
Fixes/updates a ton of website copy
updates readme to provide better instructions on setting up a local dev environment
defaults allow_quickswap to true
responses from /api/randomizer and /api/customizer now give a content type of application/json
overhauls Organized Races page
minor change to Ganon requirements for glitched players
sprite update
allows in-game text to be overwritten via customizer
inserts sprite author name into credits