### PR TITLE
New Ganonhunt goal

### DIFF
--- a/app/Filler/RandomAssumed.php
+++ b/app/Filler/RandomAssumed.php
@@ -66,7 +66,10 @@ class RandomAssumed extends Filler
         ));
 
         if ($remaining_fill_items->count() > $locations->getEmptyLocations()->count()) {
-            throw new \Exception("Trying to fill more items than available locations.");
+            throw new \Exception(
+                "Trying to fill more items than available locations." .
+                    $remaining_fill_items->count() . ' ' . $locations->getEmptyLocations()->count()
+            );
         }
 
         $worlds = new WorldCollection($this->worlds);

--- a/app/Http/Controllers/CustomizerController.php
+++ b/app/Http/Controllers/CustomizerController.php
@@ -131,7 +131,7 @@ class CustomizerController extends Controller
         // some simple validation
         // @TODO: move to validator type classes later
         if (
-            $request->input('goal', 'ganon') === 'triforce-hunt'
+            in_array($request->input('goal', 'ganon'), ['triforce-hunt', 'tfh_ganon'])
             && ($custom_data['item.Goal.Required'] ?? 0)
             > ($custom_data['item.count.TriforcePiece'] ?? 0) + ($placed_item_count['TriforcePiece:1'] ?? 0)
         ) {

--- a/app/Http/Controllers/CustomizerController.php
+++ b/app/Http/Controllers/CustomizerController.php
@@ -131,7 +131,7 @@ class CustomizerController extends Controller
         // some simple validation
         // @TODO: move to validator type classes later
         if (
-            in_array($request->input('goal', 'ganon'), ['triforce-hunt', 'tfh_ganon'])
+            in_array($request->input('goal', 'ganon'), ['triforce-hunt', 'ganonhunt'])
             && ($custom_data['item.Goal.Required'] ?? 0)
             > ($custom_data['item.count.TriforcePiece'] ?? 0) + ($placed_item_count['TriforcePiece:1'] ?? 0)
         ) {

--- a/app/Randomizer.php
+++ b/app/Randomizer.php
@@ -103,7 +103,7 @@ class Randomizer implements RandomizerContract
             case 'ganon':
             case 'fast_ganon':
             case 'dungeons':
-            case 'tfh_ganon':
+            case 'ganonhunt':
                 $world->getLocation("Ganon")->setItem(Item::get('Triforce', $world));
                 break;
         }
@@ -1007,7 +1007,7 @@ class Randomizer implements RandomizerContract
                 $world->setText('ganon_fall_in_alt', "You think you\nare ready to\nface me?\n\nI will not die\n\nunless you\ncomplete your\ngoals. Dingus!");
 
                 break;
-            case 'tfh_ganon':
+            case 'ganonhunt':
                 $ganon_require = sprintf('To beat Ganon you must collect %d Triforce Pieces.', $world->config('item.Goal.Required'));
                 $world->setText('sign_ganon', $ganon_require);
                 $world->setText('ganon_fall_in_alt', "You think you\nare ready to\nface me?\n\nI will not die\n\nunless you\ncomplete your\ngoals. Dingus!");

--- a/app/Randomizer.php
+++ b/app/Randomizer.php
@@ -103,6 +103,7 @@ class Randomizer implements RandomizerContract
             case 'ganon':
             case 'fast_ganon':
             case 'dungeons':
+            case 'tfh_ganon':
                 $world->getLocation("Ganon")->setItem(Item::get('Triforce', $world));
                 break;
         }
@@ -982,12 +983,12 @@ class Randomizer implements RandomizerContract
 
         switch ($world->config('goal')) {
             case 'ganon':
-                $ganon_crystals_singular = 'To beat Ganon you must collect %d crystal and defeat his minion at the top of his tower.';
-                $ganon_crystals_plural = 'To beat Ganon you must collect %d crystals and defeat his minion at the top of his tower.';
+                $ganon_crystals_singular = 'To beat Ganon you must collect %d Crystal and defeat his minion at the top of his tower.';
+                $ganon_crystals_plural = 'To beat Ganon you must collect %d Crystals and defeat his minion at the top of his tower.';
                 break;
             default:
-                $ganon_crystals_singular = 'You need %d crystal to beat Ganon.';
-                $ganon_crystals_plural = 'You need %d crystals to beat Ganon.';
+                $ganon_crystals_singular = 'You need %d Crystal to beat Ganon.';
+                $ganon_crystals_plural = 'You need %d Crystals to beat Ganon.';
                 break;
         }
 
