### PR TITLE
Refactor Silvers Hint

### DIFF
--- a/app/Randomizer.php
+++ b/app/Randomizer.php
@@ -950,15 +950,13 @@ class Randomizer implements RandomizerContract
             // Progressive Bow Alternate
             $first_location->setItem(new Item\Bow('ProgressiveBow', [0x65], $world));
 
-            if ($progressive_bow_locations->count() > 0) {
-                $second_location = $progressive_bow_locations->pop();
-                switch ($second_location->getRegion()->getName()) {
-                    case "Ganons Tower":
-                        $world->setText('ganon_phase_3_no_silvers_alt', "Did you find\nthe arrows in\nMy tower?");
-                        break;
-                    default:
-                        $world->setText('ganon_phase_3_no_silvers_alt', "Did you find\nthe arrows in\n" . $second_location->getRegion()->getName());
-                }
+            $second_location = $progressive_bow_locations->pop();
+            switch ($second_location->getRegion()->getName()) {
+                case "Ganons Tower":
+                    $world->setText('ganon_phase_3_no_silvers_alt', "Did you find\nthe arrows in\nMy tower?");
+                    break;
+                default:
+                    $world->setText('ganon_phase_3_no_silvers_alt', "Did you find\nthe arrows in\n" . $second_location->getRegion()->getName());
             }
         } elseif ($silver_arrows_location) {
             switch ($silver_arrows_location->getRegion()->getName()) {

--- a/app/Randomizer.php
+++ b/app/Randomizer.php
@@ -960,7 +960,6 @@ class Randomizer implements RandomizerContract
                         $world->setText('ganon_phase_3_no_silvers_alt', "Did you find\nthe arrows in\n" . $second_location->getRegion()->getName());
                 }
             }
