### PR TITLE
Fix Inverted Ganon Firerod/Lamp Logic

### DIFF
--- a/app/Region/Inverted/LightWorld/NorthEast.php
+++ b/app/Region/Inverted/LightWorld/NorthEast.php
@@ -196,12 +196,12 @@ class NorthEast extends Region\Standard\LightWorld\NorthEast
                             && ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
                                 || ($items->has('FireRod')
                                     && (($items->canExtendMagic($this->world, 3)
-                                        && $items->has('MoonPearl')) || 
+                                        && $items->has('MoonPearl')) ||
                                     $items->canExtendMagic($this->world, 4))))) || ($items->hasSword(3)
                         && ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
                             || ($items->has('FireRod')
                                 && (($items->canExtendMagic($this->world, 2)
-                                    && $items->has('MoonPearl')) || 
+                                    && $items->has('MoonPearl')) ||
                                 $items->canExtendMagic($this->world, 3))))));
         });
 

--- a/app/Region/Inverted/LightWorld/NorthEast.php
+++ b/app/Region/Inverted/LightWorld/NorthEast.php
@@ -189,20 +189,20 @@ class NorthEast extends Region\Standard\LightWorld\NorthEast
                     || $items->canShootArrows($this->world, 2)) && (
                     ($this->world->config('mode.weapons') == 'swordless'
                         && $items->has('Hammer') && ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
-                            || ($items->has('FireRod') && ($items->canExtendMagic($this->world, 1)
-                                && $items->has('MoonPearl')) || $items->canExtendMagic($this->world, 4)))) 
+                            || ($items->has('FireRod') && (($items->canExtendMagic($this->world, 2)
+                                && $items->has('MoonPearl')) || $items->canExtendMagic($this->world, 3)))))
                     || (!$this->world->config('region.requireBetterSword', false)
-                        && ($items->hasSword(2)
+                        && $items->hasSword(2)
                             && ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
                                 || ($items->has('FireRod')
-                                    && ($items->canExtendMagic($this->world, 3)
-                                        && $items->has('MoonPearl')) ||
+                                    && (($items->canExtendMagic($this->world, 3)
+                                        && $items->has('MoonPearl')) || 
                                     $items->canExtendMagic($this->world, 4))))) || ($items->hasSword(3)
                         && ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
                             || ($items->has('FireRod')
-                                && ($items->canExtendMagic($this->world, 2)
-                                    && $items->has('MoonPearl')) ||
-                                $items->canExtendMagic($this->world, 3)))));
+                                && (($items->canExtendMagic($this->world, 2)
+                                    && $items->has('MoonPearl')) || 
+                                $items->canExtendMagic($this->world, 3))))));
         });
 
         $this->can_enter = function ($locations, $items) {

--- a/tests/Inverted/LightWorldTest.php
+++ b/tests/Inverted/LightWorldTest.php
@@ -539,6 +539,8 @@ class LightWorldTest extends TestCase
             ["Ganon", false, []],
             ["Ganon", false, [], ['MoonPearl']],
             ["Ganon", false, [], ['DefeatAgahnim2']],
+            ["Ganon", false, [], ['FireRod', 'Lamp']],
+            ["Ganon", false, [], ['AnySword']],
         ];
     }
 }

--- a/tests/InvertedMajorGlitches/LightWorldTest.php
+++ b/tests/InvertedMajorGlitches/LightWorldTest.php
@@ -535,6 +535,9 @@ class LightWorldTest extends TestCase
             ["Bomb Merchant", true, ['Crystal5', 'Crystal6']],
             
             ["Ganon", false, []],
+            ["Ganon", false, [], ['DefeatAgahnim2']],
+            ["Ganon", false, [], ['FireRod', 'Lamp']],
+            ["Ganon", false, [], ['AnySword']],
         ];
     }
 }

--- a/tests/InvertedOverworldGlitches/LightWorldTest.php
+++ b/tests/InvertedOverworldGlitches/LightWorldTest.php
@@ -328,6 +328,9 @@ class LightWorldTest extends TestCase
             ["Bomb Merchant", true, ['Crystal5', 'Crystal6', 'DefeatAgahnim']],
             
             ["Ganon", false, []],
+            ["Ganon", false, [], ['DefeatAgahnim2']],
+            ["Ganon", false, [], ['FireRod', 'Lamp']],
+            ["Ganon", false, [], ['AnySword']],
         ];
     }
 }

--- a/tests/MajorGlitches/DarkWorld/NorthEastTest.php
+++ b/tests/MajorGlitches/DarkWorld/NorthEastTest.php
@@ -125,6 +125,8 @@ class NorthEastTest extends TestCase
 
             ["Ganon", false, []],
             ["Ganon", false, [], ['DefeatAgahnim2']],
+            ["Ganon", false, [], ['FireRod', 'Lamp']],
+            ["Ganon", false, [], ['AnySword']],
         ];
     }
 }

--- a/tests/NoGlitches/DarkWorld/NorthEastTest.php
+++ b/tests/NoGlitches/DarkWorld/NorthEastTest.php
@@ -134,6 +134,8 @@ class NorthEastTest extends TestCase
             ["Ganon", false, []],
             ["Ganon", false, [], ['MoonPearl']],
             ["Ganon", false, [], ['DefeatAgahnim2']],
+            ["Ganon", false, [], ['FireRod', 'Lamp']],
+            ["Ganon", false, [], ['AnySword']],
         ];
     }
 }

--- a/tests/OverworldGlitches/DarkWorld/NorthEastTest.php
+++ b/tests/OverworldGlitches/DarkWorld/NorthEastTest.php
@@ -73,6 +73,8 @@ class NorthEastTest extends TestCase
             ["Ganon", false, []],
             ["Ganon", false, [], ['MoonPearl']],
             ["Ganon", false, [], ['DefeatAgahnim2']],
+            ["Ganon", false, [], ['FireRod', 'Lamp']],
+            ["Ganon", false, [], ['AnySword']],
         ];
     }
 }


### PR DESCRIPTION
Add missing brackets around magic extension logic.
Adjust magic extension logic in swordless to be in line with the tempered version of that logic.
Add Tests for Standard + Inverted Ganon being unbeatable without firesource or swords.