@@ -1002,6 +1003,12 @@ class Randomizer implements RandomizerContract
                 break;
             case 'fast_ganon':
                 $ganon_require = sprintf($ganon_string, $world->config('crystals.ganon'));
+                $world->setText('sign_ganon', $ganon_require);
+                $world->setText('ganon_fall_in_alt', "You think you\nare ready to\nface me?\n\nI will not die\n\nunless you\ncomplete your\ngoals. Dingus!");
+
+                break;
+            case 'tfh_ganon':
+                $ganon_require = sprintf('To beat Ganon you must collect %d Triforce Pieces.', $world->config('item.Goal.Required'));
                 $world->setText('sign_ganon', $ganon_require);
                 $world->setText('ganon_fall_in_alt', "You think you\nare ready to\nface me?\n\nI will not die\n\nunless you\ncomplete your\ngoals. Dingus!");
 

--- a/app/Region/Standard/DarkWorld/NorthEast.php
+++ b/app/Region/Standard/DarkWorld/NorthEast.php
@@ -184,7 +184,7 @@ class NorthEast extends Region
 
         $this->prize_location->setRequirements(function ($locations, $items) {
             if (
-                $this->world->config('goal') == 'tfh_ganon'
+                $this->world->config('goal') == 'ganonhunt'
                 && (!$items->has('TriforcePiece', $this->world->config('item.Goal.Required')))
             ) {
                     return false;

--- a/app/Region/Standard/DarkWorld/NorthEast.php
+++ b/app/Region/Standard/DarkWorld/NorthEast.php
@@ -184,6 +184,13 @@ class NorthEast extends Region
 
         $this->prize_location->setRequirements(function ($locations, $items) {
             if (
+                $this->world->config('goal') == 'tfh_ganon'
+                && (!$items->has('TriforcePiece', $this->world->config('item.Goal.Required')))
+            ) {
+                    return false;
+            }
+
+            if (
                 $this->world->config('goal') == 'dungeons'
                 && (!$items->has('PendantOfCourage')
                     || !$items->has('PendantOfWisdom')

--- a/app/Rom.php
+++ b/app/Rom.php
@@ -584,6 +584,9 @@ class Rom
             case 'custom':
                 $byte = pack('C', 0x04);
                 break;
+            case 'tfh_ganon':
+                $byte = pack('C', 0x05);
+                break;
             case 'no':
             default:
                 $byte = pack('C*', 0x00);

--- a/app/Rom.php
+++ b/app/Rom.php
@@ -584,7 +584,7 @@ class Rom
             case 'custom':
                 $byte = pack('C', 0x04);
                 break;
-            case 'tfh_ganon':
+            case 'ganonhunt':
                 $byte = pack('C', 0x05);
                 break;
             case 'no':

--- a/app/Rom.php
+++ b/app/Rom.php
@@ -581,11 +581,25 @@ class Rom
             case 'yes':
                 $byte = pack('C*', 0x01);
                 break;
-            case 'custom':
+            case 'crystals_only':
                 $byte = pack('C', 0x04);
                 break;
             case 'ganonhunt':
                 $byte = pack('C', 0x05);
+                break;
+            case 'lightspeed':
+                // light world only, pull ped, kill aga 1
+                $byte = pack('C', 0x06);
+                break;
+            case 'crystals_bosses':
+                $byte = pack('C', 0x07);
+                break;
+            case 'bosses_only':
+                $byte = pack('C', 0x08);
+                break;
+            case 'dungeons_no_agahnim':
+                // all dungeons, aga 1 not required
+                $byte = pack('C', 0x09);
                 break;
             case 'no':
             default:

--- a/app/World.php
+++ b/app/World.php
@@ -375,7 +375,8 @@ abstract class World
      *
      * @return array
      */
-    public function getConfig(): array {
+    public function getConfig(): array
+    {
         $config_copy = $this->config;
         return $config_copy;
     }
@@ -1182,14 +1183,14 @@ abstract class World
                 break;
             case 'ganonhunt':
                 $rom->initial_sram->preOpenPyramid();
-                $rom->setGanonInvincible('ganonhunt');
+                $rom->setGanonInvincible('triforce_pieces');
                 break;
             case 'fast_ganon':
                 $rom->initial_sram->preOpenPyramid();
 
                 // no break
             default:
-                $rom->setGanonInvincible('custom');
+                $rom->setGanonInvincible('crystals_only');
         }
 
         if ($this->config('rom.mapOnPickup', false)) {
@@ -1329,7 +1330,8 @@ abstract class World
      *
      * @return void
      */
-    public function setEscapeFills(Rom $rom) {
+    public function setEscapeFills(Rom $rom)
+    {
         $uncle_items = new ItemCollection;
         $uncle_items->setChecksForWorld($this->id);
         $uncle_items = $uncle_items->addItem($this->getLocation("Link's Uncle")->getItem());
@@ -1347,9 +1349,11 @@ abstract class World
             $rom->setUncleSpawnRefills(0, 0, 0);
             $rom->setZeldaSpawnRefills(0, 0, 0);
             $rom->setMantleSpawnRefills(0, 0, 0);
-        } elseif ($uncle_items->has('FireRod')
+        } elseif (
+            $uncle_items->has('FireRod')
             || $uncle_items->has('CaneOfSomaria')
-            || ($uncle_items->has('CaneOfByrna') && $this->config('enemizer.enemyHealth', 'default') == 'default')) {
+            || ($uncle_items->has('CaneOfByrna') && $this->config('enemizer.enemyHealth', 'default') == 'default')
+        ) {
             $rom->setEscapeFills(0b00000100);
             $rom->setUncleSpawnRefills(
                 $this->config('rom.EscapeRefills.Uncle.Magic', 0x80),

--- a/app/World.php
+++ b/app/World.php
@@ -102,7 +102,7 @@ abstract class World
             $collected_items->setChecksForWorld($this->id);
             return $collected_items->has('Triforce')
                 || ($this->regions['North East Light World']->canEnter($this->locations, $collected_items) &&
-                    $collected_items->has('TriforcePiece', $this->config('item.Goal.Required')));
+                    ($this->config('goal', 'ganon') == 'triforce-hunt' && $collected_items->has('TriforcePiece', $this->config('item.Goal.Required'))));
         };
 
         // Handle configuration options that map to switches.
@@ -1179,6 +1179,10 @@ abstract class World
                 break;
             case 'dungeons':
                 $rom->setGanonInvincible('dungeons');
+                break;
+            case 'tfh_ganon':
+                $rom->initial_sram->preOpenPyramid();
+                $rom->setGanonInvincible('tfh_ganon');
                 break;
             case 'fast_ganon':
                 $rom->initial_sram->preOpenPyramid();

--- a/app/World.php
+++ b/app/World.php
@@ -1180,9 +1180,9 @@ abstract class World
             case 'dungeons':
                 $rom->setGanonInvincible('dungeons');
                 break;
-            case 'tfh_ganon':
+            case 'ganonhunt':
                 $rom->initial_sram->preOpenPyramid();
-                $rom->setGanonInvincible('tfh_ganon');
+                $rom->setGanonInvincible('ganonhunt');
                 break;
             case 'fast_ganon':
                 $rom->initial_sram->preOpenPyramid();

--- a/config/alttp.php
+++ b/config/alttp.php
@@ -39,6 +39,17 @@ return [
                 ],
             ],
         ],
+        'tfh_ganon' => [
+            'item' => [
+                'count' => [
+                    'TriforcePiece' => 60,
+                ],
+                'Goal' => [
+                    'Required' => 40,
+                    'Icon' => 'triforce',
+                ],
+            ],
+        ],
     ],
     'randomizer' => [
         'item' => [
@@ -206,6 +217,7 @@ return [
                 'dungeons' => 'All Dungeons',
                 'pedestal' => 'Master Sword Pedestal',
                 'triforce-hunt' => 'Triforce Pieces',
+                'tfh_ganon' => 'Triforce Hunt + Ganon',
             ],
             'tower_open' => [
                 '0' => 'none',
@@ -326,6 +338,7 @@ return [
                 'dungeons' => 10,
                 'pedestal' => 10,
                 'triforce-hunt' => 10,
+                'tfh_ganon' => 0,
             ],
             'tower_open' => [
                 '0' => 5,

--- a/config/alttp.php
+++ b/config/alttp.php
@@ -39,7 +39,7 @@ return [
                 ],
             ],
         ],
-        'tfh_ganon' => [
+        'ganonhunt' => [
             'item' => [
                 'count' => [
                     'TriforcePiece' => 60,
@@ -217,7 +217,7 @@ return [
                 'dungeons' => 'All Dungeons',
                 'pedestal' => 'Master Sword Pedestal',
                 'triforce-hunt' => 'Triforce Pieces',
-                'tfh_ganon' => 'Triforce Hunt + Ganon',
+                'ganonhunt' => 'Triforce Hunt + Ganon',
             ],
             'tower_open' => [
                 '0' => 'none',
@@ -338,7 +338,7 @@ return [
                 'dungeons' => 10,
                 'pedestal' => 10,
                 'triforce-hunt' => 10,
-                'tfh_ganon' => 0,
+                'ganonhunt' => 0,
             ],
             'tower_open' => [
                 '0' => 5,

--- a/config/alttp.php
+++ b/config/alttp.php
@@ -217,7 +217,7 @@ return [
                 'dungeons' => 'All Dungeons',
                 'pedestal' => 'Master Sword Pedestal',
                 'triforce-hunt' => 'Triforce Pieces',
-                'ganonhunt' => 'Triforce Hunt + Ganon',
+                'ganonhunt' => 'Ganonhunt',
             ],
             'tower_open' => [
                 '0' => 'none',

--- a/resources/js/store/modules/randomizer.js
+++ b/resources/js/store/modules/randomizer.js
@@ -186,7 +186,7 @@ export default {
       if (state.goal.value === "dungeons") {
         commit("setGanonOpen", "7");
       }
-      if (state.goal.value === "tfh_ganon") {
+      if (state.goal.value === "ganonhunt") {
         commit("setEntranceShuffle", "none");
       }
     },
@@ -221,7 +221,7 @@ export default {
         }
 
         // ER doesn't currently support TFH Ganon
-        if (state.goal.value === "tfh_ganon") {
+        if (state.goal.value === "ganonhunt") {
           commit("setGoal", "fast_ganon");
         }
 

--- a/resources/js/store/modules/randomizer.js
+++ b/resources/js/store/modules/randomizer.js
@@ -220,7 +220,7 @@ export default {
           commit("setDungeonItems", "standard");
         }
 
-        // ER doesn't currently support TFH Ganon
+        // ER doesn't currently support Ganonhunt
         if (state.goal.value === "ganonhunt") {
           commit("setGoal", "fast_ganon");
         }

--- a/resources/js/store/modules/randomizer.js
+++ b/resources/js/store/modules/randomizer.js
@@ -186,6 +186,9 @@ export default {
       if (state.goal.value === "dungeons") {
         commit("setGanonOpen", "7");
       }
+      if (state.goal.value === "tfh_ganon") {
+        commit("setEntranceShuffle", "none");
+      }
     },
     setGanonOpen({ commit, state }, value) {
       commit("setGanonOpen", value);
@@ -216,6 +219,12 @@ export default {
         if (["full", "standard"].indexOf(state.dungeon_items.value) === -1) {
           commit("setDungeonItems", "standard");
         }
+
+        // ER doesn't currently support TFH Ganon
+        if (state.goal.value === "tfh_ganon") {
+          commit("setGoal", "fast_ganon");
+        }
+
         if (state.item_pool.value === "crowd_control") {
           commit("setItemPool", "expert");
         }

--- a/resources/lang/de/options.php
+++ b/resources/lang/de/options.php
@@ -116,6 +116,12 @@ return [
                         'Karten, Kompasse, kleine Schlüssel und große Schlüssel sind nicht mehr an ihren Palast gebunden (könnten trotzdem noch drin landen).',
                     ],
                 ],
+                [
+                    'header' => __('randomizer.goal.options.tfh_ganon'),
+                    'content' => [
+                        'The Triforce has been shattered into 60 pieces and scattered throughout Hyrule! You must first collect 40 of the 60 pieces, and only then will Ganon be vulnerable to your attacks!  Like Fast Ganon, the hole leading to Ganon has been made permanently accessible.  This goal is not available if entrances are randomized.',
+                    ],
+                ],
             ],
         ],
         'accessibility' => [

--- a/resources/lang/de/options.php
+++ b/resources/lang/de/options.php
@@ -117,7 +117,7 @@ return [
                     ],
                 ],
                 [
-                    'header' => __('randomizer.goal.options.tfh_ganon'),
+                    'header' => __('randomizer.goal.options.ganonhunt'),
                     'content' => [
                         'The Triforce has been shattered into 60 pieces and scattered throughout Hyrule! You must first collect 40 of the 60 pieces, and only then will Ganon be vulnerable to your attacks!  Like Fast Ganon, the hole leading to Ganon has been made permanently accessible.  This goal is not available if entrances are randomized.',
                     ],

--- a/resources/lang/de/randomizer.php
+++ b/resources/lang/de/randomizer.php
@@ -61,7 +61,7 @@ return [
             'dungeons' => 'Alle Dungeons',
             'pedestal' => 'Master-Schwert Sockel',
             'triforce-hunt' => 'Triforce-Splitter',
-            'tfh_ganon' => 'Triforce Pieces & Fast Ganon',
+            'ganonhunt' => 'Ganonhunt',
         ],
     ],
     'tower_open' => [

--- a/resources/lang/de/randomizer.php
+++ b/resources/lang/de/randomizer.php
@@ -61,7 +61,7 @@ return [
             'dungeons' => 'Alle Dungeons',
             'pedestal' => 'Master-Schwert Sockel',
             'triforce-hunt' => 'Triforce-Splitter',
-            'tfh_ganon' => 'Triforce Pieces & Defeat Ganon',
+            'tfh_ganon' => 'Triforce Pieces & Fast Ganon',
         ],
     ],
     'tower_open' => [

--- a/resources/lang/de/randomizer.php
+++ b/resources/lang/de/randomizer.php
@@ -61,6 +61,7 @@ return [
             'dungeons' => 'Alle Dungeons',
             'pedestal' => 'Master-Schwert Sockel',
             'triforce-hunt' => 'Triforce-Splitter',
+            'tfh_ganon' => 'Triforce Pieces & Defeat Ganon',
         ],
     ],
     'tower_open' => [

--- a/resources/lang/en/options.php
+++ b/resources/lang/en/options.php
@@ -168,6 +168,12 @@ return [
                         'The Triforce has been shattered into 30 pieces and scattered throughout Hyrule! You must collect 20 of the 30 pieces and take them to Murahdahla to receive the Triforce. Who is Murahdahla I hear you ask? Why, he is obviously the younger brother of Sahasrahla and Aginah! Back from his vacation in Lorule you can find him hanging out around Hyrule Castle courtyard.',
                     ],
                 ],
+                [
+                    'header' => __('randomizer.goal.options.tfh_ganon'),
+                    'content' => [
+                        'The Triforce has been shattered into 60 pieces and scattered throughout Hyrule! You must first collect 40 of the 60 pieces, and only then will Ganon be vulnerable to your attacks!  Like Fast Ganon, the hole leading to Ganon has been made permanently accessible.  This goal is not available if entrances are randomized.',
+                    ],
+                ],
             ],
         ],
         'tower_open' => [

--- a/resources/lang/en/options.php
+++ b/resources/lang/en/options.php
@@ -169,7 +169,7 @@ return [
                     ],
                 ],
                 [
-                    'header' => __('randomizer.goal.options.tfh_ganon'),
+                    'header' => __('randomizer.goal.options.ganonhunt'),
                     'content' => [
                         'The Triforce has been shattered into 60 pieces and scattered throughout Hyrule! You must first collect 40 of the 60 pieces, and only then will Ganon be vulnerable to your attacks!  Like Fast Ganon, the hole leading to Ganon has been made permanently accessible.  This goal is not available if entrances are randomized.',
                     ],

--- a/resources/lang/en/randomizer.php
+++ b/resources/lang/en/randomizer.php
@@ -61,7 +61,7 @@ return [
             'dungeons' => 'All Dungeons',
             'pedestal' => 'Master Sword Pedestal',
             'triforce-hunt' => 'Triforce Pieces',
-            'tfh_ganon' => 'Triforce Pieces & Fast Ganon',
+            'ganonhunt' => 'Ganonhunt',
         ],
     ],
     'tower_open' => [

--- a/resources/lang/en/randomizer.php
+++ b/resources/lang/en/randomizer.php
@@ -61,7 +61,7 @@ return [
             'dungeons' => 'All Dungeons',
             'pedestal' => 'Master Sword Pedestal',
             'triforce-hunt' => 'Triforce Pieces',
-            'tfh_ganon' => 'Triforce Pieces & Defeat Ganon',
+            'tfh_ganon' => 'Triforce Pieces & Fast Ganon',
         ],
     ],
     'tower_open' => [

--- a/resources/lang/en/randomizer.php
+++ b/resources/lang/en/randomizer.php
@@ -61,6 +61,7 @@ return [
             'dungeons' => 'All Dungeons',
             'pedestal' => 'Master Sword Pedestal',
             'triforce-hunt' => 'Triforce Pieces',
+            'tfh_ganon' => 'Triforce Pieces & Defeat Ganon',
         ],
     ],
     'tower_open' => [

--- a/resources/lang/es/options.php
+++ b/resources/lang/es/options.php
@@ -176,7 +176,7 @@ return [
                     ],
                 ],
                 [
-                    'header' => __('randomizer.goal.options.tfh_ganon'),
+                    'header' => __('randomizer.goal.options.ganonhunt'),
                     'content' => [
                         'The Triforce has been shattered into 60 pieces and scattered throughout Hyrule! You must first collect 40 of the 60 pieces, and only then will Ganon be vulnerable to your attacks!  Like Fast Ganon, the hole leading to Ganon has been made permanently accessible.  This goal is not available if entrances are randomized.',
                     ],

--- a/resources/lang/es/options.php
+++ b/resources/lang/es/options.php
@@ -175,6 +175,12 @@ return [
                         '¡La Trifuerza se ha roto en 30 fragmentos esparcidos por todo Hyrule! Tienes que encontrar 20 de las 30 piezas y llevárselas a Murahdahla para recibir la Trifuerza. ¿Que preguntas quién es Murahdahala? ¡Pues obviamente es el hermano menor de Sahasrahla y Aginah! Ha vuelto de sus vacaciones en Lorule y puedes encontrarle pasando el rato en el patio del Castillo de Hyrule.',
                     ],
                 ],
+                [
+                    'header' => __('randomizer.goal.options.tfh_ganon'),
+                    'content' => [
+                        'The Triforce has been shattered into 60 pieces and scattered throughout Hyrule! You must first collect 40 of the 60 pieces, and only then will Ganon be vulnerable to your attacks!  Like Fast Ganon, the hole leading to Ganon has been made permanently accessible.  This goal is not available if entrances are randomized.',
+                    ],
+                ],
             ],
         ],
         'tower_open' => [

--- a/resources/lang/es/randomizer.php
+++ b/resources/lang/es/randomizer.php
@@ -61,7 +61,7 @@ return [
             'dungeons' => 'Todas las mazmorras',
             'pedestal' => 'Pedestal de la Espada Maestra',
             'triforce-hunt' => 'Piezas de la Trifuerza',
-            'tfh_ganon' => 'Triforce Pieces & Fast Ganon',
+            'ganonhunt' => 'Ganonhunt',
         ],
     ],
     'tower_open' => [

--- a/resources/lang/es/randomizer.php
+++ b/resources/lang/es/randomizer.php
@@ -61,6 +61,7 @@ return [
             'dungeons' => 'Todas las mazmorras',
             'pedestal' => 'Pedestal de la Espada Maestra',
             'triforce-hunt' => 'Piezas de la Trifuerza',
+            'tfh_ganon' => 'Triforce Pieces & Defeat Ganon',
         ],
     ],
     'tower_open' => [

--- a/resources/lang/es/randomizer.php
+++ b/resources/lang/es/randomizer.php
@@ -61,7 +61,7 @@ return [
             'dungeons' => 'Todas las mazmorras',
             'pedestal' => 'Pedestal de la Espada Maestra',
             'triforce-hunt' => 'Piezas de la Trifuerza',
-            'tfh_ganon' => 'Triforce Pieces & Defeat Ganon',
+            'tfh_ganon' => 'Triforce Pieces & Fast Ganon',
         ],
     ],
     'tower_open' => [

--- a/resources/lang/fr/options.php
+++ b/resources/lang/fr/options.php
@@ -175,7 +175,7 @@ return [
                     ],
                 ],
                 [
-                    'header' => __('randomizer.goal.options.tfh_ganon'),
+                    'header' => __('randomizer.goal.options.ganonhunt'),
                     'content' => [
                         'The Triforce has been shattered into 60 pieces and scattered throughout Hyrule! You must first collect 40 of the 60 pieces, and only then will Ganon be vulnerable to your attacks!  Like Fast Ganon, the hole leading to Ganon has been made permanently accessible.  This goal is not available if entrances are randomized.',
                     ],

--- a/resources/lang/fr/options.php
+++ b/resources/lang/fr/options.php
@@ -174,6 +174,12 @@ return [
                         'La Triforce a été brisée en 30 morceaux, éparpillés à travers Hyrule! Vous devez retrouver 20 des 30 pièces, et les emmener à Murahdhala pour recevoir la Triforce. Qui est ce Murahdahla, me direz-vous? Mais enfin, il est évidemment le petit frère de Sahasrahla et Aginah! De retour de ses vacances à Lorule, vous le trouverez dans la cour du Château d’Hyrule.',
                     ],
                 ],
+                [
+                    'header' => __('randomizer.goal.options.tfh_ganon'),
+                    'content' => [
+                        'The Triforce has been shattered into 60 pieces and scattered throughout Hyrule! You must first collect 40 of the 60 pieces, and only then will Ganon be vulnerable to your attacks!  Like Fast Ganon, the hole leading to Ganon has been made permanently accessible.  This goal is not available if entrances are randomized.',
+                    ],
+                ],
             ],
         ],
         'tower_open' => [

--- a/resources/lang/fr/randomizer.php
+++ b/resources/lang/fr/randomizer.php
@@ -61,7 +61,7 @@ return [
             'dungeons' => 'Tous les Donjons',
             'pedestal' => 'Piédestal de la Master Sword',
             'triforce-hunt' => 'Morceaux de Triforce ',
-            'tfh_ganon' => 'Triforce Pieces & Fast Ganon',
+            'ganonhunt' => 'Ganonhunt',
         ],
     ],
     'tower_open' => [

--- a/resources/lang/fr/randomizer.php
+++ b/resources/lang/fr/randomizer.php
@@ -61,7 +61,7 @@ return [
             'dungeons' => 'Tous les Donjons',
             'pedestal' => 'Piédestal de la Master Sword',
             'triforce-hunt' => 'Morceaux de Triforce ',
-            'tfh_ganon' => 'Triforce Pieces & Defeat Ganon',
+            'tfh_ganon' => 'Triforce Pieces & Fast Ganon',
         ],
     ],
     'tower_open' => [

--- a/resources/lang/fr/randomizer.php
+++ b/resources/lang/fr/randomizer.php
@@ -61,6 +61,7 @@ return [
             'dungeons' => 'Tous les Donjons',
             'pedestal' => 'Piédestal de la Master Sword',
             'triforce-hunt' => 'Morceaux de Triforce ',
+            'tfh_ganon' => 'Triforce Pieces & Defeat Ganon',
         ],
     ],
     'tower_open' => [

--- a/resources/views/updates.blade.php
+++ b/resources/views/updates.blade.php
@@ -7,7 +7,7 @@
     <li>New Features</li>
     <ul>
         <li>The randomizer now uses a new font that is more compact and contains lowercase characters!  Thank you to total, kan, kara, Aerinon, and cassidymoen for the work on this feature.</li>
-        <li>A new goal called "Triforce Pieces & Defeat Ganon" has been added!  This goal is similar to the "Triforce Pieces" goal, but requires the player to defeat Ganon after collecting the triforce pieces instead of turning them into Murahdahla.</li>
+        <li>A new goal called "Triforce Pieces & Fast Ganon" has been added!  This goal is similar to the "Triforce Pieces" goal, but requires the player to defeat Ganon after collecting the triforce pieces instead of turning them into Murahdahla.</li>
         <li>Players may now include lowercase letters and numbers in their file name.</li>
         <li>Winners of the 2022 Main Tournament, and 2022 No Logic tournaments have been added to their respective in-game signs.</li>
         <li>Hybrid Major Glitches is now a fully supported logic option.</li>

--- a/resources/views/updates.blade.php
+++ b/resources/views/updates.blade.php
@@ -7,6 +7,7 @@
     <li>New Features</li>
     <ul>
         <li>The randomizer now uses a new font that is more compact and contains lowercase characters!  Thank you to total, kan, kara, Aerinon, and cassidymoen for the work on this feature.</li>
+        <li>A new goal called "Triforce Pieces & Defeat Ganon" has been added!  This goal is similar to the "Triforce Pieces" goal, but requires the player to defeat Ganon after collecting the triforce pieces instead of turning them into Murahdahla.</li>
         <li>Players may now include lowercase letters and numbers in their file name.</li>
         <li>Winners of the 2022 Main Tournament, and 2022 No Logic tournaments have been added to their respective in-game signs.</li>
         <li>Hybrid Major Glitches is now a fully supported logic option.</li>

--- a/resources/views/updates.blade.php
+++ b/resources/views/updates.blade.php
@@ -7,7 +7,7 @@
     <li>New Features</li>
     <ul>
         <li>The randomizer now uses a new font that is more compact and contains lowercase characters!  Thank you to total, kan, kara, Aerinon, and cassidymoen for the work on this feature.</li>
-        <li>A new goal called "Triforce Pieces & Fast Ganon" has been added!  This goal is similar to the "Triforce Pieces" goal, but requires the player to defeat Ganon after collecting the triforce pieces instead of turning them into Murahdahla.</li>
+        <li>A new goal called "Ganonhunt" has been added!  This goal is similar to the "Triforce Pieces" goal, but requires the player to defeat Ganon after collecting the triforce pieces instead of turning them into Murahdahla.</li>
         <li>Players may now include lowercase letters and numbers in their file name.</li>
         <li>Winners of the 2022 Main Tournament, and 2022 No Logic tournaments have been added to their respective in-game signs.</li>
         <li>Hybrid Major Glitches is now a fully supported logic option.</li>

--- a/tests/RomTest.php
+++ b/tests/RomTest.php
@@ -679,6 +679,13 @@ class RomTest extends TestCase
         $this->assertEquals(0x01, $this->rom->read(0x18003E));
     }
 
+    public function testSetGanonInvincibleTFH()
+    {
+        $this->rom->setGanonInvincible('tfh_ganon');
+
+        $this->assertEquals(0x05, $this->rom->read(0x18003E));
+    }
+
     public function testSetGanonInvincibleCustom()
     {
         $this->rom->setGanonInvincible('custom');

--- a/tests/RomTest.php
+++ b/tests/RomTest.php
@@ -679,16 +679,16 @@ class RomTest extends TestCase
         $this->assertEquals(0x01, $this->rom->read(0x18003E));
     }
 
-    public function testSetGanonInvincibleGanonhunt()
+    public function testSetGanonInvincibleTriforcePieces()
     {
-        $this->rom->setGanonInvincible('ganonhunt');
+        $this->rom->setGanonInvincible('triforce_pieces');
 
         $this->assertEquals(0x05, $this->rom->read(0x18003E));
     }
 
-    public function testSetGanonInvincibleCustom()
+    public function testSetGanonInvincibleCrystalsOnly()
     {
-        $this->rom->setGanonInvincible('custom');
+        $this->rom->setGanonInvincible('crystals_only');
 
         $this->assertEquals(0x04, $this->rom->read(0x18003E));
     }
@@ -769,7 +769,7 @@ class RomTest extends TestCase
         $this->assertEquals($expectedByte, $this->rom->read(0x6FA2C));
         $this->assertEquals($expectedByte, $this->rom->read(0x6FA2E));
         $this->assertEquals($expectedByte, $this->rom->read(0x6FA30));
-        
+
         $this->assertEquals($expectedFileByte, $this->rom->read(0x65561));
     }
 

--- a/tests/RomTest.php
+++ b/tests/RomTest.php
@@ -681,7 +681,7 @@ class RomTest extends TestCase
 
     public function testSetGanonInvincibleTFH()
     {
-        $this->rom->setGanonInvincible('tfh_ganon');
+        $this->rom->setGanonInvincible('ganonhunt');
 
         $this->assertEquals(0x05, $this->rom->read(0x18003E));
     }

--- a/tests/RomTest.php
+++ b/tests/RomTest.php
@@ -679,7 +679,7 @@ class RomTest extends TestCase
         $this->assertEquals(0x01, $this->rom->read(0x18003E));
     }
 
-    public function testSetGanonInvincibleTFH()
+    public function testSetGanonInvincibleGanonhunt()
     {
         $this->rom->setGanonInvincible('ganonhunt');
 


### PR DESCRIPTION
Adds a new goal called "Ganonhunt".  There are some things that I think we may still need to do regarding this PR, but I wanted to give you at least a first look at it.  This will not currently work with Entrance Randomizer, and as a result it has been explicitly disabled.  The frontend will force entrance shuffle off if the new goal is chosen, and if entrances are turned on while the new goal is chosen, it'll set the goal to Fast Ganon.

Rules:
1. Pyramid is pre-opened.
2. Agahnim 2 is not required
3. Crystals are not required to defeat Ganon.  Ganon vulnerability is strictly 40 Triforce Pieces.
4. Crystals are still required for GT entry.  GT fill rules are the same as the other Ganon goals.

Remaining (potential) tasks:

- [ ] Get i18n from the community.  Right now there's just placeholder English in place for the goal name and description.
- [x] Unit tests:  Are unit tests needed for this?
- [ ] Bug testing
- [ ] Potentially update ER to also support this goal.
- [ ] Right now it places 60 pieces, and 40 are required to engage Ganon.  This may require further tuning discussion.