-            Log::info("progresisve silvers hint");
         } elseif ($silver_arrows_location) {
             switch ($silver_arrows_location->getRegion()->getName()) {
                 case "Ganons Tower":
@@ -971,7 +970,6 @@ class Randomizer implements RandomizerContract
                     $world->setText('ganon_phase_3_no_silvers', "Did you find\nthe arrows in\n" . $silver_arrows_location->getRegion()->getName());
                     $world->setText('ganon_phase_3_no_silvers_alt', "Did you find\nthe arrows in\n" . $silver_arrows_location->getRegion()->getName());
             }
-            Log::info("normal silvers hint");
         } else {
             $fake_silvers_hint = Arr::first(fy_shuffle($strings['ganon_phase_3_no_silvers']));
             if ($world->config('item.pool', 'normal') === 'crowd_control') {
@@ -980,7 +978,6 @@ class Randomizer implements RandomizerContract
 
             $world->setText('ganon_phase_3_no_silvers', $fake_silvers_hint);
             $world->setText('ganon_phase_3_no_silvers_alt', $fake_silvers_hint);
-            Log::info("fake silvers hint: $fake_silvers_hint");
         }
 
         if ($world->config('crystals.tower') < 7) {

--- a/app/Randomizer.php
+++ b/app/Randomizer.php
@@ -928,28 +928,17 @@ class Randomizer implements RandomizerContract
 
         $world->setText('ganon_phase_3_alt', "Got wax in\nyour ears?\nI cannot die!");
 
+        // bow hint and handling
+        // @todo this swap of item really shouldn't happen here, we don't know
+        // for sure that the items haven't already been written to the ROM.
         $silver_arrows_location = $world->getLocationsWithItem(Item::get('SilverArrowUpgrade', $world))->first();
         if (!$silver_arrows_location) {
             $silver_arrows_location = $world->getLocationsWithItem(Item::get('BowAndSilverArrows', $world))->first();
         }
 
-        if (!$silver_arrows_location) {
-            $world->setText('ganon_phase_3_no_silvers', Arr::first(fy_shuffle($strings['ganon_phase_3_no_silvers'])));
-        } else {
-            switch ($silver_arrows_location->getRegion()->getName()) {
-                case "Ganons Tower":
-                    $world->setText('ganon_phase_3_no_silvers', "Did you find\nthe arrows in\nMy tower?");
-                    break;
-                default:
-                    $world->setText('ganon_phase_3_no_silvers', "Did you find\nthe arrows in\n" . $silver_arrows_location->getRegion()->getName());
-            }
-        }
-
-        // progressive bow hint and handling
-        // @todo this swap of item really shouldn't happen here, we don't know
-        // for sure that the items haven't already been written to the ROM.
         $progressive_bow_locations = $world->getLocationsWithItem(Item::get('ProgressiveBow', $world))->randomCollection(2);
-        if ($progressive_bow_locations->count() > 0) {
+
+        if ($progressive_bow_locations->count() >= 2 && $world->config('item.overflow.count.Bow', 2) >= 2) {
             $first_location = $progressive_bow_locations->pop();
             switch ($first_location->getRegion()->getName()) {
                 case "Ganons Tower":
@@ -971,16 +960,27 @@ class Randomizer implements RandomizerContract
                         $world->setText('ganon_phase_3_no_silvers_alt', "Did you find\nthe arrows in\n" . $second_location->getRegion()->getName());
                 }
             }
-            // Remove Hint in Hard+ Item Pool
-            if ($world->config('item.overflow.count.Bow', 2) < 2) {
-                $world->setText('ganon_phase_3_no_silvers', "Did you find\nthe arrows on\nPlanet Zebes?");
-                $world->setText('ganon_phase_3_no_silvers_alt', "Did you find\nthe arrows on\nPlanet Zebes?");
-                // Special No Silvers "Hint" for Crowd Control
-                if ($world->config('item.pool') == 'crowd_control') {
-                    $world->setText('ganon_phase_3_no_silvers', "Chat said no\nto Silvers.\nIt's over Hero");
-                    $world->setText('ganon_phase_3_no_silvers_alt', "Chat said no\nto Silvers.\nIt's over Hero");
-                }
+            Log::info("progresisve silvers hint");
+        } elseif ($silver_arrows_location) {
+            switch ($silver_arrows_location->getRegion()->getName()) {
+                case "Ganons Tower":
+                    $world->setText('ganon_phase_3_no_silvers', "Did you find\nthe arrows in\nMy tower?");
+                    $world->setText('ganon_phase_3_no_silvers_alt', "Did you find\nthe arrows in\nMy tower?");
+                    break;
+                default:
+                    $world->setText('ganon_phase_3_no_silvers', "Did you find\nthe arrows in\n" . $silver_arrows_location->getRegion()->getName());
+                    $world->setText('ganon_phase_3_no_silvers_alt', "Did you find\nthe arrows in\n" . $silver_arrows_location->getRegion()->getName());
             }
+            Log::info("normal silvers hint");
+        } else {
+            $fake_silvers_hint = Arr::first(fy_shuffle($strings['ganon_phase_3_no_silvers']));
+            if ($world->config('item.pool', 'normal') === 'crowd_control') {
+                $fake_silvers_hint = "Chat said no\nto Silvers.\nIt's over Hero";
+            }
+
+            $world->setText('ganon_phase_3_no_silvers', $fake_silvers_hint);
+            $world->setText('ganon_phase_3_no_silvers_alt', $fake_silvers_hint);
+            Log::info("fake silvers hint: $fake_silvers_hint");
         }
 
         if ($world->config('crystals.tower') < 7) {


### PR DESCRIPTION
Refactors the priority of the silvers hint so it's more what we'd expect.  I merged the handling of standalone silver arrow upgrade with the progressive bow, into a simple if/else statement.

First it checks if there are at least two progressive bows, and that the bow limit is at least 2.  If so, do the normal thing with the progressive bows.

If not, then it checks if there's a silver arrow upgrade, or a bow and silver arrows item, if so, then write the hint.

If neither scenario applies, that means silvers aren't available.  Roll a fake hint and write it.