### PR TITLE
Fixes: Item Quickswap option not available in customizer when Spoilers is set to Disabled

### DIFF
--- a/resources/js/views/Customizer.vue
+++ b/resources/js/views/Customizer.vue
@@ -572,6 +572,14 @@ export default {
                     window.location.reload(true);
                   }
 
+                  if (
+                    this.rom.shuffle ||
+                    this.rom.spoilers == "mystery" ||
+                    this.rom.allow_quickswap
+                  ) {
+                    this.rom.allowQuickSwap = true;
+                  }
+
                   this.gameLoaded = true;
                   this.generating = false;
                   EventBus.$emit("gameLoaded", this.rom);


### PR DESCRIPTION
Some code was missing witch was applied in `Randomizer.vue`.

https://github.com/sporchia/alttp_vt_randomizer/blob/219fcafd029dab597b8db400efafd8f56f8b4edb/resources/js/views/Randomizer.vue#L514

