### PR TITLE
Mirror to Inverted Catfish

### DIFF
--- a/app/Region/Inverted/DarkWorld/NorthEast.php
+++ b/app/Region/Inverted/DarkWorld/NorthEast.php
@@ -53,7 +53,12 @@ class NorthEast extends Region\Standard\DarkWorld\NorthEast
             return $items->canLiftRocks()
                 || ($this->world->config('canBootsClip', false)
                     && $items->has('PegasusBoots')) ||
-                $this->world->config('canOneFrameClipOW', false);
+                $this->world->config('canOneFrameClipOW', false)
+                || ($items->has('MagicMirror') && $this->world->getRegion('South Light World')->canEnter($locations, $items)
+                    && ($items->has('MoonPearl') || 
+                        ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                    && ($items->has('Flippers') || $this->world->config('canFakeFlipper', false)
+                        || ($this->world->config('canWaterWalk', false) && $items->has('PegasusBoots'))));
         });
 
         $this->locations["Pyramid Fairy - Sword"]->setRequirements(function ($locations, $items) {

--- a/tests/Inverted/DarkWorld/NorthEastTest.php
+++ b/tests/Inverted/DarkWorld/NorthEastTest.php
@@ -49,13 +49,16 @@ class NorthEastTest extends TestCase
     {
         return [
             ["Catfish", false, []],
-            ["Catfish", false, [], ['Gloves']],
+            ["Catfish", false, [], ['Gloves', 'Flippers']],
+            ["Catfish", false, [], ['Gloves', 'MagicMirror']],
+            ["Catfish", false, [], ['Gloves', 'MagicMirror']],
             ["Catfish", true, ['DefeatAgahnim', 'MagicMirror', 'ProgressiveGlove']],
             ["Catfish", true, ['DefeatAgahnim', 'MagicMirror',  'PowerGlove']],
             ["Catfish", true, ['DefeatAgahnim', 'MagicMirror',  'TitansMitt']],
             ["Catfish", true, ['ProgressiveGlove', 'Hammer']],
             ["Catfish", true, ['ProgressiveGlove', 'Flippers']],
             ["Catfish", true, ['ProgressiveGlove', 'ProgressiveGlove', 'MagicMirror', 'MoonPearl']],
+            ["Catfish", true, ['MagicMirror', 'Flippers', 'DefeatAgahnim', 'MoonPearl']],
 
             ["Pyramid", false, []],
             ["Pyramid", true, ['DefeatAgahnim', 'MagicMirror']],


### PR DESCRIPTION
Allow Mirroring to Catfish when you can get to Light World Zora Area.

This can happen via a Pre Activated Flute / Fake Flute to Death Mountain for Aga Light World Access

Also changed Unit Tests to reflect new Catfish Access.

Bug Reported and Change Requested by StructuralMike#5345 on [Discord](https://discord.com/channels/307860211333595146/307860548878336001/967368142995193856)