### PR TITLE
Remove logic from no logic Raindo

### DIFF
--- a/app/Randomizer.php
+++ b/app/Randomizer.php
@@ -315,7 +315,8 @@ class Randomizer implements RandomizerContract
         }
         if ($world->config('region.wildKeys', false)) {
             foreach ($dungeon_items as $key => $item) {
-                if ($item instanceof Item\Key && ($world->config('mode.state') != 'standard' || $item != Item::get('KeyH2', $world))) {
+                if ($item instanceof Item\Key && ($world->config('mode.state') !== 'standard' || $item != Item::get('KeyH2', $world)
+                    || $world->config('logic') === 'NoLogic')) {
                     unset($dungeon_items[$key]);
                     $advancement_items[] = $item;
                 }

--- a/app/Region.php
+++ b/app/Region.php
@@ -234,7 +234,7 @@ class Region
         $from_world = $item->getWorld();
         if (((!$from_world->config('region.wildKeys', false) && $item instanceof Item\Key)
                 || (!$from_world->config('region.wildBigKeys', false) && $item instanceof Item\BigKey)
-                || ($item == Item::get('KeyH2', $from_world) && $from_world->config('mode.state') == 'standard') // Sewers Key cannot leave
+                || ($item == Item::get('KeyH2', $from_world) && $from_world->config('mode.state') == 'standard' && $from_world->config('logic') !== 'NoLogic') // Sewers Key cannot leave
                 || (!$from_world->config('region.wildMaps', false) && $item instanceof Item\Map)
                 || (!$from_world->config('region.wildCompasses', false) && $item instanceof Item\Compass))
             && !in_array($item, $this->region_items)

--- a/app/World.php
+++ b/app/World.php
@@ -1319,7 +1319,7 @@ abstract class World
             if ($this->config('rom.EscapeAssist', false)) {
                 $rom->setEscapeAssist(0b00000001);
             }
-        } elseif ($uncle_items->has('TenBombs') || $this->config('logic') !== 'None') {
+        } elseif ($uncle_items->has('TenBombs') || $this->config('logic') !== 'NoLogic') {
             // TenBombs, or give player bombs if uncle was plando'd to not have a weapon.
             $rom->setEscapeFills(0b00000010);
             $rom->setUncleSpawnRefills(


### PR DESCRIPTION
Fix uncle bomb fill for standard no logic (should only apply to customizer with a non-weapon manually placed on uncle).
Make escape key wild for standard no logic.