### PR TITLE
Hard item pool shops.

### DIFF
--- a/app/Randomizer.php
+++ b/app/Randomizer.php
@@ -686,11 +686,16 @@ class Randomizer implements RandomizerContract
         // handle hardmode shops
         if ($world->config('shops.HardMode', false)) {
             $world->getShop("Capacity Upgrade")->clearInventory();
-            $world->getShop("Dark World Potion Shop")->addInventory(1, Item::get('Nothing', $world), 0);
-            $world->getShop("Dark World Forest Shop")->addInventory(0, Item::get('Nothing', $world), 0);
-            $world->getShop("Dark World Lumberjack Hut Shop")->addInventory(1, Item::get('Nothing', $world), 0);
-            $world->getShop("Dark World Outcasts Shop")->addInventory(1, Item::get('Nothing', $world), 0);
-            $world->getShop("Dark World Lake Hylia Shop")->addInventory(1, Item::get('Nothing', $world), 0);
+        }
+        $shield_replacement = Item::get($world->config('item.overflow.replacement.Shield', 'TwentyRupees2'), $world);
+        if ($world->config('item.overflow.count.Shield', 3) < 2) {
+            $world->getShop("Dark World Forest Shop")->addInventory(0, $shield_replacement, 500);
+        }
+        if ($world->config('item.overflow.count.Shield', 3) < 1) {
+            $world->getShop("Dark World Potion Shop")->addInventory(1, $shield_replacement, 50);
+            $world->getShop("Dark World Lumberjack Hut Shop")->addInventory(1, $shield_replacement, 50);
+            $world->getShop("Dark World Outcasts Shop")->addInventory(1, $shield_replacement, 50);
+            $world->getShop("Dark World Lake Hylia Shop")->addInventory(1, $shield_replacement, 50);
         }
 
         if (


### PR DESCRIPTION
Determine which shop shields are available via the shield overflow count.
Replace fire shield in dark world forest shop with a green twenty for expert+ item pool.
Replace shields in regular dark world shops with a green twenty for super expert and crowd control.