### PR TITLE
Split rom.HardMode into separate config flags on World

### DIFF
--- a/app/Randomizer.php
+++ b/app/Randomizer.php
@@ -684,18 +684,13 @@ class Randomizer implements RandomizerContract
         });
 
         // handle hardmode shops
-        switch ($world->config('rom.HardMode', 0)) {
-            case 1:
-            case 2:
-            case 3:
-                $world->getShop("Capacity Upgrade")->clearInventory();
-                $world->getShop("Dark World Potion Shop")->addInventory(1, Item::get('Nothing', $world), 0);
-                $world->getShop("Dark World Forest Shop")->addInventory(0, Item::get('Nothing', $world), 0);
-                $world->getShop("Dark World Lumberjack Hut Shop")->addInventory(1, Item::get('Nothing', $world), 0);
-                $world->getShop("Dark World Outcasts Shop")->addInventory(1, Item::get('Nothing', $world), 0);
-                $world->getShop("Dark World Lake Hylia Shop")->addInventory(1, Item::get('Nothing', $world), 0);
-
-                break;
+        if ($world->config('shops.HardMode', false)) {
+            $world->getShop("Capacity Upgrade")->clearInventory();
+            $world->getShop("Dark World Potion Shop")->addInventory(1, Item::get('Nothing', $world), 0);
+            $world->getShop("Dark World Forest Shop")->addInventory(0, Item::get('Nothing', $world), 0);
+            $world->getShop("Dark World Lumberjack Hut Shop")->addInventory(1, Item::get('Nothing', $world), 0);
+            $world->getShop("Dark World Outcasts Shop")->addInventory(1, Item::get('Nothing', $world), 0);
+            $world->getShop("Dark World Lake Hylia Shop")->addInventory(1, Item::get('Nothing', $world), 0);
         }
 
         if (
@@ -752,16 +747,11 @@ class Randomizer implements RandomizerContract
                 }
             }
 
-            switch ($world->config('rom.HardMode', 0)) {
-                case 1:
-                case 2:
-                case 3:
-                    $world->getShop("Capacity Upgrade")->clearInventory();
-
-                    break;
-                default:
-                    $world->getShop("Capacity Upgrade")->clearInventory()
-                        ->addInventory(0, Item::get('BombUpgrade5', $world), 100, 7);
+            if ($world->config('shops.HardMode', false)) {
+                $world->getShop("Capacity Upgrade")->clearInventory();
+            } else {
+                $world->getShop("Capacity Upgrade")->clearInventory()
+                    ->addInventory(0, Item::get('BombUpgrade5', $world), 100, 7);
             }
         }
     }

