### PR TITLE
Added --quickswap CLI Option

### DIFF
--- a/app/Console/Commands/Randomize.php
+++ b/app/Console/Commands/Randomize.php
@@ -45,7 +45,8 @@ class Randomize extends Command
         . ' {--accessibility=item : set item/location accessibility}'
         . ' {--hints=on : set hints on or off}'
         . ' {--item_pool=normal : set item pool}'
-        . ' {--item_functionality=normal : set item functionality}';
+        . ' {--item_functionality=normal : set item functionality}'
+        . ' {--quickswap=false : set quickswap}';
 
     /**
      * The console command description.
@@ -136,6 +137,10 @@ class Randomize extends Command
 
             if (is_string($this->option('heartbeep'))) {
                 $rom->setHeartBeepSpeed($this->option('heartbeep'));
+            }
+
+            if(is_string($this->option('quickswap'))) {
+                $rom->setQuickSwap(strtolower($this->option('quickswap')) === 'true');
             }
 
             // break out for unrandomized base game


### PR DESCRIPTION
- **For next release**
- Accepts case-insensitive `true` to activate quickswap
- **QUESTION**: For CLI, do we have to ensure that quickswap is allowed? I noted the JS side checks for Tournament mode or a simple `allowQuickswap` variable
  - This implementation will allow quickswap regardless, in its current state.
  - **ANSWER** (from Synack): Don't worry about it