### PR TITLE
Modifies crosskeys preset to default to 100% Locations accessibliity

### DIFF
--- a/config/alttp.php
+++ b/config/alttp.php
@@ -117,7 +117,7 @@ return [
                     'glitches_required' => 'none',
                     'item_placement' => 'advanced',
                     'dungeon_items' => 'full',
-                    'accessibility' => 'items',
+                    'accessibility' => 'locations',
                     'goal' => 'fast_ganon',
                     'tower_open' => '7',
                     'ganon_open' => '7',


### PR DESCRIPTION
This replaces the preset to make it default to 100% locations (AKA the crosskeys2023 preset). This has been the overwhelming majority in racing since it has been introduced and is the mode of the Crosskeys tournament as well.

I chose to not touch hints here, even though most racers run without hints. I think it may be worth revisiting that.