### PR TITLE
Allow access to left side Mire with 2 keys if big key is there

### DIFF
--- a/app/Region/Standard/MiseryMire.php
+++ b/app/Region/Standard/MiseryMire.php
@@ -89,12 +89,14 @@ class MiseryMire extends Region
         $this->locations["Misery Mire - Big Key Chest"]->setRequirements(function ($locations, $items) {
             return $items->canLightTorches()
                 && (($locations["Misery Mire - Compass Chest"]->hasItem(Item::get('BigKeyD6', $this->world)) && $items->has('KeyD6', 2))
+                    || (($locations["Misery Mire - Big Key Chest"]->hasItem(Item::get('BigKeyD6', $this->world)) && $items->has('KeyD6', 2))
                     || $items->has('KeyD6', 3));
         });
 
         $this->locations["Misery Mire - Compass Chest"]->setRequirements(function ($locations, $items) {
             return $items->canLightTorches()
                 && (($locations["Misery Mire - Big Key Chest"]->hasItem(Item::get('BigKeyD6', $this->world)) && $items->has('KeyD6', 2))
+                    || (($locations["Misery Mire - Compass Chest"]->hasItem(Item::get('BigKeyD6', $this->world)) && $items->has('KeyD6', 2))
                     || $items->has('KeyD6', 3));
         });
 


### PR DESCRIPTION
Fixes a small inconsistency where the big key can be in one of the two left side Mire chests but is considered unreachable without 3 keys, preventing some safe item configurations from being possible.  This brings the php randomizer to parity with ER in this regard.