### PR TITLE
Customizer: Save Starting Hearts on Click

### DIFF
--- a/resources/js/components/Customizer/EquipmentSelect.vue
+++ b/resources/js/components/Customizer/EquipmentSelect.vue
@@ -231,6 +231,7 @@
             <div class="cell w-100">
               <vue-slider
                 ref="slider"
+                @click.native="saveEquipment"
                 @drag-end="saveEquipment"
                 :min="1"
                 :max="20"


### PR DESCRIPTION
- Would only save if you dragged, but clicking to select a new starting hearts value wouldn't trigger `saveEquipment()`
- Now capturing this via `@Click.native`
  - `@Click` doesn't work, so using `@Click.native`
  - [Relevant thread](https://github.com/NightCatSama/vue-slider-component/issues/175)