--- a/app/Rom.php
+++ b/app/Rom.php
@@ -12,8 +12,8 @@ use Log;
  */
 class Rom
 {
-    const BUILD = '2021-06-14';
-    const HASH = 'ecca7473031de4b4e1d9994874a3e80c';
+    const BUILD = '2021-07-18';
+    const HASH = '91bd3ceeda53fd3c529d28ec7521ab5b';
     const SIZE = 2097152;
 
     private $tmp_file;

--- a/app/Rom.php
+++ b/app/Rom.php
@@ -798,6 +798,22 @@ class Rom
     }
 
     /**
+     * Set regular Cape Magic Usage
+     *
+     * @param int $normal normal magic usage
+     * @param int $half half magic usage
+     * @param int $quarter quarter magic usage
+     *
+     * @return $this
+     */
+    public function setCapeRegularMagicUsage(int $normal = 0x04, int $half = 0x08, int $quarter = 0x10): self
+    {
+        $this->write(0x3ADA7, pack('C*', $normal, $half, $quarter));
+
+        return $this;
+    }
+
+    /**
      * Set mode for HUD clock
      *
      * @param string $mode off|stopwatch|countdown-stop|countdown-continue
@@ -1607,77 +1623,6 @@ class Rom
     public function setOverworldDigPrizes(array $prizes = []): self
     {
         $this->write(0x180100, pack('C*', ...$prizes));
-
-        return $this;
-    }
-
-    /**
-     * Adjust some settings for hard mode
-     *
-     * @param int $level how hard to make it, higher should be harder
-     *
-     * @throws \Exception if an unknown hard mode is selected
-     *
-     * @return $this
-     */
-    public function setHardMode(int $level = 0): self
-    {
-        $this->setCaneOfByrnaSpikeCaveUsage();
-        $this->setCapeSpikeCaveUsage();
-        $this->setByrnaCaveSpikeDamage(0x08);
-        // Bryna magic amount used per "cycle"
-        $this->write(0x45C42, pack('C*', 0x04, 0x02, 0x01));
-
-        switch ($level) {
-            case -1:
-            case 0:
-                // Cape magic
-                $this->write(0x3ADA7, pack('C*', 0x04, 0x08, 0x10));
-                $this->setCaneOfByrnaInvulnerability(true);
-                $this->setPowderedSpriteFairyPrize(0xE3);
-                $this->setBottleFills([0xA0, 0x80]);
-                $this->setCatchableFairies(true);
-                $this->setCatchableBees(true);
-                $this->setStunItems(0x03);
-                $this->setSilversOnlyAtGanon(false);
-
-                break;
-            case 1:
-                $this->write(0x3ADA7, pack('C*', 0x02, 0x04, 0x08));
-                $this->setCaneOfByrnaInvulnerability(false);
-                $this->setPowderedSpriteFairyPrize(0xD8); // 1 heart
-                $this->setBottleFills([0x38, 0x40]); // 7 hearts, 1/2 magic refills
-                $this->setCatchableFairies(false);
-                $this->setCatchableBees(true);
-                $this->setStunItems(0x02);
-                $this->setSilversOnlyAtGanon(true);
-
-                break;
-            case 2:
-                $this->write(0x3ADA7, pack('C*', 0x02, 0x04, 0x08));
-                $this->setCaneOfByrnaInvulnerability(false);
-                $this->setPowderedSpriteFairyPrize(0xD8); // 1 heart
-                $this->setBottleFills([0x20, 0x20]); // 4 heart, 1/4 magic refills
-                $this->setCatchableFairies(false);
-                $this->setCatchableBees(true);
-                $this->setStunItems(0x00);
-                $this->setSilversOnlyAtGanon(true);
-
-                break;
-            case 3:
-                $this->write(0x3ADA7, pack('C*', 0x01, 0x02, 0x04));
-                $this->setCaneOfByrnaInvulnerability(false);
-                $this->setPowderedSpriteFairyPrize(0x79); // Bees
-                $this->setBottleFills([0x00, 0x00]); // 0 hearts, 0 magic refills
-                $this->setCatchableFairies(false);
-                $this->setCatchableBees(true);
-                $this->setStunItems(0x00);
-                $this->setSilversOnlyAtGanon(true);
-
-                break;
-            default:
-                throw new \Exception("Trying to set hard mode that doesn't exist");
-        }
 
         return $this;
     }

--- a/app/Services/HintService.php
+++ b/app/Services/HintService.php
@@ -140,18 +140,7 @@ class HintService
                     && !in_array($item->getRawName(), ['TenBombs', 'HalfMagic', 'BugCatchingNet', 'Powder', 'Mushroom']);
             });
 
-            switch ($world->config('rom.HardMode', 0)) {
-                case -1:
-                    $hints = array_slice(fy_shuffle($hintables ?? []), 0, count($tiles));
-
-                    break;
-                case 0:
-                    $hints = array_slice(fy_shuffle($hintables ?? []), 0, min(4, count($tiles)));
-
-                    break;
-                default:
-                    $hints = [];
-            }
+            $hints = array_slice(fy_shuffle($hintables ?? []), 0, min(4, count($tiles)));
 
             $hints = array_filter(array_map(function ($item) use ($world) {
                 return $world->getLocationsWithItem($item)->filter(function ($location) {

--- a/app/Support/ItemCollection.php
+++ b/app/Support/ItemCollection.php
@@ -442,7 +442,7 @@ class ItemCollection extends Collection
      */
     public function canAcquireFairy($world = null)
     {
-        if ($world !== null && $world->config('rom.HardMode') >= 1)
+        if ($world !== null && !$world->config('rom.CatchableFairies', true))
         {
             return False;
         }
@@ -514,22 +514,10 @@ class ItemCollection extends Collection
     public function canExtendMagic($world = null, $bars = 2.0)
     {
         $magicModifier = 1.0;
-        if ($world !== null)
-        {
-            $difficultyLevel = $world->config('rom.HardMode');
-            switch ($difficultyLevel)
-            {
-                case 1:
-                    $magicModifier = 0.5;
-                    break;
-                case 2:
-                    $magicModifier = 0.25;
-                    break;
-                case 3:
-                    $magicModifier = 0.0;
-                    break;
-                default:
-                    break;
+        if ($world !== null) {
+            $magicModifier = $world->config('rom.BottleFill.Magic', 0x80) / 0x80;
+            if ($magicModifier > 1) {
+                $magicModifier = 1.0;
             }
         }
 

--- a/app/World.php
+++ b/app/World.php
@@ -136,6 +136,16 @@ abstract class World
         $this->config['rom.freeItemMenu'] = $free_item_menu;
 
         switch ($this->config('item.pool')) {
+            case 'superexpert':
+                $this->config['item.overflow.count.Sword'] = 2;
+                $this->config['item.overflow.count.Armor'] = 0;
+                $this->config['item.overflow.count.Shield'] = 0;
+                $this->config['item.overflow.count.Bow'] = 1;
+                $this->config['item.overflow.count.BossHeartContainer'] = 0;
+                $this->config['item.overflow.count.PieceOfHeart'] = 0;
+                $this->config['shops.HardMode'] = true;
+
+                break;
             case 'expert':
                 $this->config['item.overflow.count.Sword'] = 2;
                 $this->config['item.overflow.count.Armor'] = 0;
@@ -143,6 +153,7 @@ abstract class World
                 $this->config['item.overflow.count.Bow'] = 1;
                 $this->config['item.overflow.count.BossHeartContainer'] = 2;
                 $this->config['item.overflow.count.PieceOfHeart'] = 8;
+                $this->config['shops.HardMode'] = true;
 
                 break;
             case 'hard':
@@ -152,6 +163,7 @@ abstract class World
                 $this->config['item.overflow.count.Bow'] = 1;
                 $this->config['item.overflow.count.BossHeartContainer'] = 6;
                 $this->config['item.overflow.count.PieceOfHeart'] = 16;
+                $this->config['shops.HardMode'] = true;
 
                 break;
             case 'crowd_control':
@@ -168,21 +180,57 @@ abstract class World
                 $this->config['item.count.TwentyRupees2'] = 4;
         }
 
+        switch ($this->config('item.functionality')) {
+            case 'superexpert':
+                $this->config['rom.CapeMagicUsage.Normal'] = 0x01;
+                $this->config['rom.CapeMagicUsage.Half'] = 0x02;
+                $this->config['rom.CapeMagicUsage.Quarter'] = 0x02;
+                $this->config['rom.CaneOfByrnaInvulnerability'] = false;
+                $this->config['rom.PowderedSpriteFairyPrize'] = 0x79; // bees
+                $this->config['rom.BottleFill.Health'] = 0x00; // nothing
+                $this->config['rom.BottleFill.Magic'] = 0x00; // nothing
+                $this->config['rom.CatchableFairies'] = false;
+                $this->config['rom.CatchableBees'] = true;
+                $this->config['rom.StunItems'] = 0x00;
+                $this->config['rom.SilversOnlyAtGanon'] = true;
+                $this->config['rom.NoFarieDrops'] = true;
+                break;
+            case 'expert':
+                $this->config['rom.CapeMagicUsage.Normal'] = 0x02;
+                $this->config['rom.CapeMagicUsage.Half'] = 0x04;
+                $this->config['rom.CapeMagicUsage.Quarter'] = 0x08;
+                $this->config['rom.CaneOfByrnaInvulnerability'] = false;
+                $this->config['rom.PowderedSpriteFairyPrize'] = 0xD8; // 1 heart
+                $this->config['rom.BottleFill.Health'] = 0x20; // 7 hearts, 1/2 magic refills
+                $this->config['rom.BottleFill.Magic'] = 0x20; // 7 hearts, 1/2 magic refills
+                $this->config['rom.CatchableFairies'] = false;
+                $this->config['rom.CatchableBees'] = true;
+                $this->config['rom.StunItems'] = 0x00;
+                $this->config['rom.SilversOnlyAtGanon'] = true;
+                $this->config['rom.NoFarieDrops'] = true;
+                break;
+            case 'hard':
+                $this->config['rom.CapeMagicUsage.Normal'] = 0x02;
+                $this->config['rom.CapeMagicUsage.Half'] = 0x04;
+                $this->config['rom.CapeMagicUsage.Quarter'] = 0x08;
+                $this->config['rom.CaneOfByrnaInvulnerability'] = false;
+                $this->config['rom.PowderedSpriteFairyPrize'] = 0xD8; // 1 heart
+                $this->config['rom.BottleFill.Health'] = 0x38; // 4 heart, 1/4 magic refills
+                $this->config['rom.BottleFill.Magic'] = 0x40; // 4 heart, 1/4 magic refills
+                $this->config['rom.CatchableFairies'] = false;
+                $this->config['rom.CatchableBees'] = true;
+                $this->config['rom.StunItems'] = 0x02;
+                $this->config['rom.SilversOnlyAtGanon'] = true;
+                $this->config['rom.NoFarieDrops'] = true;
+                break;
+        }
+
         $this->config['region.requireBetterBow'] = false;
         $this->config['region.requireBetterSword'] = false;
 
         if ($this->config('itemPlacement') === 'basic') {
             $this->config['region.requireBetterBow'] = true;
             $this->config['region.requireBetterSword'] = true;
-        }
-
-        switch ($this->config('item.functionality')) {
-            case 'expert':
-                $this->config['rom.HardMode'] = 2;
-
-                break;
-            case 'hard':
-                $this->config['rom.HardMode'] = 1;
         }
 
         // In swordless mode silvers are 100% required
@@ -277,8 +325,8 @@ abstract class World
         }
         foreach ($this->shops as $name => $shop) {
             $copy->shops[$name] = $shop->copy();
-    }
-    $boss_locations = [
+        }
+        $boss_locations = [
             ['Eastern Palace', ''],
             ['Desert Palace', ''],
             ['Tower of Hera', ''],
@@ -807,7 +855,7 @@ abstract class World
             Item::get('BottleWithFairy', $this),
         ];
 
-        return $bottles[get_random_int($filled ? 1 : 0, count($bottles) - (($this->config('rom.HardMode', 0) > 0) ? 2 : 1))];
+        return $bottles[get_random_int($filled ? 1 : 0, count($bottles) - (($this->config('rom.CatchableFairies', true)) ? 1 : 2))];
     }
 
     /**
@@ -934,10 +982,6 @@ abstract class World
             "Ganon" => "Ganon"
         ];
 
-        if ($this->config('rom.HardMode') !== null) {
-            $this->spoiler['meta']['difficulty_mode'] = $this->config('rom.HardMode', 0);
-        }
-
         $this->seed->spoiler = json_encode($this->spoiler);
 
         return $this->spoiler;
@@ -1007,7 +1051,7 @@ abstract class World
                 });
             }
         }
-        
+
         if ($this->config('mode.state') === 'standard') {
             $this->setEscapeFills($rom);
         }
@@ -1015,7 +1059,25 @@ abstract class World
         $rom->setGoalRequiredCount($this->config('item.Goal.Required', 0) ?: 0);
         $rom->setGoalIcon($this->config('item.Goal.Icon', 'triforce'));
 
-        $rom->setHardMode($this->config('rom.HardMode', 0));
+        // Set item functionality settings
+        $rom->setCaneOfByrnaSpikeCaveUsage();
+        $rom->setCapeSpikeCaveUsage();
+        $rom->setByrnaCaveSpikeDamage(0x08);
+        // Bryna magic amount used per "cycle"
+        $rom->write(0x45C42, pack('C*', 0x04, 0x02, 0x01));
+
+        $rom->setCapeRegularMagicUsage(
+            $this->config('rom.CapeMagicUsage.Normal', 0x04),
+            $this->config('rom.CapeMagicUsage.Half', 0x08),
+            $this->config('rom.CapeMagicUsage.Quarter', 0x10),
+        );
+        $rom->setCaneOfByrnaInvulnerability($this->config('rom.CaneOfByrnaInvulnerability', true));
+        $rom->setPowderedSpriteFairyPrize($this->config('rom.PowderedSpriteFairyPrize', 0xE3));
+        $rom->setBottleFills([$this->config('rom.BottleFill.Health', 0xA0), $this->config('rom.BottleFill.Magic', 0x80)]);
+        $rom->setCatchableFairies($this->config('rom.CatchableFairies', true));
+        $rom->setCatchableBees($this->config('rom.CatchableBees', true));
+        $rom->setStunItems($this->config('rom.StunItems', 0x03));
+        $rom->setSilversOnlyAtGanon($this->config('rom.SilversOnlyAtGanon', false));
 
         $rom->setRupoorValue($this->config('item.value.Rupoor', 0) ?: 0);
 
@@ -1189,7 +1251,7 @@ abstract class World
 
         return $rom;
     }
-    
+
     /**
      * Set the ammo given for escape, based on available weapons
      *
@@ -1201,7 +1263,7 @@ abstract class World
         $uncle_items = new ItemCollection;
         $uncle_items->setChecksForWorld($this->id);
         $uncle_items = $uncle_items->addItem($this->getLocation("Link's Uncle")->getItem());
-        
+
         // Add starting items if uncle doesn't have a weapon.  Temporarily disable ignoreCanKillEscapeThings for this check
         $ignoreCanKillEscapeThings = $this->config('ignoreCanKillEscapeThings', false);
         $this->config['ignoreCanKillEscapeThings'] = false;
@@ -1209,7 +1271,7 @@ abstract class World
             $uncle_items = $uncle_items->merge($this->getPreCollectedItems());
         }
         $this->config['ignoreCanKillEscapeThings'] = $ignoreCanKillEscapeThings;
-        
+
         if ($uncle_items->hasSword() || $uncle_items->has('Hammer')) {
             $rom->setEscapeFills(0b00000000);
             $rom->setUncleSpawnRefills(0, 0, 0);
@@ -1219,27 +1281,63 @@ abstract class World
             || $uncle_items->has('CaneOfSomaria')
             || ($uncle_items->has('CaneOfByrna') && $this->config('enemizer.enemyHealth', 'default') == 'default')) {
             $rom->setEscapeFills(0b00000100);
-            $rom->setUncleSpawnRefills(0x80, 0, 0);
-            $rom->setZeldaSpawnRefills(0x20, 0, 0);
-            $rom->setMantleSpawnRefills(0x20, 0, 0);
-            if ($this->config('rom.HardMode') == -1) {
+            $rom->setUncleSpawnRefills(
+                $this->config('rom.EscapeRefills.Uncle.Magic', 0x80),
+                0,
+                0
+            );
+            $rom->setZeldaSpawnRefills(
+                $this->config('rom.EscapeRefills.Zelda.Magic', 0x20),
+                0,
+                0
+            );
+            $rom->setMantleSpawnRefills(
+                $this->config('rom.EscapeRefills.Mantle.Magic', 0x20),
+                0,
+                0
+            );
+            if ($this->config('rom.EscapeAssist', false)) {
                 $rom->setEscapeAssist(0b00000100);
             }
         } elseif ($uncle_items->canShootArrows($this)) {
             $rom->setEscapeFills(0b00000001);
-            $rom->setUncleSpawnRefills(0, 0, 70);
-            $rom->setZeldaSpawnRefills(0, 0, 10);
-            $rom->setMantleSpawnRefills(0, 0, 10);
-            if ($this->config('rom.HardMode') == -1) {
+            $rom->setUncleSpawnRefills(
+                0,
+                0,
+                $this->config('rom.EscapeRefills.Uncle.Arrows', 70)
+            );
+            $rom->setZeldaSpawnRefills(
+                0,
+                0,
+                $this->config('rom.EscapeRefills.Zelda.Arrows', 10)
+            );
+            $rom->setMantleSpawnRefills(
+                0,
+                0,
+                $this->config('rom.EscapeRefills.Mantle.Arrows', 10)
+            );
+            if ($this->config('rom.EscapeAssist', false)) {
                 $rom->setEscapeAssist(0b00000001);
             }
         } elseif ($uncle_items->has('TenBombs') || $this->config('logic') !== 'None') {
             // TenBombs, or give player bombs if uncle was plando'd to not have a weapon.
             $rom->setEscapeFills(0b00000010);
-            $rom->setUncleSpawnRefills(0, 50, 0);
-            $rom->setZeldaSpawnRefills(0, 3, 0);
-            $rom->setMantleSpawnRefills(0, 3, 0);
-            if ($this->config('rom.HardMode') == -1) {
+            $rom->setUncleSpawnRefills(
+                0,
+                $this->config('rom.EscapeRefills.Uncle.Bombs', 50),
+                0
+            );
+            $rom->setZeldaSpawnRefills(
+                0,
+                $this->config('rom.EscapeRefills.Zelda.Bombs', 3),
+                0
+            );
+            $rom->setMantleSpawnRefills(
+                0,
+                $this->config('rom.EscapeRefills.Mantle.Bombs', 3),
+                0
+            );
+            if ($this->config('rom.EscapeAssist', false)) {
                 $rom->setEscapeAssist(0b00000010);
             }
         }
@@ -1268,7 +1366,7 @@ abstract class World
         }, $this->getAllDrops());
 
         // hard+ does not allow fairies/full magics
-        if ($this->config('rom.HardMode', 0) >= 2) {
+        if ($this->config('rom.NoFarieDrops', false)) {
             $drop_bytes = str_replace([0xE0, 0xE3], [0xDF, 0xD8], $drop_bytes);
         }
 

--- a/app/World.php
+++ b/app/World.php
@@ -201,8 +201,8 @@ abstract class World
                 $this->config['rom.CapeMagicUsage.Quarter'] = 0x08;
                 $this->config['rom.CaneOfByrnaInvulnerability'] = false;
                 $this->config['rom.PowderedSpriteFairyPrize'] = 0xD8; // 1 heart
-                $this->config['rom.BottleFill.Health'] = 0x20; // 7 hearts, 1/2 magic refills
-                $this->config['rom.BottleFill.Magic'] = 0x20; // 7 hearts, 1/2 magic refills
+                $this->config['rom.BottleFill.Health'] = 0x20; // 4 hearts
+                $this->config['rom.BottleFill.Magic'] = 0x20; // 1/4 magic refills
                 $this->config['rom.CatchableFairies'] = false;
                 $this->config['rom.CatchableBees'] = true;
                 $this->config['rom.StunItems'] = 0x00;
@@ -215,8 +215,8 @@ abstract class World
                 $this->config['rom.CapeMagicUsage.Quarter'] = 0x08;
                 $this->config['rom.CaneOfByrnaInvulnerability'] = false;
                 $this->config['rom.PowderedSpriteFairyPrize'] = 0xD8; // 1 heart
-                $this->config['rom.BottleFill.Health'] = 0x38; // 4 heart, 1/4 magic refills
-                $this->config['rom.BottleFill.Magic'] = 0x40; // 4 heart, 1/4 magic refills
+                $this->config['rom.BottleFill.Health'] = 0x38; // 7 hearts
+                $this->config['rom.BottleFill.Magic'] = 0x40; // 1/2 magic refills
                 $this->config['rom.CatchableFairies'] = false;
                 $this->config['rom.CatchableBees'] = true;
                 $this->config['rom.StunItems'] = 0x02;

--- a/composer.json
+++ b/composer.json
@@ -47,11 +47,11 @@
       "type": "package",
       "package": {
         "name": "z3/randomizer",
-        "version": "31.0.9",
+        "version": "31.0.10",
         "source": {
           "url": "https://github.com/KatDevsGames/z3randomizer",
           "type": "git",
-          "reference": "d0fbd11d0f6c5b2a45ee20deb0a87a925592c93a"
+          "reference": "8da0dcf3e0af4ee01f781af774d3eaa9182d31be"
         }
       }
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8f3cc7720e7fb557a57da221582a747e",
+    "content-hash": "6b2399d5c454bc77ef58ba24c1302efa",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -6961,11 +6961,11 @@
         },
         {
             "name": "z3/randomizer",
-            "version": "31.0.9",
+            "version": "31.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/KatDevsGames/z3randomizer",
-                "reference": "d0fbd11d0f6c5b2a45ee20deb0a87a925592c93a"
+                "reference": "8da0dcf3e0af4ee01f781af774d3eaa9182d31be"
             },
             "type": "library"
         }
@@ -10209,6 +10209,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "abandoned": true,
             "time": "2018-10-04T04:07:39+00:00"
         },
         {

--- a/config/alttp.php
+++ b/config/alttp.php
@@ -20,7 +20,6 @@ return [
             'wildCompasses' => false,
         ],
         'rom' => [
-            'HardMode' => 0,
             'genericKeys' => false,
         ],
         'spoil' => [

--- a/tests/RomTest.php
+++ b/tests/RomTest.php
@@ -1056,58 +1056,51 @@ class RomTest extends TestCase
         $this->assertEquals(0x05, $this->rom->read(0x180100));
     }
 
-    public function testSetHardModeUnknownValueThrowsException()
-    {
-        $this->expectException(\Exception::class);
-
-        $this->rom->setHardMode(1000000);
-    }
-
     public function testSetHardMode2ChangesCapeMagicUsage()
     {
-        $this->rom->setHardMode(2);
+        $this->rom->setCapeRegularMagicUsage(0x02, 0x04, 0x08);
 
         $this->assertEquals([0x02, 0x04, 0x08], $this->rom->read(0x3ADA7, 3));
     }
 
     public function testSetHardMode1ChangesCapeMagicUsage()
     {
-        $this->rom->setHardMode(1);
+        $this->rom->setCapeRegularMagicUsage(0x02, 0x04, 0x08);
 
         $this->assertEquals([0x02, 0x04, 0x08], $this->rom->read(0x3ADA7, 3));
     }
 
     public function testSetHardMode0ChangesCapeMagicUsage()
     {
-        $this->rom->setHardMode(0);
+        $this->rom->setCapeRegularMagicUsage(0x04, 0x08, 0x10);
 
         $this->assertEquals([0x04, 0x08, 0x10], $this->rom->read(0x3ADA7, 3));
     }
 
     public function testSetHardMode3ChangesBubbleTransform()
     {
-        $this->rom->setHardMode(3);
+        $this->rom->setPowderedSpriteFairyPrize(0x79);
 
         $this->assertEquals(0x79, $this->rom->read(0x36DD0));
     }
 
     public function testSetHardMode2ChangesBubbleTransform()
     {
-        $this->rom->setHardMode(2);
+        $this->rom->setPowderedSpriteFairyPrize(0xD8);
 
         $this->assertEquals(0xD8, $this->rom->read(0x36DD0));
     }
 
     public function testSetHardMode1ChangesBubbleTransform()
     {
-        $this->rom->setHardMode(1);
+        $this->rom->setPowderedSpriteFairyPrize(0xD8);
 
         $this->assertEquals(0xD8, $this->rom->read(0x36DD0));
     }
 
     public function testSetHardMode0ChangesBubbleTransform()
     {
-        $this->rom->setHardMode(0);
+        $this->rom->setPowderedSpriteFairyPrize(0xE3);
 
         $this->assertEquals(0xE3, $this->rom->read(0x36DD0));
     }

--- a/tests/Support/ItemCollectionTest.php
+++ b/tests/Support/ItemCollectionTest.php
@@ -217,10 +217,10 @@ class ItemCollectionTest extends TestCase
             [['Bottle'], "normal", 3, False],
             [['Bottle', 'HalfMagic'], "normal", 4, True],
             [['Bottle', 'HalfMagic'], "normal", 5, False],
-            [['Bottle', 'HalfMagic'], "hard", 3, True], # failing
+            [['Bottle', 'HalfMagic'], "hard", 3, True],
             [['Bottle', 'HalfMagic'], "hard", 4, False],
             [['Bottle', 'Bottle', 'Bottle', 'Bottle', 'QuarterMagic'], "expert", 8, True],
-            [['Bottle', 'Bottle', 'Bottle', 'Bottle', 'QuarterMagic'], "expert", 9, False], # failing
+            [['Bottle', 'Bottle', 'Bottle', 'Bottle', 'QuarterMagic'], "expert", 9, False],
             [['Bottle', 'Bottle', 'Bottle', 'Bottle', 'QuarterMagic'], "superexpert", 4, True],
             [['Bottle', 'Bottle', 'Bottle', 'Bottle', 'QuarterMagic'], "superexpert", 5, False],
         ];

--- a/tests/Support/ItemCollectionTest.php
+++ b/tests/Support/ItemCollectionTest.php
@@ -211,18 +211,18 @@ class ItemCollectionTest extends TestCase
     public function canExtendMagicDataProvider()
     {
         return [
-            [[], 0, 1, True],
-            [[], 3, 2, False],
-            [['Bottle'], 0, 2, True],
-            [['Bottle'], 0, 3, False],
-            [['Bottle', 'HalfMagic'], 0, 4, True],
-            [['Bottle', 'HalfMagic'], 0, 5, False],
-            [['Bottle', 'HalfMagic'], 1, 3, True],
-            [['Bottle', 'HalfMagic'], 1, 4, False],
-            [['Bottle', 'Bottle', 'Bottle', 'Bottle', 'QuarterMagic'], 2, 8, True],
-            [['Bottle', 'Bottle', 'Bottle', 'Bottle', 'QuarterMagic'], 2, 9, False],
-            [['Bottle', 'Bottle', 'Bottle', 'Bottle', 'QuarterMagic'], 3, 4, True],
-            [['Bottle', 'Bottle', 'Bottle', 'Bottle', 'QuarterMagic'], 3, 5, False],
+            [[], "normal", 1, True],
+            [[], "superexpert", 2, False],
+            [['Bottle'], "normal", 2, True],
+            [['Bottle'], "normal", 3, False],
+            [['Bottle', 'HalfMagic'], "normal", 4, True],
+            [['Bottle', 'HalfMagic'], "normal", 5, False],
+            [['Bottle', 'HalfMagic'], "hard", 3, True], # failing
+            [['Bottle', 'HalfMagic'], "hard", 4, False],
+            [['Bottle', 'Bottle', 'Bottle', 'Bottle', 'QuarterMagic'], "expert", 8, True],
+            [['Bottle', 'Bottle', 'Bottle', 'Bottle', 'QuarterMagic'], "expert", 9, False], # failing
+            [['Bottle', 'Bottle', 'Bottle', 'Bottle', 'QuarterMagic'], "superexpert", 4, True],
+            [['Bottle', 'Bottle', 'Bottle', 'Bottle', 'QuarterMagic'], "superexpert", 5, False],
         ];
     }
 
@@ -231,7 +231,7 @@ class ItemCollectionTest extends TestCase
      */
     public function testCanExtendMagic($items, $difficultySetting, $magicBars, $expectedResult)
     {
-        $this->world = World::factory('standard', ['rom.HardMode' => $difficultySetting]);
+        $this->world = World::factory('standard', ['item.functionality' => $difficultySetting]);
 
         $this->collected->setChecksForWorld($this->world->id);
 


### PR DESCRIPTION
This gives us more flexibility to only make specific changes that are provided by the item functionality setting.  We get rid of rom.HardMode and instead break it into individual flags that are wrapped up into item.functionality

Additionally, it lets us set the amount the escape checkpoints refill a resource for, based on uncle weapon.

Finally, it switches the hard item shop changes to be based on Item Pool setting, not Item Functionality.  This is also a separate flag that we can then set at will.